### PR TITLE
Allow whitespaces in simulation path (remote)

### DIFF
--- a/matlab/RunOpenEMS.m
+++ b/matlab/RunOpenEMS.m
@@ -157,7 +157,7 @@ if (enable_ssh)
     disp( 'Remote simulation done... copying back results and cleaning up...' );
 
     %copy back all results
-    [stat, res] = system([scp_command ' -r ' scp_options ' ' Settings.SSH.host ':' ssh_work_path '/* ' pwd '/']);
+    [stat, res] = system([scp_command ' -r ' scp_options ' ' Settings.SSH.host ':' ssh_work_path '/* ./']);
     if (stat~=0);
         disp(res);
         error('openEMS:RunOpenEMS','scp failed!');


### PR DESCRIPTION
A simulation path that contains a whitespace character (and probably a lot of other characters that have special meanings inside a shell) leads to an scp failure when the simulation data is copied back to the host machine. Replacing [pwd '/'] by just './' as the back-copying destination fixes this problem.