### PR TITLE
Fix crash on recalling run() with enabled cleanup

### DIFF
--- a/python/openEMS/openEMS.pyx
+++ b/python/openEMS/openEMS.pyx
@@ -428,7 +428,6 @@ cdef class openEMS:
             os.mkdir(sim_path)
         if not os.path.exists(sim_path):
             os.mkdir(sim_path)
-        cwd = os.getcwd()
         os.chdir(sim_path)
         if verbose is not None:
             self.thisptr.SetVerboseLevel(verbose)


### PR DESCRIPTION
Solved the issue #59
Calling the run function multiple times caused an error