### PR TITLE
Modify the find command to return only one line.

### DIFF
--- a/matlab/setup.m
+++ b/matlab/setup.m
@@ -19,14 +19,14 @@ if isOctave()
     fflush(stdout);
     if isunix
         [res, fn_so] = unix('find /usr/lib     -name libhdf5.so');
-        [res, fn_h]  = unix('find /usr/include -name hdf5.h');
+        [res, fn_h]  = unix('find /usr/include -name hdf5.h | head -1');
         if length(fn_so)>0 && length(fn_h)>0
-            [hdf5lib_dir, hdf5lib_fn] = fileparts(fn_so);
+            [hdf5lib_dir, hdf5lib_fn, ext] = fileparts(fn_so);
             disp(["HDF5 library path found at: " hdf5lib_dir])
 
-            [hdf5inc_dir, hdf5inc_fn] = fileparts(fn_h);
+            [hdf5inc_dir, hdf5inc_fn, ext] = fileparts(fn_h);
             disp(["HDF5 include path found at: " hdf5inc_dir])
-            mkoctfile(["-L" hdf5lib_dir " -I" hdf5inc_dir],"-lhdf5", "h5readatt_octave.cc")
+            mkoctfile("h5readatt_octave.cc", ["-L" hdf5lib_dir], ["-I" hdf5inc_dir], "-L hdf5")
         else
             mkoctfile -lhdf5 h5readatt_octave.cc
         end


### PR DESCRIPTION
 If the command returned two lines (in the case that there were two copies of hdf5.h on the system, then the system got confused. Also updated the options to the mkoctfile command to concatenate the strings separately. This fixes Issue #36 (at least on my Debian testing installation)