### PR TITLE
Gave Parse_XML_FDTDSetup a return value

### DIFF
--- a/openems.cpp
+++ b/openems.cpp
@@ -821,6 +821,7 @@ bool openEMS::Parse_XML_FDTDSetup(TiXmlElement* FDTD_Opts)
 		this->SetTimeStep(dhelp);
 	if (FDTD_Opts->QueryDoubleAttribute("TimeStepFactor",&dhelp)==TIXML_SUCCESS)
 		this->SetTimeStepFactor(dhelp);
+	return true;
 }
 
 void openEMS::SetGaussExcite(double f0, double fc)


### PR DESCRIPTION
Now with the current version of openems.cpp

BTW: MPI was tested on an AWS cluster.  Without the fix only one split per coordinate was possible. Now it works fine for me, tested also SimplePatch tutorial. 