### PR TITLE
changed the scaling of the result, added some comments

### DIFF
--- a/matlab/DFT_time2freq.m
+++ b/matlab/DFT_time2freq.m
@@ -27,6 +27,14 @@ for f_idx=1:numel(freq)
     f_val(f_idx) = sum( val .* exp( -1i * 2*pi*freq(f_idx) * t ) );
 end
 
+% scaling for pulse-like signals
+% as in the Fourier transform (https://en.wikipedia.org/wiki/Fourier_transform#Definition)
+% the unit of the result is V/Hz, A/Hz, .../Hz
 f_val = f_val * dt;
+
+% scaling for periodic signals
+% as in the Fourier series (https://en.wikipedia.org/wiki/Fourier_series#Definition)
+% the unit of the result is V, A, ...
+%f_val = f_val / length(t);
  
 f_val = f_val * 2; % single-sided spectrum


### PR DESCRIPTION
The original scaling is fine, but only works for pulse-like signals.

If the original example is started with a time range of
t=linspace(0,3,100);
then the answer is not approx. 0.9, but 2.7, which is not equal to the amplitude of the given sine function.

The added scaling option still gives the correct results of 0.9, no matter which time range is used for the input time function.
