### PR TITLE
Handling cases when a script interpolates a location outside of the m…

### DIFF
--- a/matlab/AddCPWPort.m
+++ b/matlab/AddCPWPort.m
@@ -152,28 +152,32 @@ else
 end
 
 % calculate position of the voltage probes
-mesh{1} = sort(CSX.RectilinearGrid.XLines);
-mesh{2} = sort(CSX.RectilinearGrid.YLines);
-mesh{3} = sort(CSX.RectilinearGrid.ZLines);
-meshlines = interp1( mesh{idx_prop}, 1:numel(mesh{idx_prop}), measplanepos, 'nearest' );
-meshlines = mesh{idx_prop}(meshlines-1:meshlines+1); % get three lines (approx. at center)
-if direction == -1
-    meshlines = fliplr(meshlines);
+try
+	mesh{1} = sort(CSX.RectilinearGrid.XLines);
+	mesh{2} = sort(CSX.RectilinearGrid.YLines);
+	mesh{3} = sort(CSX.RectilinearGrid.ZLines);
+	meshlines = interp1( mesh{idx_prop}, 1:numel(mesh{idx_prop}), measplanepos, 'nearest' );
+	meshlines = mesh{idx_prop}(meshlines-1:meshlines+1); % get three lines (approx. at center)
+	if direction == -1
+		meshlines = fliplr(meshlines);
+	end
+	SL_w2 = interp1( mesh{idx_width}, 1:numel(mesh{idx_width}), (nstart(idx_width)+nstop(idx_width))/2, 'nearest' );
+	SL_w2 = mesh{idx_width}(SL_w2); % get e-line at center of CPW (SL_width/2)
+	v1_start(idx_prop)   = meshlines(1);
+	v1_start(idx_width)  = (nstart(idx_width)+nstop(idx_width))/2;
+	v1_start(idx_height) = start(idx_height);
+	v1_stop  = v1_start;
+	v2_start = v1_start;
+	v2_stop  = v1_stop;
+	v2_start(idx_prop)   = meshlines(2);
+	v2_stop(idx_prop)    = meshlines(2);
+	v3_start = v2_start;
+	v3_stop  = v2_stop;
+	v3_start(idx_prop)   = meshlines(3);
+	v3_stop(idx_prop)    = meshlines(3);
+catch
+	error('Unable to place voltage probe on mesh; check the location of the CPW and the probe (MeasPlaneShift), and make sure that the mesh is large enough');
 end
-SL_w2 = interp1( mesh{idx_width}, 1:numel(mesh{idx_width}), (nstart(idx_width)+nstop(idx_width))/2, 'nearest' );
-SL_w2 = mesh{idx_width}(SL_w2); % get e-line at center of CPW (SL_width/2)
-v1_start(idx_prop)   = meshlines(1);
-v1_start(idx_width)  = (nstart(idx_width)+nstop(idx_width))/2;
-v1_start(idx_height) = start(idx_height);
-v1_stop  = v1_start;
-v2_start = v1_start;
-v2_stop  = v1_stop;
-v2_start(idx_prop)   = meshlines(2);
-v2_stop(idx_prop)    = meshlines(2);
-v3_start = v2_start;
-v3_stop  = v2_stop;
-v3_start(idx_prop)   = meshlines(3);
-v3_stop(idx_prop)    = meshlines(3);
 
 width_add_start = [0 0 0];
 width_add_stop  = [0 0 0];
@@ -209,19 +213,23 @@ CSX = AddProbe( CSX, port.U_filename{3,2}, 0, 'weight', weight );
 CSX = AddBox( CSX, port.U_filename{3,2}, prio, v3_start+width_add_start, v3_stop+width_add_stop );
 
 % calculate position of the current probes
