### PR TITLE
Fix the error, while building hdf5

### DIFF
--- a/matlab/setup.m
+++ b/matlab/setup.m
@@ -19,7 +19,7 @@ if isOctave()
     fflush(stdout);
     if isunix
         [res, fn_so] = unix('find /usr/lib     -name libhdf5.so');
-        [res, fn_h]  = unix('find /usr/include -name hdf5.h | sort -r | head -1');
+        [res, fn_h]  = unix('find /usr/include -name hdf5.h | grep "hdf5/serial" | head -1');
         if length(fn_so)>0 && length(fn_h)>0
             [hdf5lib_dir, hdf5lib_fn, ext] = fileparts(fn_so);
             disp(["HDF5 library path found at: " hdf5lib_dir])


### PR DESCRIPTION
Hello Thorsten. 
I encountered an issue on my system, which caused the "hdf5" build fail.
It turned out, I had other library installed on my ubuntu, that contained a file with the simmilar name.

The `find /usr/include -name hdf5.h | sort -r | head -1` result, as funny as it sounds, was:
`/usr/include/opencv4/opencv2/flann/hdf5.h`

Replacing the line with `find /usr/include -name hdf5.h | grep "hdf5/serial" | head -1` seems to be working better.

Kind Regards.