### PR TITLE
Use Boost_INCLUDE_DIRS instead of Boost_INCLUDE_DIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,9 +130,9 @@ find_package(Boost 1.46 COMPONENTS
   chrono
   REQUIRED
 )
-message(STATUS "Boost_INCLUDE_DIR: ${Boost_INCLUDE_DIR}")
+message(STATUS "Boost_INCLUDE_DIRS: ${Boost_INCLUDE_DIRS}")
 message(STATUS "Boost_LIBRARIES: ${Boost_LIBRARIES}")
-INCLUDE_DIRECTORIES (${Boost_INCLUDE_DIR})
+INCLUDE_DIRECTORIES (${Boost_INCLUDE_DIRS})
 
 # vtk
 find_package(VTK COMPONENTS vtkIOXML vtkIOGeometry vtkIOLegacy vtkIOPLY NO_MODULE REQUIRED)


### PR DESCRIPTION
According to https://cmake.org/cmake/help/v3.0/module/FindBoost.html `Boost_INCLUDE_DIR` is only a cache variable, while `Boost_INCLUDE_DIRS` should be used. Some recent version of cmake seems to have broken the build when the cache variables are used in CMakeLists.txt.

Reported by MrHighVoltage via https://aur.archlinux.org/packages/openems-git/