-idx = interp1( mesh{idx_width}, 1:numel(mesh{idx_width}), nstart(idx_width), 'nearest' );
-i1_start(idx_width)  = mesh{idx_width}(idx) - diff(mesh{idx_width}(idx-1:idx))/2;
-idx = interp1( mesh{idx_height}, 1:numel(mesh{idx_height}), start(idx_height), 'nearest' );
-i1_start(idx_height) = mesh{idx_height}(idx-1) - diff(mesh{idx_height}(idx-2:idx-1))/2;
-i1_stop(idx_height)  = mesh{idx_height}(idx+1) + diff(mesh{idx_height}(idx+1:idx+2))/2;
-i1_start(idx_prop)   = sum(meshlines(1:2))/2;
-i1_stop(idx_prop)    = i1_start(idx_prop);
-idx = interp1( mesh{idx_width}, 1:numel(mesh{idx_width}), nstop(idx_width), 'nearest' );
-i1_stop(idx_width)   = mesh{idx_width}(idx) + diff(mesh{idx_width}(idx:idx+1))/2;
-i2_start = i1_start;
-i2_stop  = i1_stop;
-i2_start(idx_prop)   = sum(meshlines(2:3))/2;
-i2_stop(idx_prop)    = i2_start(idx_prop);
+try
+	idx = interp1( mesh{idx_width}, 1:numel(mesh{idx_width}), nstart(idx_width), 'nearest' );
+	i1_start(idx_width)  = mesh{idx_width}(idx) - diff(mesh{idx_width}(idx-1:idx))/2;
+	idx = interp1( mesh{idx_height}, 1:numel(mesh{idx_height}), start(idx_height), 'nearest' );
+	i1_start(idx_height) = mesh{idx_height}(idx-1) - diff(mesh{idx_height}(idx-2:idx-1))/2;
+	i1_stop(idx_height)  = mesh{idx_height}(idx+1) + diff(mesh{idx_height}(idx+1:idx+2))/2;
+	i1_start(idx_prop)   = sum(meshlines(1:2))/2;
+	i1_stop(idx_prop)    = i1_start(idx_prop);
+	idx = interp1( mesh{idx_width}, 1:numel(mesh{idx_width}), nstop(idx_width), 'nearest' );
+	i1_stop(idx_width)   = mesh{idx_width}(idx) + diff(mesh{idx_width}(idx:idx+1))/2;
+	i2_start = i1_start;
+	i2_stop  = i1_stop;
+	i2_start(idx_prop)   = sum(meshlines(2:3))/2;
+	i2_stop(idx_prop)    = i2_start(idx_prop);
+catch
+	error('Unable to place current probe on mesh; check the location of the CPW and the probe (MeasPlaneShift), and make sure that the mesh is large enough');
+end
 
 % create the curr-probes
 weight = direction;
@@ -248,13 +256,17 @@ port.measplanepos = abs(v2_start(idx_prop) - start(idx_prop))*port.LengthScale;
 % port
 
 % create excitation (if enabled) and port resistance
-meshline = interp1( mesh{idx_prop}, 1:numel(mesh{idx_prop}), start(idx_prop) + feed_shift*direction, 'nearest' );
-ex_start(idx_prop)   = mesh{idx_prop}(meshline) ;
-ex_start(idx_width)  = (nstart(idx_width)+nstop(idx_width))/2;
-ex_start(idx_height) = nstart(idx_height);
-ex_stop(idx_prop)    = ex_start(idx_prop);
-ex_stop(idx_width)   = (nstart(idx_width)+nstop(idx_width))/2;
-ex_stop(idx_height)  = nstop(idx_height);
+try
+	meshline = interp1( mesh{idx_prop}, 1:numel(mesh{idx_prop}), start(idx_prop) + feed_shift*direction, 'nearest' );
+	ex_start(idx_prop)   = mesh{idx_prop}(meshline) ;
+	ex_start(idx_width)  = (nstart(idx_width)+nstop(idx_width))/2;
+	ex_start(idx_height) = nstart(idx_height);
+	ex_stop(idx_prop)    = ex_start(idx_prop);
+	ex_stop(idx_width)   = (nstart(idx_width)+nstop(idx_width))/2;
+	ex_stop(idx_height)  = nstop(idx_height);
+catch
+	error('Unable to place excitation on mesh; check the location of the CPW and the excitation (FeedShift), and make sure that the mesh is large enough');
+end
 
 port.excite = 0;
 if excite

