### PR TITLE
Expose sinusoidal, dirac pulse and step pulse excitation to the Python API.

### DIFF
--- a/openems.cpp
+++ b/openems.cpp
@@ -854,6 +854,24 @@ void openEMS::SetGaussExcite(double f0, double fc)
 	m_Exc->SetupGaussianPulse(f0, fc);
 }
 
+void openEMS::SetSinusExcite(double f0)
+{
+	this->InitExcitation();
+	m_Exc->SetupSinusoidal(f0);
+}
+
+void openEMS::SetDiracExcite(double f_max)
+{
+	this->InitExcitation();
+	m_Exc->SetupDiracPulse(f_max);
+}
+
+void openEMS::SetStepExcite(double f_max)
+{
+	this->InitExcitation();
+	m_Exc->SetupStepExcite(f_max);
+}
+
 Excitation* openEMS::InitExcitation()
 {
 	delete m_Exc;

--- a/openems.h
+++ b/openems.h
@@ -102,6 +102,10 @@ public:
 	bool CheckAbortCond();
 
 	void SetGaussExcite(double f0, double fc);
+	void SetSinusExcite(double f0);
+	void SetDiracExcite(double f_max);
+	void SetStepExcite(double f_max);
+
 	Excitation* InitExcitation();
 
 	void SetCSX(ContinuousStructure* csx);

--- a/python/openEMS/openEMS.pxd
+++ b/python/openEMS/openEMS.pxd
@@ -48,6 +48,9 @@ cdef extern from "openEMS/openems.h":
         void Set_Mur_PhaseVel(int idx, double val)
 
         void SetGaussExcite(double f0, double fc)
+        void SetSinusExcite(double f0)
+        void SetDiracExcite(double f_max)
+        void SetStepExcite(double f_max)
 
         void SetAbort(bool val)
 

--- a/python/openEMS/openEMS.pyx
+++ b/python/openEMS/openEMS.pyx
@@ -232,6 +232,33 @@ cdef class openEMS:
         """
         self.thisptr.SetGaussExcite(f0, fc)
 
+    def SetSinusExcite(self, f0):
+        """ SetSinusExcite(f0)
+
+        Set a sinusoidal signal as excitation signal.
+
+        :param f0: float -- frequency in Hz.
+        """
+        self.thisptr.SetSinusExcite(f0)
+
+    def SetDiracExcite(self, f_max):
+        """ SetDiracExcite(f_max)
+
+        Set a dirac pulse as excitation signal.
+
+        :param f_max: float -- maximum simulated frequency in Hz.
+        """
+        self.thisptr.SetDiracExcite(f_max)
+
+    def SetStepExcite(self, f_max):
+        """ SetStepExcite(f_max)
+
+        Set a step function as excitation signal.
+
+        :param f_max: float -- maximum simulated frequency in Hz.
+        """
+        self.thisptr.SetStepExcite(f_max)
+
 
     def SetBoundaryCond(self, BC):
         """ SetBoundaryCond(BC)


### PR DESCRIPTION
For some experiments, I required the step excitation and i just exposed the additional functions to the python API. I did not look into the CustomExcite, probably requires some String casting between C++ and Python and I did not use it for now.