### PR TITLE
Newmpifix

### DIFF
--- a/FDTD/openems_fdtd_mpi.cpp
+++ b/FDTD/openems_fdtd_mpi.cpp
@@ -210,7 +210,7 @@ bool openEMS_FDTD_MPI::SetupMPI()
 	if (numProcs!=m_NumProc)
 	{
 		if (m_MyID==0)
-			cerr << "openEMS_FDTD_MPI::SetupMPI: Error: Requested splits require " << numProcs << " processes, but only " << m_NumProc << " were found! Exit! " << endl;
+			cerr << "openEMS_FDTD_MPI::SetupMPI: Error: Requested splits require " << numProcs << " processes, but " << m_NumProc << " were found! Exit! " << endl;
 		exit(10);
 	}
 
@@ -256,8 +256,8 @@ bool openEMS_FDTD_MPI::SetupMPI()
 						grid->AddDiscLine(2, m_Original_Grid->GetLine(2,n) );
 
 					m_MPI_Op->SetSplitPos(0,m_SplitNumber[0].at(i));
-					m_MPI_Op->SetSplitPos(1,m_SplitNumber[1].at(i));
-					m_MPI_Op->SetSplitPos(2,m_SplitNumber[2].at(i));
+					m_MPI_Op->SetSplitPos(1,m_SplitNumber[1].at(j));
+					m_MPI_Op->SetSplitPos(2,m_SplitNumber[2].at(k));
 
 					if (i>0)
 						m_MPI_Op->SetNeighborDown(0,procTable[i-1][j][k]);

--- a/main.cpp
+++ b/main.cpp
@@ -68,8 +68,12 @@ int main(int argc, char *argv[])
 	}
 
 	int EC = FDTD.ParseFDTDSetup(argv[1]);
+	if(!EC) {
+	  cerr << "openEMS - ParseFDTDSetup failed." << endl;
+	  exit(1);
+	}
 	EC = FDTD.SetupFDTD();
-	if (EC) return EC;
+	if (EC) exit(EC);
 	FDTD.RunFDTD();
 
 #ifdef MPI_SUPPORT
@@ -77,5 +81,5 @@ int main(int argc, char *argv[])
 	MPI::Finalize();
 #endif
 
-	return 0;
+	exit(0);
 }

--- a/matlab/RunOpenEMS_MPI.m
+++ b/matlab/RunOpenEMS_MPI.m
@@ -87,7 +87,7 @@ end
 
 if isfield(Settings.MPI,'Hosts')
     disp(['Running remote openEMS_MPI in working dir: ' work_path]);
-    [status]  = system(['mpiexec -host ' HostList ' -n ' int2str(NrProc) ' -wdir ' work_path ' ' Settings.MPI.Binary ' ' Sim_File ' ' opts ' ' append_unix]);
+    [status]  = system(['mpiexec ' Settings.MPI.GlobalArgs ' -host ' HostList ' -n ' int2str(NrProc) ' -wdir ' work_path ' ' Settings.MPI.Binary ' ' Sim_File ' ' opts ' ' append_unix]);
 else
     disp('Running local openEMS_MPI');
     [status]  = system(['mpiexec ' Settings.MPI.GlobalArgs ' -n ' int2str(NrProc) ' ' Settings.MPI.Binary ' ' Sim_File ' ' opts ' ' append_unix]);

--- a/openems.cpp
+++ b/openems.cpp
@@ -418,13 +418,11 @@ bool openEMS::SetupProcessing()
 					}
 					if (CylinderCoords)
 						proc->SetMeshType(Processing::CYLINDRICAL_MESH);
-					if ((pb->GetProbeType()==1) || (pb->GetProbeType()==3))
+					if ((pb->GetProbeType()==1) || (pb->GetProbeType()==3) || (pb->GetProbeType()==11))
 					{
 						proc->SetDualTime(true);
 						proc->SetDualMesh(true);
 					}
-					if (pb->GetProbeType()==11)
-						proc->SetDualTime(true);
 					proc->SetProcessInterval(Nyquist/m_OverSampling);
 					if (pb->GetStartTime()>0 || pb->GetStopTime()>0)
 						proc->SetProcessStartStopTime(pb->GetStartTime(), pb->GetStopTime());
@@ -821,6 +819,7 @@ bool openEMS::Parse_XML_FDTDSetup(TiXmlElement* FDTD_Opts)
 		this->SetTimeStep(dhelp);
 	if (FDTD_Opts->QueryDoubleAttribute("TimeStepFactor",&dhelp)==TIXML_SUCCESS)
 		this->SetTimeStepFactor(dhelp);
+	return true;
 }
 
 void openEMS::SetGaussExcite(double f0, double fc)

--- a/openems.cpp
+++ b/openems.cpp
@@ -418,11 +418,13 @@ bool openEMS::SetupProcessing()
 					}
 					if (CylinderCoords)
 						proc->SetMeshType(Processing::CYLINDRICAL_MESH);
-					if ((pb->GetProbeType()==1) || (pb->GetProbeType()==3) || (pb->GetProbeType()==11))
+					if ((pb->GetProbeType()==1) || (pb->GetProbeType()==3))
 					{
 						proc->SetDualTime(true);
 						proc->SetDualMesh(true);
 					}
+					if (pb->GetProbeType()==11)
+						proc->SetDualTime(true);
 					proc->SetProcessInterval(Nyquist/m_OverSampling);
 					if (pb->GetStartTime()>0 || pb->GetStopTime()>0)
 						proc->SetProcessStartStopTime(pb->GetStartTime(), pb->GetStopTime());


### PR DESCRIPTION
You mean like this? 

BTW the spurious chrash of the highest rank MPI instance occurs only *after* the final return in main (which is somehow mysterious) and only if there is a NF2FF box in the model. So probably this is due to a destructor relating to nf2ff (and MPI). 