--- a/matlab/AddCoaxialPort.m
+++ b/matlab/AddCoaxialPort.m
@@ -114,27 +114,31 @@ else
 end
 
 % calculate position of the voltage probes
-mesh{1} = sort(unique(CSX.RectilinearGrid.XLines));
-mesh{2} = sort(unique(CSX.RectilinearGrid.YLines));
-mesh{3} = sort(unique(CSX.RectilinearGrid.ZLines));
-meshlines = interp1( mesh{idx_prop_n}, 1:numel(mesh{idx_prop_n}), measplanepos, 'nearest' );
-meshlines = mesh{idx_prop_n}(meshlines-1:meshlines+1); % get three lines (approx. at center)
-if direction == -1
-    meshlines = fliplr(meshlines);
+try
+	mesh{1} = sort(unique(CSX.RectilinearGrid.XLines));
+	mesh{2} = sort(unique(CSX.RectilinearGrid.YLines));
+	mesh{3} = sort(unique(CSX.RectilinearGrid.ZLines));
+	meshlines = interp1( mesh{idx_prop_n}, 1:numel(mesh{idx_prop_n}), measplanepos, 'nearest' );
+	meshlines = mesh{idx_prop_n}(meshlines-1:meshlines+1); % get three lines (approx. at center)
+	if direction == -1
+		meshlines = fliplr(meshlines);
+	end
+	v1_start(idx_prop_n)   = meshlines(1);
+	v1_start(idx_prop_nP)  = start(idx_prop_nP)+r_i;
+	v1_start(idx_prop_nPP) = start(idx_prop_nPP);
+	v1_stop  = v1_start;
+	v1_stop(idx_prop_nP)  = start(idx_prop_nP)+r_o;
+	v2_start = v1_start;
+	v2_stop  = v1_stop;
+	v2_start(idx_prop_n)   = meshlines(2);
+	v2_stop(idx_prop_n)    = meshlines(2);
+	v3_start = v2_start;
+	v3_stop  = v2_stop;
+	v3_start(idx_prop_n)   = meshlines(3);
+	v3_stop(idx_prop_n)    = meshlines(3);
+catch
+	error('Unable to place voltage probe on mesh; check the location of the port and the probe (MeasPlaneShift), and make sure that the mesh is large enough');
 end
-v1_start(idx_prop_n)   = meshlines(1);
-v1_start(idx_prop_nP)  = start(idx_prop_nP)+r_i;
-v1_start(idx_prop_nPP) = start(idx_prop_nPP);
-v1_stop  = v1_start;
-v1_stop(idx_prop_nP)  = start(idx_prop_nP)+r_o;
-v2_start = v1_start;
-v2_stop  = v1_stop;
-v2_start(idx_prop_n)   = meshlines(2);
-v2_stop(idx_prop_n)    = meshlines(2);
-v3_start = v2_start;
-v3_stop  = v2_stop;
-v3_start(idx_prop_n)   = meshlines(3);
-v3_stop(idx_prop_n)    = meshlines(3);
 
 % calculate position of the current probes
 i1_start(idx_prop_n)   = 0.5*(meshlines(1)+meshlines(2));
@@ -184,12 +188,16 @@ port.r_i = r_i;
 port.r_o = r_o;
 
 % create excitation (if enabled) and port resistance
-meshline = interp1( mesh{idx_prop_n}, 1:numel(mesh{idx_prop_n}), start(idx_prop_n) + feed_shift*direction, 'nearest' );
-min_cell_prop = min(diff(mesh{idx_prop_n}));
-ex_start = start;
-ex_start(idx_prop_n)   = mesh{idx_prop_n}(meshline) - 0.01*min_cell_prop;
-ex_stop  = ex_start;
-ex_stop(idx_prop_n)   = mesh{idx_prop_n}(meshline) + 0.01*min_cell_prop;
+try
+	meshline = interp1( mesh{idx_prop_n}, 1:numel(mesh{idx_prop_n}), start(idx_prop_n) + feed_shift*direction, 'nearest' );
+	min_cell_prop = min(diff(mesh{idx_prop_n}));
+	ex_start = start;
+	ex_start(idx_prop_n)   = mesh{idx_prop_n}(meshline) - 0.01*min_cell_prop;
+	ex_stop  = ex_start;
+	ex_stop(idx_prop_n)   = mesh{idx_prop_n}(meshline) + 0.01*min_cell_prop;
+catch
+	error('Unable to place excitation on mesh; check the location of the port and the excitation (FeedShift), and make sure that the mesh is large enough');
+end
 
 port.excite = 0;
 if (excite_amp~=0)

