### PR TITLE
Guard xmmintrin.h include so it is only used when necessary

### DIFF
--- a/FDTD/engine_multithread.cpp
+++ b/FDTD/engine_multithread.cpp
@@ -32,7 +32,10 @@
 #include "boost/date_time/posix_time/posix_time.hpp"
 #include "boost/date_time/gregorian/gregorian.hpp"
 #include <iomanip>
+
+#ifndef SSE_CORRECT_DENORMALS
 #include <xmmintrin.h>
+#endif
 
 //! \brief construct an Engine_Multithread instance
 //! it's the responsibility of the caller to free the returned pointer

--- a/FDTD/engine_sse.cpp
+++ b/FDTD/engine_sse.cpp
@@ -15,7 +15,10 @@
 *	along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#ifndef SSE_CORRECT_DENORMALS
 #include <xmmintrin.h>
+#endif
+
 #include "engine_sse.h"
 
 //! \brief construct an Engine_sse instance


### PR DESCRIPTION
The x86/SSE specific code for Flush-To-Zero is only used when
SSE_CORRECT_DENORMALS is not defined. Guarding the include allows the
code to compile on e.g. ARM.

Signed-off-by: Stefan Brüns <stefan.bruens@rwth-aachen.de>