--- a/matlab/AddCurvePort.m
+++ b/matlab/AddCurvePort.m
@@ -78,23 +78,27 @@ for n=1:3
 end
 
 % calculate position
-port_start_idx = start_idx;
-port_stop_idx  = stop_idx;
-if abs(start_idx(dir) - stop_idx(dir)) ~= 1
-    % calc port position
-    idx  = interp1( mesh{dir},  1:numel(mesh{dir}),  (nstart(dir)+nstop(dir))/2,   'nearest' );
-    idx1 = interp1( mesh{dir1}, 1:numel(mesh{dir1}), (nstart(dir1)+nstop(dir1))/2, 'nearest' );
-    idx2 = interp1( mesh{dir2}, 1:numel(mesh{dir2}), (nstart(dir2)+nstop(dir2))/2, 'nearest' );
-    port_start_idx(dir)  = idx;
-    port_start_idx(dir1) = idx1;
-    port_start_idx(dir2) = idx2;
-    port_stop_idx(dir)   = idx+1;
-    port_stop_idx(dir1)  = idx1;
-    port_stop_idx(dir2)  = idx2;
-    metalname = [PortNamePrefix 'port' num2str(portnr) '_PEC'];
-    CSX = AddMetal( CSX, metalname );
-    CSX = AddCurve( CSX, metalname, prio, [nstart.' [mesh{1}(port_start_idx(1));mesh{2}(port_start_idx(2));mesh{3}(port_start_idx(3))]] );
-    CSX = AddCurve( CSX, metalname, prio, [nstop.' [mesh{1}(port_stop_idx(1));mesh{2}(port_stop_idx(2));mesh{3}(port_stop_idx(3))]] );
+try
+	port_start_idx = start_idx;
+	port_stop_idx  = stop_idx;
+	if abs(start_idx(dir) - stop_idx(dir)) ~= 1
+		% calc port position
+		idx  = interp1( mesh{dir},  1:numel(mesh{dir}),  (nstart(dir)+nstop(dir))/2,   'nearest' );
+		idx1 = interp1( mesh{dir1}, 1:numel(mesh{dir1}), (nstart(dir1)+nstop(dir1))/2, 'nearest' );
+		idx2 = interp1( mesh{dir2}, 1:numel(mesh{dir2}), (nstart(dir2)+nstop(dir2))/2, 'nearest' );
+		port_start_idx(dir)  = idx;
+		port_start_idx(dir1) = idx1;
+		port_start_idx(dir2) = idx2;
+		port_stop_idx(dir)   = idx+1;
+		port_stop_idx(dir1)  = idx1;
+		port_stop_idx(dir2)  = idx2;
+		metalname = [PortNamePrefix 'port' num2str(portnr) '_PEC'];
+		CSX = AddMetal( CSX, metalname );
+		CSX = AddCurve( CSX, metalname, prio, [nstart.' [mesh{1}(port_start_idx(1));mesh{2}(port_start_idx(2));mesh{3}(port_start_idx(3))]] );
+		CSX = AddCurve( CSX, metalname, prio, [nstop.' [mesh{1}(port_stop_idx(1));mesh{2}(port_stop_idx(2));mesh{3}(port_stop_idx(3))]] );
+	end
+catch
+	error('Unable to place port on mesh; check the location of the port, and make sure that the mesh is large enough');
 end
 
 % calculate position of resistive material

--- a/matlab/AddStripLinePort.m
+++ b/matlab/AddStripLinePort.m
@@ -151,29 +151,33 @@ else
 end
 
 % calculate position of the voltage probes
-mesh{1} = sort(CSX.RectilinearGrid.XLines);
-mesh{2} = sort(CSX.RectilinearGrid.YLines);
-mesh{3} = sort(CSX.RectilinearGrid.ZLines);
-meshlines = interp1( mesh{idx_prop}, 1:numel(mesh{idx_prop}), measplanepos, 'nearest' );
-meshlines = mesh{idx_prop}(meshlines-1:meshlines+1); % get three lines (approx. at center)
-if direction == -1
-    meshlines = fliplr(meshlines);
+try
+	mesh{1} = sort(CSX.RectilinearGrid.XLines);
+	mesh{2} = sort(CSX.RectilinearGrid.YLines);
+	mesh{3} = sort(CSX.RectilinearGrid.ZLines);
+	meshlines = interp1( mesh{idx_prop}, 1:numel(mesh{idx_prop}), measplanepos, 'nearest' );
+	meshlines = mesh{idx_prop}(meshlines-1:meshlines+1); % get three lines (approx. at center)
+	if direction == -1
+		meshlines = fliplr(meshlines);
+	end
+	SL_w2 = interp1( mesh{idx_width}, 1:numel(mesh{idx_width}), (nstart(idx_width)+nstop(idx_width))/2, 'nearest' );
+	SL_w2 = mesh{idx_width}(SL_w2); % get e-line at center of MSL (SL_width/2)
+	v1_start(idx_prop)   = meshlines(1);
+	v1_start(idx_width)  = SL_w2;
+	v1_start(idx_height) = start(idx_height);
+	v1_stop  = v1_start;
+	v1_stop(idx_height)  = v1_start(idx_height);
+	v2_start = v1_start;
+	v2_stop  = v1_stop;
+	v2_start(idx_prop)   = meshlines(2);
+	v2_stop(idx_prop)    = meshlines(2);
+	v3_start = v2_start;
+	v3_stop  = v2_stop;
+	v3_start(idx_prop)   = meshlines(3);
+	v3_stop(idx_prop)    = meshlines(3);
+catch
+	error('Unable to place voltage probe on mesh; check the location of the stripline and the probe (MeasPlaneShift), and make sure that the mesh is large enough');
 end
-SL_w2 = interp1( mesh{idx_width}, 1:numel(mesh{idx_width}), (nstart(idx_width)+nstop(idx_width))/2, 'nearest' );
-SL_w2 = mesh{idx_width}(SL_w2); % get e-line at center of MSL (SL_width/2)
-v1_start(idx_prop)   = meshlines(1);
-v1_start(idx_width)  = SL_w2;
-v1_start(idx_height) = start(idx_height);
-v1_stop  = v1_start;
-v1_stop(idx_height)  = v1_start(idx_height);
-v2_start = v1_start;
-v2_stop  = v1_stop;
-v2_start(idx_prop)   = meshlines(2);
-v2_stop(idx_prop)    = meshlines(2);
-v3_start = v2_start;
-v3_stop  = v2_stop;
-v3_start(idx_prop)   = meshlines(3);
-v3_stop(idx_prop)    = meshlines(3);
 
 height_vector = [0 0 0];
 height_vector(idx_height) = height;
@@ -207,19 +211,23 @@ CSX = AddProbe( CSX, port.U_filename{3,2}, 0, 'weight', -1*weight );
 CSX = AddBox( CSX, port.U_filename{3,2}, prio, v3_start, v3_stop-height_vector );
 
 % calculate position of the current probes
-idx = interp1( mesh{idx_width}, 1:numel(mesh{idx_width}), nstart(idx_width), 'nearest' );
-i1_start(idx_width)  = mesh{idx_width}(idx) - diff(mesh{idx_width}(idx-1:idx))/2;
-idx = interp1( mesh{idx_height}, 1:numel(mesh{idx_height}), start(idx_height), 'nearest' );
-i1_start(idx_height) = mesh{idx_height}(idx-1) - diff(mesh{idx_height}(idx-2:idx-1))/2;
-i1_stop(idx_height)  = mesh{idx_height}(idx+1) + diff(mesh{idx_height}(idx+1:idx+2))/2;
-i1_start(idx_prop)   = sum(meshlines(1:2))/2;
-i1_stop(idx_prop)    = i1_start(idx_prop);
-idx = interp1( mesh{idx_width}, 1:numel(mesh{idx_width}), nstop(idx_width), 'nearest' );
-i1_stop(idx_width)   = mesh{idx_width}(idx) + diff(mesh{idx_width}(idx:idx+1))/2;
-i2_start = i1_start;
-i2_stop  = i1_stop;
-i2_start(idx_prop)   = sum(meshlines(2:3))/2;
-i2_stop(idx_prop)    = i2_start(idx_prop);
+try
+	idx = interp1( mesh{idx_width}, 1:numel(mesh{idx_width}), nstart(idx_width), 'nearest' );
+	i1_start(idx_width)  = mesh{idx_width}(idx) - diff(mesh{idx_width}(idx-1:idx))/2;
+	idx = interp1( mesh{idx_height}, 1:numel(mesh{idx_height}), start(idx_height), 'nearest' );
+	i1_start(idx_height) = mesh{idx_height}(idx-1) - diff(mesh{idx_height}(idx-2:idx-1))/2;
+	i1_stop(idx_height)  = mesh{idx_height}(idx+1) + diff(mesh{idx_height}(idx+1:idx+2))/2;
+	i1_start(idx_prop)   = sum(meshlines(1:2))/2;
+	i1_stop(idx_prop)    = i1_start(idx_prop);
+	idx = interp1( mesh{idx_width}, 1:numel(mesh{idx_width}), nstop(idx_width), 'nearest' );
+	i1_stop(idx_width)   = mesh{idx_width}(idx) + diff(mesh{idx_width}(idx:idx+1))/2;
+	i2_start = i1_start;
+	i2_stop  = i1_stop;
+	i2_start(idx_prop)   = sum(meshlines(2:3))/2;
+	i2_stop(idx_prop)    = i2_start(idx_prop);
+catch
+	error('Unable to place current probe on mesh; check the location of the stripline and the probe (MeasPlaneShift), and make sure that the mesh is large enough');
+end
 
 % create the curr-probes
 weight = direction;
@@ -246,13 +254,17 @@ port.measplanepos = abs(v2_start(idx_prop) - start(idx_prop))*port.LengthScale;
 % port
 
 % create excitation (if enabled) and port resistance
-meshline = interp1( mesh{idx_prop}, 1:numel(mesh{idx_prop}), start(idx_prop) + feed_shift*direction, 'nearest' );
-ex_start(idx_prop)   = mesh{idx_prop}(meshline) ;
-ex_start(idx_width)  = nstart(idx_width);
-ex_start(idx_height) = nstart(idx_height);
-ex_stop(idx_prop)    = ex_start(idx_prop);
-ex_stop(idx_width)   = nstop(idx_width);
-ex_stop(idx_height)  = nstop(idx_height);
+try
+	meshline = interp1( mesh{idx_prop}, 1:numel(mesh{idx_prop}), start(idx_prop) + feed_shift*direction, 'nearest' );
+	ex_start(idx_prop)   = mesh{idx_prop}(meshline) ;
+	ex_start(idx_width)  = nstart(idx_width);
+	ex_start(idx_height) = nstart(idx_height);
+	ex_stop(idx_prop)    = ex_start(idx_prop);
+	ex_stop(idx_width)   = nstop(idx_width);
+	ex_stop(idx_height)  = nstop(idx_height);
+catch
+	error('Unable to place excitation on mesh; check the location of the stripline and the probe (MeasPlaneShift), and make sure that the mesh is large enough');
+end
 
 port.excite = 0;
 if excite


### PR DESCRIPTION
There were several cases under which the Octave script attempted to interpolate a coordinate that was outside of the mesh. The user got a meaningless error, e.g. "minimum of 2 points required in each dimension" or "subscripts must be either integers 1 to (2^31)-1 or logicals".

I wrapped all of the cases I could find in try-catch, and provide a (hopefully) more helpful message.