### PR TITLE
Speeding Up FDTD Engine By 20%-30% by Using Multi-dimensional Arrays with Contiguous Memory

### DIFF
--- a/FDTD/engine.cpp
+++ b/FDTD/engine.cpp
@@ -123,16 +123,37 @@ void Engine::UpdateVoltages(unsigned int startX, unsigned int numX)
 				shift[2]=pos[2];
 				//do the updates here
 				//for x
-				volt[0][pos[0]][pos[1]][pos[2]] *= Op->vv[0][pos[0]][pos[1]][pos[2]];
-				volt[0][pos[0]][pos[1]][pos[2]] += Op->vi[0][pos[0]][pos[1]][pos[2]] * ( curr[2][pos[0]][pos[1]][pos[2]] - curr[2][pos[0]][pos[1]-shift[1]][pos[2]] - curr[1][pos[0]][pos[1]][pos[2]] + curr[1][pos[0]][pos[1]][pos[2]-shift[2]]);
+				volt[0][pos[0]][pos[1]][pos[2]] *=
+				    Op->vv[0][pos[0]][pos[1]][pos[2]];
+				volt[0][pos[0]][pos[1]][pos[2]] +=
+				    Op->vi[0][pos[0]][pos[1]][pos[2]] * (
+				        curr[2][pos[0]][pos[1]         ][pos[2]         ] -
+				        curr[2][pos[0]][pos[1]-shift[1]][pos[2]         ] -
+				        curr[1][pos[0]][pos[1]         ][pos[2]         ] +
+				        curr[1][pos[0]][pos[1]         ][pos[2]-shift[2]]
+				    );
 
 				//for y
-				volt[1][pos[0]][pos[1]][pos[2]] *= Op->vv[1][pos[0]][pos[1]][pos[2]];
-				volt[1][pos[0]][pos[1]][pos[2]] += Op->vi[1][pos[0]][pos[1]][pos[2]] * ( curr[0][pos[0]][pos[1]][pos[2]] - curr[0][pos[0]][pos[1]][pos[2]-shift[2]] - curr[2][pos[0]][pos[1]][pos[2]] + curr[2][pos[0]-shift[0]][pos[1]][pos[2]]);
+				volt[1][pos[0]][pos[1]][pos[2]] *=
+				    Op->vv[1][pos[0]][pos[1]][pos[2]];
+				volt[1][pos[0]][pos[1]][pos[2]] +=
+				    Op->vi[1][pos[0]][pos[1]][pos[2]] * (
+				        curr[0][pos[0]         ][pos[1]][pos[2]         ] -
+				        curr[0][pos[0]         ][pos[1]][pos[2]-shift[2]] -
+				        curr[2][pos[0]         ][pos[1]][pos[2]         ] +
+				        curr[2][pos[0]-shift[0]][pos[1]][pos[2]         ]
+				    );
 
 				//for z
-				volt[2][pos[0]][pos[1]][pos[2]] *= Op->vv[2][pos[0]][pos[1]][pos[2]];
-				volt[2][pos[0]][pos[1]][pos[2]] += Op->vi[2][pos[0]][pos[1]][pos[2]] * ( curr[1][pos[0]][pos[1]][pos[2]] - curr[1][pos[0]-shift[0]][pos[1]][pos[2]] - curr[0][pos[0]][pos[1]][pos[2]] + curr[0][pos[0]][pos[1]-shift[1]][pos[2]]);
+				volt[2][pos[0]][pos[1]][pos[2]] *=
+				    Op->vv[2][pos[0]][pos[1]][pos[2]];
+				volt[2][pos[0]][pos[1]][pos[2]] +=
+				    Op->vi[2][pos[0]][pos[1]][pos[2]] * (
+				        curr[1][pos[0]         ][pos[1]         ][pos[2]] -
+				        curr[1][pos[0]-shift[0]][pos[1]         ][pos[2]] -
+				        curr[0][pos[0]         ][pos[1]         ][pos[2]] +
+				        curr[0][pos[0]         ][pos[1]-shift[1]][pos[2]]
+				    );
 			}
 		}
 		++pos[0];
@@ -151,16 +172,37 @@ void Engine::UpdateCurrents(unsigned int startX, unsigned int numX)
 			{
 				//do the updates here
 				//for x
-				curr[0][pos[0]][pos[1]][pos[2]] *= Op->ii[0][pos[0]][pos[1]][pos[2]];
-				curr[0][pos[0]][pos[1]][pos[2]] += Op->iv[0][pos[0]][pos[1]][pos[2]] * ( volt[2][pos[0]][pos[1]][pos[2]] - volt[2][pos[0]][pos[1]+1][pos[2]] - volt[1][pos[0]][pos[1]][pos[2]] + volt[1][pos[0]][pos[1]][pos[2]+1]);
+				curr[0][pos[0]][pos[1]][pos[2]] *=
+				    Op->ii[0][pos[0]][pos[1]][pos[2]];
+				curr[0][pos[0]][pos[1]][pos[2]] +=
+				    Op->iv[0][pos[0]][pos[1]][pos[2]] * (
+				        volt[2][pos[0]][pos[1]  ][pos[2]  ] -
+				        volt[2][pos[0]][pos[1]+1][pos[2]  ] -
+				        volt[1][pos[0]][pos[1]  ][pos[2]  ] +
+				        volt[1][pos[0]][pos[1]  ][pos[2]+1]
+				    );
 
 				//for y
-				curr[1][pos[0]][pos[1]][pos[2]] *= Op->ii[1][pos[0]][pos[1]][pos[2]];
-				curr[1][pos[0]][pos[1]][pos[2]] += Op->iv[1][pos[0]][pos[1]][pos[2]] * ( volt[0][pos[0]][pos[1]][pos[2]] - volt[0][pos[0]][pos[1]][pos[2]+1] - volt[2][pos[0]][pos[1]][pos[2]] + volt[2][pos[0]+1][pos[1]][pos[2]]);
+				curr[1][pos[0]][pos[1]][pos[2]] *=
+				    Op->ii[1][pos[0]][pos[1]][pos[2]];
+				curr[1][pos[0]][pos[1]][pos[2]] +=
+				    Op->iv[1][pos[0]][pos[1]][pos[2]] * (
+				        volt[0][pos[0]  ][pos[1]][pos[2]  ] -
+				        volt[0][pos[0]  ][pos[1]][pos[2]+1] -
+				        volt[2][pos[0]  ][pos[1]][pos[2]  ] +
+				        volt[2][pos[0]+1][pos[1]][pos[2]  ]
+				    );
 
 				//for z
-				curr[2][pos[0]][pos[1]][pos[2]] *= Op->ii[2][pos[0]][pos[1]][pos[2]];
-				curr[2][pos[0]][pos[1]][pos[2]] += Op->iv[2][pos[0]][pos[1]][pos[2]] * ( volt[1][pos[0]][pos[1]][pos[2]] - volt[1][pos[0]+1][pos[1]][pos[2]] - volt[0][pos[0]][pos[1]][pos[2]] + volt[0][pos[0]][pos[1]+1][pos[2]]);
+				curr[2][pos[0]][pos[1]][pos[2]] *=
+				    Op->ii[2][pos[0]][pos[1]][pos[2]];
+				curr[2][pos[0]][pos[1]][pos[2]] +=
+				    Op->iv[2][pos[0]][pos[1]][pos[2]] * (
+				        volt[1][pos[0]  ][pos[1]  ][pos[2]] -
+				        volt[1][pos[0]+1][pos[1]  ][pos[2]] -
+				        volt[0][pos[0]  ][pos[1]  ][pos[2]] +
+				        volt[0][pos[0]  ][pos[1]+1][pos[2]]
+				    );
 			}
 		}
 		++pos[0];

--- a/FDTD/engine_cylindermultigrid.cpp
+++ b/FDTD/engine_cylindermultigrid.cpp
@@ -134,6 +134,9 @@ bool Engine_CylinderMultiGrid::IterateTS(unsigned int iterTS)
 void Engine_CylinderMultiGrid::InterpolVoltChild2Base(unsigned int rPos)
 {
 	//interpolate voltages from child engine to the base engine...
+	Flat_N_3DArray<f4vector> &f4_volt = *f4_volt_ptr;
+	Flat_N_3DArray<f4vector> &engine_f4_volt = *m_InnerEngine->f4_volt_ptr;
+
 	unsigned int pos[3];
 	pos[0] = rPos;
 	for (pos[1]=0; pos[1]<numLines[1]; ++pos[1])
@@ -141,16 +144,16 @@ void Engine_CylinderMultiGrid::InterpolVoltChild2Base(unsigned int rPos)
 		for (pos[2]=0; pos[2]<numVectors; ++pos[2])
 		{
 			//r - direction
-			f4_volt[0][pos[0]][pos[1]][pos[2]].v  = Op_CMG->f4_interpol_v_2p[0][pos[1]].v * m_InnerEngine->f4_volt[0][pos[0]][Op_CMG->m_interpol_pos_v_2p[0][pos[1]]][pos[2]].v
-													+ Op_CMG->f4_interpol_v_2pp[0][pos[1]].v * m_InnerEngine->f4_volt[0][pos[0]][Op_CMG->m_interpol_pos_v_2pp[0][pos[1]]][pos[2]].v;
+			f4_volt(0, pos[0], pos[1], pos[2]).v  = Op_CMG->f4_interpol_v_2p[0][pos[1]].v * engine_f4_volt(0, pos[0], Op_CMG->m_interpol_pos_v_2p[0][pos[1]], pos[2]).v
+													+ Op_CMG->f4_interpol_v_2pp[0][pos[1]].v * engine_f4_volt(0, pos[0], Op_CMG->m_interpol_pos_v_2pp[0][pos[1]], pos[2]).v;
 
 			//z - direction
-			f4_volt[2][pos[0]][pos[1]][pos[2]].v  = Op_CMG->f4_interpol_v_2p[0][pos[1]].v * m_InnerEngine->f4_volt[2][pos[0]][Op_CMG->m_interpol_pos_v_2p[0][pos[1]]][pos[2]].v
-													+ Op_CMG->f4_interpol_v_2pp[0][pos[1]].v * m_InnerEngine->f4_volt[2][pos[0]][Op_CMG->m_interpol_pos_v_2pp[0][pos[1]]][pos[2]].v;
+			f4_volt(2, pos[0], pos[1], pos[2]).v  = Op_CMG->f4_interpol_v_2p[0][pos[1]].v * engine_f4_volt(2, pos[0], Op_CMG->m_interpol_pos_v_2p[0][pos[1]], pos[2]).v
+													+ Op_CMG->f4_interpol_v_2pp[0][pos[1]].v * engine_f4_volt(2, pos[0], Op_CMG->m_interpol_pos_v_2pp[0][pos[1]], pos[2]).v;
 
 			//alpha - direction
-			f4_volt[1][pos[0]][pos[1]][pos[2]].v  = Op_CMG->f4_interpol_v_2p[1][pos[1]].v * m_InnerEngine->f4_volt[1][pos[0]][Op_CMG->m_interpol_pos_v_2p[1][pos[1]]][pos[2]].v
-													+ Op_CMG->f4_interpol_v_2pp[1][pos[1]].v * m_InnerEngine->f4_volt[1][pos[0]][Op_CMG->m_interpol_pos_v_2pp[1][pos[1]]][pos[2]].v;
+			f4_volt(1, pos[0], pos[1], pos[2]).v  = Op_CMG->f4_interpol_v_2p[1][pos[1]].v * engine_f4_volt(1, pos[0], Op_CMG->m_interpol_pos_v_2p[1][pos[1]], pos[2]).v
+													+ Op_CMG->f4_interpol_v_2pp[1][pos[1]].v * engine_f4_volt(1, pos[0], Op_CMG->m_interpol_pos_v_2pp[1][pos[1]], pos[2]).v;
 		}
 	}
 }
@@ -158,6 +161,9 @@ void Engine_CylinderMultiGrid::InterpolVoltChild2Base(unsigned int rPos)
 void Engine_CylinderMultiGrid::InterpolCurrChild2Base(unsigned int rPos)
 {
 	//interpolate voltages from child engine to the base engine...
+	Flat_N_3DArray<f4vector> &f4_curr = *f4_volt_ptr;
+	Flat_N_3DArray<f4vector> &engine_f4_curr = *m_InnerEngine->f4_curr_ptr;
+
 	unsigned int pos[3];
 	pos[0] = rPos;
 	for (pos[1]=0; pos[1]<numLines[1]; ++pos[1])
@@ -165,16 +171,16 @@ void Engine_CylinderMultiGrid::InterpolCurrChild2Base(unsigned int rPos)
 		for (pos[2]=0; pos[2]<numVectors; ++pos[2])
 		{
 			//r - direction
-			f4_curr[0][pos[0]][pos[1]][pos[2]].v  = Op_CMG->f4_interpol_i_2p[0][pos[1]].v * m_InnerEngine->f4_curr[0][pos[0]][Op_CMG->m_interpol_pos_i_2p[0][pos[1]]][pos[2]].v
-													+ Op_CMG->f4_interpol_i_2pp[0][pos[1]].v * m_InnerEngine->f4_curr[0][pos[0]][Op_CMG->m_interpol_pos_i_2pp[0][pos[1]]][pos[2]].v;
+			f4_curr(0, pos[0], pos[1], pos[2]).v  = Op_CMG->f4_interpol_i_2p[0][pos[1]].v * engine_f4_curr(0, pos[0], Op_CMG->m_interpol_pos_i_2p[0][pos[1]], pos[2]).v
+													+ Op_CMG->f4_interpol_i_2pp[0][pos[1]].v * engine_f4_curr(0, pos[0], Op_CMG->m_interpol_pos_i_2pp[0][pos[1]], pos[2]).v;
 
 			//z - direction
-			f4_curr[2][pos[0]][pos[1]][pos[2]].v  = Op_CMG->f4_interpol_i_2p[0][pos[1]].v * m_InnerEngine->f4_curr[2][pos[0]][Op_CMG->m_interpol_pos_i_2p[0][pos[1]]][pos[2]].v
-													+ Op_CMG->f4_interpol_i_2pp[0][pos[1]].v * m_InnerEngine->f4_curr[2][pos[0]][Op_CMG->m_interpol_pos_i_2pp[0][pos[1]]][pos[2]].v;
+			f4_curr(2, pos[0], pos[1], pos[2]).v  = Op_CMG->f4_interpol_i_2p[0][pos[1]].v * engine_f4_curr(2, pos[0], Op_CMG->m_interpol_pos_i_2p[0][pos[1]], pos[2]).v
+													+ Op_CMG->f4_interpol_i_2pp[0][pos[1]].v * engine_f4_curr(2, pos[0], Op_CMG->m_interpol_pos_i_2pp[0][pos[1]], pos[2]).v;
 
 			//alpha - direction
-			f4_curr[1][pos[0]][pos[1]][pos[2]].v  = Op_CMG->f4_interpol_i_2p[1][pos[1]].v * m_InnerEngine->f4_curr[1][pos[0]][Op_CMG->m_interpol_pos_i_2p[1][pos[1]]][pos[2]].v
-													+ Op_CMG->f4_interpol_i_2pp[1][pos[1]].v * m_InnerEngine->f4_curr[1][pos[0]][Op_CMG->m_interpol_pos_i_2pp[1][pos[1]]][pos[2]].v;
+			f4_curr(1, pos[0], pos[1], pos[2]).v  = Op_CMG->f4_interpol_i_2p[1][pos[1]].v * engine_f4_curr(1, pos[0], Op_CMG->m_interpol_pos_i_2p[1][pos[1]], pos[2]).v
+													+ Op_CMG->f4_interpol_i_2pp[1][pos[1]].v * engine_f4_curr(1, pos[0], Op_CMG->m_interpol_pos_i_2pp[1][pos[1]], pos[2]).v;
 		}
 	}
 }

--- a/FDTD/engine_interface_sse_fdtd.cpp
+++ b/FDTD/engine_interface_sse_fdtd.cpp
@@ -36,6 +36,9 @@ Engine_Interface_SSE_FDTD::~Engine_Interface_SSE_FDTD()
 
 double Engine_Interface_SSE_FDTD::CalcFastEnergy() const
 {
+	Flat_N_3DArray<f4vector> &f4_volt = *m_Eng_SSE->Engine_sse::f4_volt_ptr;
+	Flat_N_3DArray<f4vector> &f4_curr = *m_Eng_SSE->Engine_sse::f4_curr_ptr;
+
 	f4vector E_energy;
 	E_energy.f[0]=0;
 	E_energy.f[1]=0;
@@ -54,13 +57,13 @@ double Engine_Interface_SSE_FDTD::CalcFastEnergy() const
 		{
 			for (pos[2]=0; pos[2]<m_Op_SSE->numVectors; ++pos[2])
 			{
-				E_energy.v += m_Eng_SSE->Engine_sse::f4_volt[0][pos[0]][pos[1]][pos[2]].v * m_Eng_SSE->Engine_sse::f4_volt[0][pos[0]][pos[1]][pos[2]].v;
-				E_energy.v += m_Eng_SSE->Engine_sse::f4_volt[1][pos[0]][pos[1]][pos[2]].v * m_Eng_SSE->Engine_sse::f4_volt[1][pos[0]][pos[1]][pos[2]].v;
-				E_energy.v += m_Eng_SSE->Engine_sse::f4_volt[2][pos[0]][pos[1]][pos[2]].v * m_Eng_SSE->Engine_sse::f4_volt[2][pos[0]][pos[1]][pos[2]].v;
+				E_energy.v += f4_volt(0, pos[0], pos[1], pos[2]).v * f4_volt(0, pos[0], pos[1], pos[2]).v;
+				E_energy.v += f4_volt(1, pos[0], pos[1], pos[2]).v * f4_volt(1, pos[0], pos[1], pos[2]).v;
+				E_energy.v += f4_volt(2, pos[0], pos[1], pos[2]).v * f4_volt(2, pos[0], pos[1], pos[2]).v;
 
-				H_energy.v += m_Eng_SSE->Engine_sse::f4_curr[0][pos[0]][pos[1]][pos[2]].v * m_Eng_SSE->Engine_sse::f4_curr[0][pos[0]][pos[1]][pos[2]].v;
-				H_energy.v += m_Eng_SSE->Engine_sse::f4_curr[1][pos[0]][pos[1]][pos[2]].v * m_Eng_SSE->Engine_sse::f4_curr[1][pos[0]][pos[1]][pos[2]].v;
-				H_energy.v += m_Eng_SSE->Engine_sse::f4_curr[2][pos[0]][pos[1]][pos[2]].v * m_Eng_SSE->Engine_sse::f4_curr[2][pos[0]][pos[1]][pos[2]].v;
+				H_energy.v += f4_curr(0, pos[0], pos[1], pos[2]).v * f4_curr(0, pos[0], pos[1], pos[2]).v;
+				H_energy.v += f4_curr(1, pos[0], pos[1], pos[2]).v * f4_curr(1, pos[0], pos[1], pos[2]).v;
+				H_energy.v += f4_curr(2, pos[0], pos[1], pos[2]).v * f4_curr(2, pos[0], pos[1], pos[2]).v;
 			}
 		}
 	}

--- a/FDTD/engine_sse.cpp
+++ b/FDTD/engine_sse.cpp
@@ -35,8 +35,8 @@ Engine_sse::Engine_sse(const Operator_sse* op) : Engine(op)
 {
 	m_type = SSE;
 	Op = op;
-	f4_volt = 0;
-	f4_curr = 0;
+	f4_volt_ptr = 0;
+	f4_curr_ptr = 0;
 	numVectors =  ceil((double)numLines[2]/4.0);
 
 	// speed up the calculation of denormal floating point values (flush-to-zero)
@@ -62,21 +62,26 @@ void Engine_sse::Init()
 	Delete_N_3DArray(curr,numLines);
 	curr=NULL; // not used
 
-	f4_volt = Create_N_3DArray_v4sf(numLines);
-	f4_curr = Create_N_3DArray_v4sf(numLines);
+	f4_volt_ptr = Create_Flat_N_3DArray<f4vector>(numLines);
+	f4_curr_ptr = Create_Flat_N_3DArray<f4vector>(numLines);
 }
 
 void Engine_sse::Reset()
 {
 	Engine::Reset();
-	Delete_N_3DArray_v4sf(f4_volt,numLines);
-	f4_volt = 0;
-	Delete_N_3DArray_v4sf(f4_curr,numLines);
-	f4_curr = 0;
+	Delete_Flat_N_3DArray(f4_volt_ptr,numLines);
+	f4_volt_ptr = 0;
+	Delete_Flat_N_3DArray(f4_curr_ptr,numLines);
+	f4_curr_ptr = 0;
 }
 
 void Engine_sse::UpdateVoltages(unsigned int startX, unsigned int numX)
 {
+	Flat_N_3DArray<f4vector> &f4_volt = *f4_volt_ptr;
+	Flat_N_3DArray<f4vector> &f4_curr = *f4_curr_ptr;
+	Flat_N_3DArray<f4vector> &op_f4_vv = *Op->f4_vv_ptr;
+	Flat_N_3DArray<f4vector> &op_f4_vi = *Op->f4_vi_ptr;
+
 	unsigned int pos[3];
 	bool shift[2];
 	f4vector temp;
@@ -91,79 +96,79 @@ void Engine_sse::UpdateVoltages(unsigned int startX, unsigned int numX)
 			for (pos[2]=1; pos[2]<numVectors; ++pos[2])
 			{
 				// x-polarization
-				f4_volt[0][pos[0]][pos[1]][pos[2]].v *=
-				    Op->f4_vv[0][pos[0]][pos[1]][pos[2]].v;
-				f4_volt[0][pos[0]][pos[1]][pos[2]].v +=
-				    Op->f4_vi[0][pos[0]][pos[1]][pos[2]].v * (
-				        f4_curr[2][pos[0]][pos[1]         ][pos[2]].v -
-				        f4_curr[2][pos[0]][pos[1]-shift[1]][pos[2]].v -
-				        f4_curr[1][pos[0]][pos[1]         ][pos[2]].v +
-				        f4_curr[1][pos[0]][pos[1]         ][pos[2]-1].v
+				f4_volt(0, pos[0], pos[1], pos[2]).v *=
+				    op_f4_vv(0, pos[0], pos[1], pos[2]).v;
+				f4_volt(0, pos[0], pos[1], pos[2]).v +=
+				    op_f4_vi(0, pos[0], pos[1], pos[2]).v * (
+				        f4_curr(2, pos[0], pos[1],          pos[2]  ).v -
+				        f4_curr(2, pos[0], pos[1]-shift[1], pos[2]  ).v -
+				        f4_curr(1, pos[0], pos[1],          pos[2]  ).v +
+				        f4_curr(1, pos[0], pos[1],          pos[2]-1).v
 				    );
 
 				// y-polarization
-				f4_volt[1][pos[0]][pos[1]][pos[2]].v *=
-				    Op->f4_vv[1][pos[0]][pos[1]][pos[2]].v;
-				f4_volt[1][pos[0]][pos[1]][pos[2]].v +=
-				    Op->f4_vi[1][pos[0]][pos[1]][pos[2]].v * (
-				        f4_curr[0][pos[0]         ][pos[1]][pos[2]  ].v -
-				        f4_curr[0][pos[0]         ][pos[1]][pos[2]-1].v -
-				        f4_curr[2][pos[0]         ][pos[1]][pos[2]  ].v +
-				        f4_curr[2][pos[0]-shift[0]][pos[1]][pos[2]  ].v
+				f4_volt(1, pos[0], pos[1], pos[2]).v *=
+				    op_f4_vv(1, pos[0], pos[1], pos[2]).v;
+				f4_volt(1, pos[0], pos[1], pos[2]).v +=
+				    op_f4_vi(1, pos[0], pos[1], pos[2]).v * (
+				        f4_curr(0, pos[0],          pos[1], pos[2]  ).v -
+				        f4_curr(0, pos[0],          pos[1], pos[2]-1).v -
+				        f4_curr(2, pos[0],          pos[1], pos[2]  ).v +
+				        f4_curr(2, pos[0]-shift[0], pos[1], pos[2]  ).v
 				    );
 
 				// z-polarization
-				f4_volt[2][pos[0]][pos[1]][pos[2]].v *=
-				    Op->f4_vv[2][pos[0]][pos[1]][pos[2]].v;
-				f4_volt[2][pos[0]][pos[1]][pos[2]].v +=
-				    Op->f4_vi[2][pos[0]][pos[1]][pos[2]].v * (
-				        f4_curr[1][pos[0]         ][pos[1]         ][pos[2]].v -
-				        f4_curr[1][pos[0]-shift[0]][pos[1]         ][pos[2]].v -
-				        f4_curr[0][pos[0]         ][pos[1]         ][pos[2]].v +
-				        f4_curr[0][pos[0]         ][pos[1]-shift[1]][pos[2]].v
+				f4_volt(2, pos[0], pos[1], pos[2]).v *=
+				    op_f4_vv(2, pos[0], pos[1], pos[2]).v;
+				f4_volt(2, pos[0], pos[1], pos[2]).v +=
+				    op_f4_vi(2, pos[0], pos[1], pos[2]).v * (
+				        f4_curr(1, pos[0],          pos[1],          pos[2]).v -
+				        f4_curr(1, pos[0]-shift[0], pos[1],          pos[2]).v -
+				        f4_curr(0, pos[0],          pos[1],          pos[2]).v +
+				        f4_curr(0, pos[0],          pos[1]-shift[1], pos[2]).v
 				    );
 			}
 
 			// for pos[2] = 0
 			// x-polarization
 			temp.f[0] = 0;
-			temp.f[1] = f4_curr[1][pos[0]][pos[1]][numVectors-1].f[0];
-			temp.f[2] = f4_curr[1][pos[0]][pos[1]][numVectors-1].f[1];
-			temp.f[3] = f4_curr[1][pos[0]][pos[1]][numVectors-1].f[2];
-			f4_volt[0][pos[0]][pos[1]][0].v *=
-			    Op->f4_vv[0][pos[0]][pos[1]][0].v;
-			f4_volt[0][pos[0]][pos[1]][0].v +=
-			    Op->f4_vi[0][pos[0]][pos[1]][0].v * (
-			        f4_curr[2][pos[0]][pos[1]         ][0].v -
-			        f4_curr[2][pos[0]][pos[1]-shift[1]][0].v -
-			        f4_curr[1][pos[0]][pos[1]         ][0].v +
+			temp.f[1] = f4_curr(1, pos[0], pos[1], numVectors-1).f[0];
+			temp.f[2] = f4_curr(1, pos[0], pos[1], numVectors-1).f[1];
+			temp.f[3] = f4_curr(1, pos[0], pos[1], numVectors-1).f[2];
+			f4_volt(0, pos[0], pos[1], 0).v *=
+			    op_f4_vv(0, pos[0], pos[1], 0).v;
+			f4_volt(0, pos[0], pos[1], 0).v +=
+			    op_f4_vi(0, pos[0], pos[1], 0).v * (
+			        f4_curr(2, pos[0], pos[1],          0).v -
+			        f4_curr(2, pos[0], pos[1]-shift[1], 0).v -
+			        f4_curr(1, pos[0], pos[1],          0).v +
 			        temp.v
 			    );
 
 			// y-polarization
 			temp.f[0] = 0;
-			temp.f[1] = f4_curr[0][pos[0]][pos[1]][numVectors-1].f[0];
-			temp.f[2] = f4_curr[0][pos[0]][pos[1]][numVectors-1].f[1];
-			temp.f[3] = f4_curr[0][pos[0]][pos[1]][numVectors-1].f[2];
-			f4_volt[1][pos[0]][pos[1]][0].v *=
-			    Op->f4_vv[1][pos[0]][pos[1]][0].v;
-			f4_volt[1][pos[0]][pos[1]][0].v +=
-			    Op->f4_vi[1][pos[0]][pos[1]][0].v * (
-			        f4_curr[0][pos[0]         ][pos[1]][0].v -
+			temp.f[1] = f4_curr(0, pos[0], pos[1], numVectors-1).f[0];
+			temp.f[2] = f4_curr(0, pos[0], pos[1], numVectors-1).f[1];
+			temp.f[3] = f4_curr(0, pos[0], pos[1], numVectors-1).f[2];
+			f4_volt(1, pos[0], pos[1], 0).v *=
+			    op_f4_vv(1, pos[0], pos[1], 0).v;
+			f4_volt(1, pos[0], pos[1], 0).v +=
+			    op_f4_vi(1, pos[0], pos[1], 0).v * (
+			        f4_curr(0, pos[0],          pos[1], 0).v -
 			        temp.v -
-			        f4_curr[2][pos[0]         ][pos[1]][0].v +
-			        f4_curr[2][pos[0]-shift[0]][pos[1]][0].v
+			        f4_curr(2, pos[0],          pos[1], 0).v +
+			        f4_curr(2, pos[0]-shift[0], pos[1], 0).v
 			    );
 
 			// z-polarization
-			f4_volt[2][pos[0]][pos[1]][0].v *=
-			    Op->f4_vv[2][pos[0]][pos[1]][0].v;
-			f4_volt[2][pos[0]][pos[1]][0].v +=
-			    Op->f4_vi[2][pos[0]][pos[1]][0].v * (
-			        f4_curr[1][pos[0]         ][pos[1]         ][0].v -
-			        f4_curr[1][pos[0]-shift[0]][pos[1]         ][0].v -
-			        f4_curr[0][pos[0]         ][pos[1]         ][0].v +
-			        f4_curr[0][pos[0]         ][pos[1]-shift[1]][0].v
+			f4_volt(2, pos[0], pos[1], 0).v *=
+			    op_f4_vv(2, pos[0], pos[1], 0).v;
+			f4_volt(2, pos[0], pos[1], 0).v +=
+			    op_f4_vi(2, pos[0], pos[1], 0).v * (
+			        f4_curr(1, pos[0],          pos[1],          0).v -
+			        f4_curr(1, pos[0]-shift[0], pos[1],          0).v -
+			        f4_curr(0, pos[0],          pos[1],          0).v +
+			        f4_curr(0, pos[0],          pos[1]-shift[1], 0).v
 			    );
 		}
 		++pos[0];
@@ -172,6 +177,11 @@ void Engine_sse::UpdateVoltages(unsigned int startX, unsigned int numX)
 
 void Engine_sse::UpdateCurrents(unsigned int startX, unsigned int numX)
 {
+	Flat_N_3DArray<f4vector> &f4_volt = *f4_volt_ptr;
+	Flat_N_3DArray<f4vector> &f4_curr = *f4_curr_ptr;
+	Flat_N_3DArray<f4vector> &op_f4_iv = *Op->f4_iv_ptr;
+	Flat_N_3DArray<f4vector> &op_f4_ii = *Op->f4_ii_ptr;
+
 	unsigned int pos[5];
 	f4vector temp;
 
@@ -183,79 +193,79 @@ void Engine_sse::UpdateCurrents(unsigned int startX, unsigned int numX)
 			for (pos[2]=0; pos[2]<numVectors-1; ++pos[2])
 			{
 				// x-pol
-				f4_curr[0][pos[0]][pos[1]][pos[2]].v *=
-				    Op->f4_ii[0][pos[0]][pos[1]][pos[2]].v;
-				f4_curr[0][pos[0]][pos[1]][pos[2]].v +=
-				    Op->f4_iv[0][pos[0]][pos[1]][pos[2]].v * (
-				        f4_volt[2][pos[0]][pos[1]  ][pos[2]  ].v -
-				        f4_volt[2][pos[0]][pos[1]+1][pos[2]  ].v -
-				        f4_volt[1][pos[0]][pos[1]  ][pos[2]  ].v +
-				        f4_volt[1][pos[0]][pos[1]  ][pos[2]+1].v
+				f4_curr(0, pos[0], pos[1], pos[2]).v *=
+				    op_f4_ii(0, pos[0], pos[1], pos[2]).v;
+				f4_curr(0, pos[0], pos[1], pos[2]).v +=
+				    op_f4_iv(0, pos[0], pos[1], pos[2]).v * (
+				        f4_volt(2, pos[0], pos[1],   pos[2]  ).v -
+				        f4_volt(2, pos[0], pos[1]+1, pos[2]  ).v -
+				        f4_volt(1, pos[0], pos[1],   pos[2]  ).v +
+				        f4_volt(1, pos[0], pos[1],   pos[2]+1).v
 				    );
 
 				// y-pol
-				f4_curr[1][pos[0]][pos[1]][pos[2]].v *=
-				    Op->f4_ii[1][pos[0]][pos[1]][pos[2]].v;
-				f4_curr[1][pos[0]][pos[1]][pos[2]].v +=
-				    Op->f4_iv[1][pos[0]][pos[1]][pos[2]].v * (
-				        f4_volt[0][pos[0]  ][pos[1]][pos[2]  ].v -
-				        f4_volt[0][pos[0]  ][pos[1]][pos[2]+1].v -
-				        f4_volt[2][pos[0]  ][pos[1]][pos[2]  ].v +
-				        f4_volt[2][pos[0]+1][pos[1]][pos[2]  ].v
+				f4_curr(1, pos[0], pos[1], pos[2]).v *=
+				    op_f4_ii(1, pos[0], pos[1], pos[2]).v;
+				f4_curr(1, pos[0], pos[1], pos[2]).v +=
+				    op_f4_iv(1, pos[0], pos[1], pos[2]).v * (
+				        f4_volt(0, pos[0],   pos[1], pos[2]  ).v -
+				        f4_volt(0, pos[0],   pos[1], pos[2]+1).v -
+				        f4_volt(2, pos[0],   pos[1], pos[2]  ).v +
+				        f4_volt(2, pos[0]+1, pos[1], pos[2]  ).v
 				    );
 
 				// z-pol
-				f4_curr[2][pos[0]][pos[1]][pos[2]].v *=
-				    Op->f4_ii[2][pos[0]][pos[1]][pos[2]].v;
-				f4_curr[2][pos[0]][pos[1]][pos[2]].v +=
-				    Op->f4_iv[2][pos[0]][pos[1]][pos[2]].v * (
-				        f4_volt[1][pos[0]  ][pos[1]  ][pos[2]].v -
-				        f4_volt[1][pos[0]+1][pos[1]  ][pos[2]].v -
-				        f4_volt[0][pos[0]  ][pos[1]  ][pos[2]].v +
-				        f4_volt[0][pos[0]  ][pos[1]+1][pos[2]].v
+				f4_curr(2, pos[0], pos[1], pos[2]).v *=
+				    op_f4_ii(2, pos[0], pos[1], pos[2]).v;
+				f4_curr(2, pos[0], pos[1], pos[2]).v +=
+				    op_f4_iv(2, pos[0], pos[1], pos[2]).v * (
+				        f4_volt(1, pos[0],   pos[1],   pos[2]).v -
+				        f4_volt(1, pos[0]+1, pos[1],   pos[2]).v -
+				        f4_volt(0, pos[0],   pos[1],   pos[2]).v +
+				        f4_volt(0, pos[0],   pos[1]+1, pos[2]).v
 				    );
 			}
 
 			// for pos[2] = numVectors-1
 			// x-pol
-			temp.f[0] = f4_volt[1][pos[0]][pos[1]][0].f[1];
-			temp.f[1] = f4_volt[1][pos[0]][pos[1]][0].f[2];
-			temp.f[2] = f4_volt[1][pos[0]][pos[1]][0].f[3];
+			temp.f[0] = f4_volt(1, pos[0], pos[1], 0).f[1];
+			temp.f[1] = f4_volt(1, pos[0], pos[1], 0).f[2];
+			temp.f[2] = f4_volt(1, pos[0], pos[1], 0).f[3];
 			temp.f[3] = 0;
-			f4_curr[0][pos[0]][pos[1]][numVectors-1].v *=
-			    Op->f4_ii[0][pos[0]][pos[1]][numVectors-1].v;
-			f4_curr[0][pos[0]][pos[1]][numVectors-1].v +=
-			    Op->f4_iv[0][pos[0]][pos[1]][numVectors-1].v * (
-			        f4_volt[2][pos[0]][pos[1]  ][numVectors-1].v -
-			        f4_volt[2][pos[0]][pos[1]+1][numVectors-1].v -
-			        f4_volt[1][pos[0]][pos[1]  ][numVectors-1].v +
+			f4_curr(0, pos[0], pos[1], numVectors-1).v *=
+			    op_f4_ii(0, pos[0], pos[1], numVectors-1).v;
+			f4_curr(0, pos[0], pos[1], numVectors-1).v +=
+			    op_f4_iv(0, pos[0], pos[1], numVectors-1).v * (
+			        f4_volt(2, pos[0], pos[1],   numVectors-1).v -
+			        f4_volt(2, pos[0], pos[1]+1, numVectors-1).v -
+			        f4_volt(1, pos[0], pos[1],   numVectors-1).v +
 			        temp.v
 			    );
 
 			// y-pol
-			temp.f[0] = f4_volt[0][pos[0]][pos[1]][0].f[1];
-			temp.f[1] = f4_volt[0][pos[0]][pos[1]][0].f[2];
-			temp.f[2] = f4_volt[0][pos[0]][pos[1]][0].f[3];
+			temp.f[0] = f4_volt(0, pos[0], pos[1], 0).f[1];
+			temp.f[1] = f4_volt(0, pos[0], pos[1], 0).f[2];
+			temp.f[2] = f4_volt(0, pos[0], pos[1], 0).f[3];
 			temp.f[3] = 0;
-			f4_curr[1][pos[0]][pos[1]][numVectors-1].v *=
-			    Op->f4_ii[1][pos[0]][pos[1]][numVectors-1].v;
-			f4_curr[1][pos[0]][pos[1]][numVectors-1].v +=
-			    Op->f4_iv[1][pos[0]][pos[1]][numVectors-1].v * (
-			        f4_volt[0][pos[0]  ][pos[1]][numVectors-1].v -
+			f4_curr(1, pos[0], pos[1], numVectors-1).v *=
+			    op_f4_ii(1, pos[0], pos[1], numVectors-1).v;
+			f4_curr(1, pos[0], pos[1], numVectors-1).v +=
+			    op_f4_iv(1, pos[0], pos[1], numVectors-1).v * (
+			        f4_volt(0, pos[0],   pos[1], numVectors-1).v -
 			        temp.v -
-			        f4_volt[2][pos[0]  ][pos[1]][numVectors-1].v +
-			        f4_volt[2][pos[0]+1][pos[1]][numVectors-1].v
+			        f4_volt(2, pos[0],   pos[1], numVectors-1).v +
+			        f4_volt(2, pos[0]+1, pos[1], numVectors-1).v
 			    );
 
 			// z-pol
-			f4_curr[2][pos[0]][pos[1]][numVectors-1].v *=
-			    Op->f4_ii[2][pos[0]][pos[1]][numVectors-1].v;
-			f4_curr[2][pos[0]][pos[1]][numVectors-1].v +=
-			    Op->f4_iv[2][pos[0]][pos[1]][numVectors-1].v * (
-			        f4_volt[1][pos[0]  ][pos[1]  ][numVectors-1].v -
-			        f4_volt[1][pos[0]+1][pos[1]  ][numVectors-1].v -
-			        f4_volt[0][pos[0]  ][pos[1]  ][numVectors-1].v +
-			        f4_volt[0][pos[0]  ][pos[1]+1][numVectors-1].v
+			f4_curr(2, pos[0], pos[1], numVectors-1).v *=
+			    op_f4_ii(2, pos[0], pos[1], numVectors-1).v;
+			f4_curr(2, pos[0], pos[1], numVectors-1).v +=
+			    op_f4_iv(2, pos[0], pos[1], numVectors-1).v * (
+			        f4_volt(1, pos[0],   pos[1],   numVectors-1).v -
+			        f4_volt(1, pos[0]+1, pos[1],   numVectors-1).v -
+			        f4_volt(0, pos[0],   pos[1],   numVectors-1).v +
+			        f4_volt(0, pos[0],   pos[1]+1, numVectors-1).v
 			    );
 		}
 		++pos[0];

--- a/FDTD/engine_sse.cpp
+++ b/FDTD/engine_sse.cpp
@@ -91,16 +91,37 @@ void Engine_sse::UpdateVoltages(unsigned int startX, unsigned int numX)
 			for (pos[2]=1; pos[2]<numVectors; ++pos[2])
 			{
 				// x-polarization
-				f4_volt[0][pos[0]][pos[1]][pos[2]].v *= Op->f4_vv[0][pos[0]][pos[1]][pos[2]].v;
-				f4_volt[0][pos[0]][pos[1]][pos[2]].v += Op->f4_vi[0][pos[0]][pos[1]][pos[2]].v * ( f4_curr[2][pos[0]][pos[1]][pos[2]].v - f4_curr[2][pos[0]][pos[1]-shift[1]][pos[2]].v - f4_curr[1][pos[0]][pos[1]][pos[2]].v + f4_curr[1][pos[0]][pos[1]][pos[2]-1].v );
+				f4_volt[0][pos[0]][pos[1]][pos[2]].v *=
+				    Op->f4_vv[0][pos[0]][pos[1]][pos[2]].v;
+				f4_volt[0][pos[0]][pos[1]][pos[2]].v +=
+				    Op->f4_vi[0][pos[0]][pos[1]][pos[2]].v * (
+				        f4_curr[2][pos[0]][pos[1]         ][pos[2]].v -
+				        f4_curr[2][pos[0]][pos[1]-shift[1]][pos[2]].v -
+				        f4_curr[1][pos[0]][pos[1]         ][pos[2]].v +
+				        f4_curr[1][pos[0]][pos[1]         ][pos[2]-1].v
+				    );
 
 				// y-polarization
-				f4_volt[1][pos[0]][pos[1]][pos[2]].v *= Op->f4_vv[1][pos[0]][pos[1]][pos[2]].v;
-				f4_volt[1][pos[0]][pos[1]][pos[2]].v += Op->f4_vi[1][pos[0]][pos[1]][pos[2]].v * ( f4_curr[0][pos[0]][pos[1]][pos[2]].v - f4_curr[0][pos[0]][pos[1]][pos[2]-1].v - f4_curr[2][pos[0]][pos[1]][pos[2]].v + f4_curr[2][pos[0]-shift[0]][pos[1]][pos[2]].v);
+				f4_volt[1][pos[0]][pos[1]][pos[2]].v *=
+				    Op->f4_vv[1][pos[0]][pos[1]][pos[2]].v;
+				f4_volt[1][pos[0]][pos[1]][pos[2]].v +=
+				    Op->f4_vi[1][pos[0]][pos[1]][pos[2]].v * (
+				        f4_curr[0][pos[0]         ][pos[1]][pos[2]  ].v -
+				        f4_curr[0][pos[0]         ][pos[1]][pos[2]-1].v -
+				        f4_curr[2][pos[0]         ][pos[1]][pos[2]  ].v +
+				        f4_curr[2][pos[0]-shift[0]][pos[1]][pos[2]  ].v
+				    );
 
 				// z-polarization
-				f4_volt[2][pos[0]][pos[1]][pos[2]].v *= Op->f4_vv[2][pos[0]][pos[1]][pos[2]].v;
-				f4_volt[2][pos[0]][pos[1]][pos[2]].v += Op->f4_vi[2][pos[0]][pos[1]][pos[2]].v * ( f4_curr[1][pos[0]][pos[1]][pos[2]].v - f4_curr[1][pos[0]-shift[0]][pos[1]][pos[2]].v - f4_curr[0][pos[0]][pos[1]][pos[2]].v + f4_curr[0][pos[0]][pos[1]-shift[1]][pos[2]].v);
+				f4_volt[2][pos[0]][pos[1]][pos[2]].v *=
+				    Op->f4_vv[2][pos[0]][pos[1]][pos[2]].v;
+				f4_volt[2][pos[0]][pos[1]][pos[2]].v +=
+				    Op->f4_vi[2][pos[0]][pos[1]][pos[2]].v * (
+				        f4_curr[1][pos[0]         ][pos[1]         ][pos[2]].v -
+				        f4_curr[1][pos[0]-shift[0]][pos[1]         ][pos[2]].v -
+				        f4_curr[0][pos[0]         ][pos[1]         ][pos[2]].v +
+				        f4_curr[0][pos[0]         ][pos[1]-shift[1]][pos[2]].v
+				    );
 			}
 
 			// for pos[2] = 0
@@ -109,20 +130,41 @@ void Engine_sse::UpdateVoltages(unsigned int startX, unsigned int numX)
 			temp.f[1] = f4_curr[1][pos[0]][pos[1]][numVectors-1].f[0];
 			temp.f[2] = f4_curr[1][pos[0]][pos[1]][numVectors-1].f[1];
 			temp.f[3] = f4_curr[1][pos[0]][pos[1]][numVectors-1].f[2];
-			f4_volt[0][pos[0]][pos[1]][0].v *= Op->f4_vv[0][pos[0]][pos[1]][0].v;
-			f4_volt[0][pos[0]][pos[1]][0].v += Op->f4_vi[0][pos[0]][pos[1]][0].v * ( f4_curr[2][pos[0]][pos[1]][0].v - f4_curr[2][pos[0]][pos[1]-shift[1]][0].v - f4_curr[1][pos[0]][pos[1]][0].v + temp.v );
+			f4_volt[0][pos[0]][pos[1]][0].v *=
+			    Op->f4_vv[0][pos[0]][pos[1]][0].v;
+			f4_volt[0][pos[0]][pos[1]][0].v +=
+			    Op->f4_vi[0][pos[0]][pos[1]][0].v * (
+			        f4_curr[2][pos[0]][pos[1]         ][0].v -
+			        f4_curr[2][pos[0]][pos[1]-shift[1]][0].v -
+			        f4_curr[1][pos[0]][pos[1]         ][0].v +
+			        temp.v
+			    );
 
 			// y-polarization
 			temp.f[0] = 0;
 			temp.f[1] = f4_curr[0][pos[0]][pos[1]][numVectors-1].f[0];
 			temp.f[2] = f4_curr[0][pos[0]][pos[1]][numVectors-1].f[1];
 			temp.f[3] = f4_curr[0][pos[0]][pos[1]][numVectors-1].f[2];
-			f4_volt[1][pos[0]][pos[1]][0].v *= Op->f4_vv[1][pos[0]][pos[1]][0].v;
-			f4_volt[1][pos[0]][pos[1]][0].v += Op->f4_vi[1][pos[0]][pos[1]][0].v * ( f4_curr[0][pos[0]][pos[1]][0].v - temp.v - f4_curr[2][pos[0]][pos[1]][0].v + f4_curr[2][pos[0]-shift[0]][pos[1]][0].v);
+			f4_volt[1][pos[0]][pos[1]][0].v *=
+			    Op->f4_vv[1][pos[0]][pos[1]][0].v;
+			f4_volt[1][pos[0]][pos[1]][0].v +=
+			    Op->f4_vi[1][pos[0]][pos[1]][0].v * (
+			        f4_curr[0][pos[0]         ][pos[1]][0].v -
+			        temp.v -
+			        f4_curr[2][pos[0]         ][pos[1]][0].v +
+			        f4_curr[2][pos[0]-shift[0]][pos[1]][0].v
+			    );
 
 			// z-polarization
-			f4_volt[2][pos[0]][pos[1]][0].v *= Op->f4_vv[2][pos[0]][pos[1]][0].v;
-			f4_volt[2][pos[0]][pos[1]][0].v += Op->f4_vi[2][pos[0]][pos[1]][0].v * ( f4_curr[1][pos[0]][pos[1]][0].v - f4_curr[1][pos[0]-shift[0]][pos[1]][0].v - f4_curr[0][pos[0]][pos[1]][0].v + f4_curr[0][pos[0]][pos[1]-shift[1]][0].v);
+			f4_volt[2][pos[0]][pos[1]][0].v *=
+			    Op->f4_vv[2][pos[0]][pos[1]][0].v;
+			f4_volt[2][pos[0]][pos[1]][0].v +=
+			    Op->f4_vi[2][pos[0]][pos[1]][0].v * (
+			        f4_curr[1][pos[0]         ][pos[1]         ][0].v -
+			        f4_curr[1][pos[0]-shift[0]][pos[1]         ][0].v -
+			        f4_curr[0][pos[0]         ][pos[1]         ][0].v +
+			        f4_curr[0][pos[0]         ][pos[1]-shift[1]][0].v
+			    );
 		}
 		++pos[0];
 	}
@@ -141,16 +183,37 @@ void Engine_sse::UpdateCurrents(unsigned int startX, unsigned int numX)
 			for (pos[2]=0; pos[2]<numVectors-1; ++pos[2])
 			{
 				// x-pol
-				f4_curr[0][pos[0]][pos[1]][pos[2]].v *= Op->f4_ii[0][pos[0]][pos[1]][pos[2]].v;
-				f4_curr[0][pos[0]][pos[1]][pos[2]].v += Op->f4_iv[0][pos[0]][pos[1]][pos[2]].v * ( f4_volt[2][pos[0]][pos[1]][pos[2]].v - f4_volt[2][pos[0]][pos[1]+1][pos[2]].v - f4_volt[1][pos[0]][pos[1]][pos[2]].v + f4_volt[1][pos[0]][pos[1]][pos[2]+1].v);
+				f4_curr[0][pos[0]][pos[1]][pos[2]].v *=
+				    Op->f4_ii[0][pos[0]][pos[1]][pos[2]].v;
+				f4_curr[0][pos[0]][pos[1]][pos[2]].v +=
+				    Op->f4_iv[0][pos[0]][pos[1]][pos[2]].v * (
+				        f4_volt[2][pos[0]][pos[1]  ][pos[2]  ].v -
+				        f4_volt[2][pos[0]][pos[1]+1][pos[2]  ].v -
+				        f4_volt[1][pos[0]][pos[1]  ][pos[2]  ].v +
+				        f4_volt[1][pos[0]][pos[1]  ][pos[2]+1].v
+				    );
 
 				// y-pol
-				f4_curr[1][pos[0]][pos[1]][pos[2]].v *= Op->f4_ii[1][pos[0]][pos[1]][pos[2]].v;
-				f4_curr[1][pos[0]][pos[1]][pos[2]].v += Op->f4_iv[1][pos[0]][pos[1]][pos[2]].v * ( f4_volt[0][pos[0]][pos[1]][pos[2]].v - f4_volt[0][pos[0]][pos[1]][pos[2]+1].v - f4_volt[2][pos[0]][pos[1]][pos[2]].v + f4_volt[2][pos[0]+1][pos[1]][pos[2]].v);
+				f4_curr[1][pos[0]][pos[1]][pos[2]].v *=
+				    Op->f4_ii[1][pos[0]][pos[1]][pos[2]].v;
+				f4_curr[1][pos[0]][pos[1]][pos[2]].v +=
+				    Op->f4_iv[1][pos[0]][pos[1]][pos[2]].v * (
+				        f4_volt[0][pos[0]  ][pos[1]][pos[2]  ].v -
+				        f4_volt[0][pos[0]  ][pos[1]][pos[2]+1].v -
+				        f4_volt[2][pos[0]  ][pos[1]][pos[2]  ].v +
+				        f4_volt[2][pos[0]+1][pos[1]][pos[2]  ].v
+				    );
 
 				// z-pol
-				f4_curr[2][pos[0]][pos[1]][pos[2]].v *= Op->f4_ii[2][pos[0]][pos[1]][pos[2]].v;
-				f4_curr[2][pos[0]][pos[1]][pos[2]].v += Op->f4_iv[2][pos[0]][pos[1]][pos[2]].v * ( f4_volt[1][pos[0]][pos[1]][pos[2]].v - f4_volt[1][pos[0]+1][pos[1]][pos[2]].v - f4_volt[0][pos[0]][pos[1]][pos[2]].v + f4_volt[0][pos[0]][pos[1]+1][pos[2]].v);
+				f4_curr[2][pos[0]][pos[1]][pos[2]].v *=
+				    Op->f4_ii[2][pos[0]][pos[1]][pos[2]].v;
+				f4_curr[2][pos[0]][pos[1]][pos[2]].v +=
+				    Op->f4_iv[2][pos[0]][pos[1]][pos[2]].v * (
+				        f4_volt[1][pos[0]  ][pos[1]  ][pos[2]].v -
+				        f4_volt[1][pos[0]+1][pos[1]  ][pos[2]].v -
+				        f4_volt[0][pos[0]  ][pos[1]  ][pos[2]].v +
+				        f4_volt[0][pos[0]  ][pos[1]+1][pos[2]].v
+				    );
 			}
 
 			// for pos[2] = numVectors-1
@@ -159,20 +222,41 @@ void Engine_sse::UpdateCurrents(unsigned int startX, unsigned int numX)
 			temp.f[1] = f4_volt[1][pos[0]][pos[1]][0].f[2];
 			temp.f[2] = f4_volt[1][pos[0]][pos[1]][0].f[3];
 			temp.f[3] = 0;
-			f4_curr[0][pos[0]][pos[1]][numVectors-1].v *= Op->f4_ii[0][pos[0]][pos[1]][numVectors-1].v;
-			f4_curr[0][pos[0]][pos[1]][numVectors-1].v += Op->f4_iv[0][pos[0]][pos[1]][numVectors-1].v * ( f4_volt[2][pos[0]][pos[1]][numVectors-1].v - f4_volt[2][pos[0]][pos[1]+1][numVectors-1].v - f4_volt[1][pos[0]][pos[1]][numVectors-1].v + temp.v);
+			f4_curr[0][pos[0]][pos[1]][numVectors-1].v *=
+			    Op->f4_ii[0][pos[0]][pos[1]][numVectors-1].v;
+			f4_curr[0][pos[0]][pos[1]][numVectors-1].v +=
+			    Op->f4_iv[0][pos[0]][pos[1]][numVectors-1].v * (
+			        f4_volt[2][pos[0]][pos[1]  ][numVectors-1].v -
+			        f4_volt[2][pos[0]][pos[1]+1][numVectors-1].v -
+			        f4_volt[1][pos[0]][pos[1]  ][numVectors-1].v +
+			        temp.v
+			    );
 
 			// y-pol
 			temp.f[0] = f4_volt[0][pos[0]][pos[1]][0].f[1];
 			temp.f[1] = f4_volt[0][pos[0]][pos[1]][0].f[2];
 			temp.f[2] = f4_volt[0][pos[0]][pos[1]][0].f[3];
 			temp.f[3] = 0;
-			f4_curr[1][pos[0]][pos[1]][numVectors-1].v *= Op->f4_ii[1][pos[0]][pos[1]][numVectors-1].v;
-			f4_curr[1][pos[0]][pos[1]][numVectors-1].v += Op->f4_iv[1][pos[0]][pos[1]][numVectors-1].v * ( f4_volt[0][pos[0]][pos[1]][numVectors-1].v - temp.v - f4_volt[2][pos[0]][pos[1]][numVectors-1].v + f4_volt[2][pos[0]+1][pos[1]][numVectors-1].v);
+			f4_curr[1][pos[0]][pos[1]][numVectors-1].v *=
+			    Op->f4_ii[1][pos[0]][pos[1]][numVectors-1].v;
+			f4_curr[1][pos[0]][pos[1]][numVectors-1].v +=
+			    Op->f4_iv[1][pos[0]][pos[1]][numVectors-1].v * (
+			        f4_volt[0][pos[0]  ][pos[1]][numVectors-1].v -
+			        temp.v -
+			        f4_volt[2][pos[0]  ][pos[1]][numVectors-1].v +
+			        f4_volt[2][pos[0]+1][pos[1]][numVectors-1].v
+			    );
 
 			// z-pol
-			f4_curr[2][pos[0]][pos[1]][numVectors-1].v *= Op->f4_ii[2][pos[0]][pos[1]][numVectors-1].v;
-			f4_curr[2][pos[0]][pos[1]][numVectors-1].v += Op->f4_iv[2][pos[0]][pos[1]][numVectors-1].v * ( f4_volt[1][pos[0]][pos[1]][numVectors-1].v - f4_volt[1][pos[0]+1][pos[1]][numVectors-1].v - f4_volt[0][pos[0]][pos[1]][numVectors-1].v + f4_volt[0][pos[0]][pos[1]+1][numVectors-1].v);
+			f4_curr[2][pos[0]][pos[1]][numVectors-1].v *=
+			    Op->f4_ii[2][pos[0]][pos[1]][numVectors-1].v;
+			f4_curr[2][pos[0]][pos[1]][numVectors-1].v +=
+			    Op->f4_iv[2][pos[0]][pos[1]][numVectors-1].v * (
+			        f4_volt[1][pos[0]  ][pos[1]  ][numVectors-1].v -
+			        f4_volt[1][pos[0]+1][pos[1]  ][numVectors-1].v -
+			        f4_volt[0][pos[0]  ][pos[1]  ][numVectors-1].v +
+			        f4_volt[0][pos[0]  ][pos[1]+1][numVectors-1].v
+			    );
 		}
 		++pos[0];
 	}

--- a/FDTD/engine_sse.h
+++ b/FDTD/engine_sse.h
@@ -33,15 +33,44 @@ public:
 	virtual unsigned int GetNumberOfTimesteps() {return numTS;};
 
 	//this access functions muss be overloaded by any new engine using a different storage model
-	inline virtual FDTD_FLOAT GetVolt( unsigned int n, unsigned int x, unsigned int y, unsigned int z )	const { return f4_volt[n][x][y][z%numVectors].f[z/numVectors]; }
-	inline virtual FDTD_FLOAT GetVolt( unsigned int n, const unsigned int pos[3] )						const { return f4_volt[n][pos[0]][pos[1]][pos[2]%numVectors].f[pos[2]/numVectors]; }
-	inline virtual FDTD_FLOAT GetCurr( unsigned int n, unsigned int x, unsigned int y, unsigned int z )	const { return f4_curr[n][x][y][z%numVectors].f[z/numVectors]; }
-	inline virtual FDTD_FLOAT GetCurr( unsigned int n, const unsigned int pos[3] )						const { return f4_curr[n][pos[0]][pos[1]][pos[2]%numVectors].f[pos[2]/numVectors]; }
+	inline virtual FDTD_FLOAT GetVolt( unsigned int n, unsigned int x, unsigned int y, unsigned int z ) const
+	{
+		Flat_N_3DArray<f4vector> &f4_volt = *f4_volt_ptr;
+		return f4_volt(n, x, y, z%numVectors).f[z/numVectors];
+	}
+	inline virtual FDTD_FLOAT GetVolt( unsigned int n, const unsigned int pos[3] ) const
+	{
+		Flat_N_3DArray<f4vector> &f4_volt = *f4_volt_ptr;
+		return f4_volt(n, pos[0], pos[1], pos[2]%numVectors).f[pos[2]/numVectors];
+	}
+	inline virtual FDTD_FLOAT GetCurr( unsigned int n, unsigned int x, unsigned int y, unsigned int z ) const
+	{
+		Flat_N_3DArray<f4vector> &f4_curr = *f4_curr_ptr;
+		return f4_curr(n, x, y, z%numVectors).f[z/numVectors];
+	}
+	inline virtual FDTD_FLOAT GetCurr( unsigned int n, const unsigned int pos[3] ) const
+	{
+		Flat_N_3DArray<f4vector> &f4_curr = *f4_curr_ptr;
+		return f4_curr(n, pos[0], pos[1], pos[2]%numVectors).f[pos[2]/numVectors];
+	}
 
-	inline virtual void SetVolt( unsigned int n, unsigned int x, unsigned int y, unsigned int z, FDTD_FLOAT value)	{ f4_volt[n][x][y][z%numVectors].f[z/numVectors]=value; }
-	inline virtual void SetVolt( unsigned int n, const unsigned int pos[3], FDTD_FLOAT value )						{ f4_volt[n][pos[0]][pos[1]][pos[2]%numVectors].f[pos[2]/numVectors]=value; }
-	inline virtual void SetCurr( unsigned int n, unsigned int x, unsigned int y, unsigned int z, FDTD_FLOAT value)	{ f4_curr[n][x][y][z%numVectors].f[z/numVectors]=value; }
-	inline virtual void SetCurr( unsigned int n, const unsigned int pos[3], FDTD_FLOAT value )						{ f4_curr[n][pos[0]][pos[1]][pos[2]%numVectors].f[pos[2]/numVectors]=value; }
+	inline virtual void SetVolt( unsigned int n, unsigned int x, unsigned int y, unsigned int z, FDTD_FLOAT value)
+	{
+		Flat_N_3DArray<f4vector> &f4_volt = *f4_volt_ptr;
+		f4_volt(n, x, y, z%numVectors).f[z/numVectors]=value;
+	}
+	inline virtual void SetVolt( unsigned int n, const unsigned int pos[3], FDTD_FLOAT value )						{
+		Flat_N_3DArray<f4vector> &f4_volt = *f4_volt_ptr;
+		f4_volt(n, pos[0], pos[1], pos[2]%numVectors).f[pos[2]/numVectors]=value;
+	}
+	inline virtual void SetCurr( unsigned int n, unsigned int x, unsigned int y, unsigned int z, FDTD_FLOAT value)	{
+		Flat_N_3DArray<f4vector> &f4_curr = *f4_curr_ptr;
+		f4_curr(n, x, y, z%numVectors).f[z/numVectors]=value;
+	}
+	inline virtual void SetCurr( unsigned int n, const unsigned int pos[3], FDTD_FLOAT value )						{
+		Flat_N_3DArray<f4vector> &f4_curr = *f4_curr_ptr;
+		f4_curr(n, pos[0], pos[1], pos[2]%numVectors).f[pos[2]/numVectors]=value;
+	}
 
 protected:
 	Engine_sse(const Operator_sse* op);
@@ -53,8 +82,8 @@ protected:
 	unsigned int numVectors;
 
 public: //public access to the sse arrays for efficient extensions access... use careful...
-	f4vector**** f4_volt;
-	f4vector**** f4_curr;
+	Flat_N_3DArray<f4vector>* f4_volt_ptr;
+	Flat_N_3DArray<f4vector>* f4_curr_ptr;
 };
 
 #endif // ENGINE_SSE_H

--- a/FDTD/engine_sse_compressed.cpp
+++ b/FDTD/engine_sse_compressed.cpp
@@ -39,6 +39,9 @@ Engine_SSE_Compressed::~Engine_SSE_Compressed()
 
 void Engine_SSE_Compressed::UpdateVoltages(unsigned int startX, unsigned int numX)
 {
+	Flat_N_3DArray<f4vector> &f4_volt = *f4_volt_ptr;
+	Flat_N_3DArray<f4vector> &f4_curr = *f4_curr_ptr;
+
 	unsigned int pos[3];
 	bool shift[2];
 	f4vector temp;
@@ -55,36 +58,36 @@ void Engine_SSE_Compressed::UpdateVoltages(unsigned int startX, unsigned int num
 			{
 				index = Op->m_Op_index[pos[0]][pos[1]][pos[2]];
 				// x-polarization
-				f4_volt[0][pos[0]][pos[1]][pos[2]].v *=
+				f4_volt(0, pos[0], pos[1], pos[2]).v *=
 				    Op->f4_vv_Compressed[0][index].v;
-				f4_volt[0][pos[0]][pos[1]][pos[2]].v +=
+				f4_volt(0, pos[0], pos[1], pos[2]).v +=
 				    Op->f4_vi_Compressed[0][index].v * (
-				        f4_curr[2][pos[0]][pos[1]         ][pos[2]  ].v -
-				        f4_curr[2][pos[0]][pos[1]-shift[1]][pos[2]  ].v -
-				        f4_curr[1][pos[0]][pos[1]         ][pos[2]  ].v +
-				        f4_curr[1][pos[0]][pos[1]         ][pos[2]-1].v
+				        f4_curr(2, pos[0], pos[1],          pos[2]  ).v -
+				        f4_curr(2, pos[0], pos[1]-shift[1], pos[2]  ).v -
+				        f4_curr(1, pos[0], pos[1],          pos[2]  ).v +
+				        f4_curr(1, pos[0], pos[1],          pos[2]-1).v
 				    );
 
 				// y-polarization
-				f4_volt[1][pos[0]][pos[1]][pos[2]].v *=
+				f4_volt(1, pos[0], pos[1], pos[2]).v *=
 				    Op->f4_vv_Compressed[1][index].v;
-				f4_volt[1][pos[0]][pos[1]][pos[2]].v +=
+				f4_volt(1, pos[0], pos[1], pos[2]).v +=
 				    Op->f4_vi_Compressed[1][index].v * (
-				        f4_curr[0][pos[0]         ][pos[1]][pos[2]  ].v -
-				        f4_curr[0][pos[0]         ][pos[1]][pos[2]-1].v -
-				        f4_curr[2][pos[0]         ][pos[1]][pos[2]  ].v +
-				        f4_curr[2][pos[0]-shift[0]][pos[1]][pos[2]  ].v
+				        f4_curr(0, pos[0],          pos[1], pos[2]  ).v -
+				        f4_curr(0, pos[0],          pos[1], pos[2]-1).v -
+				        f4_curr(2, pos[0],          pos[1], pos[2]  ).v +
+				        f4_curr(2, pos[0]-shift[0], pos[1], pos[2]  ).v
 				    );
 
 				// z-polarization
-				f4_volt[2][pos[0]][pos[1]][pos[2]].v *=
+				f4_volt(2, pos[0], pos[1], pos[2]).v *=
 				    Op->f4_vv_Compressed[2][index].v;
-				f4_volt[2][pos[0]][pos[1]][pos[2]].v +=
+				f4_volt(2, pos[0], pos[1], pos[2]).v +=
 				    Op->f4_vi_Compressed[2][index].v * (
-				        f4_curr[1][pos[0]         ][pos[1]]         [pos[2]].v -
-				        f4_curr[1][pos[0]-shift[0]][pos[1]]         [pos[2]].v -
-				        f4_curr[0][pos[0]         ][pos[1]]         [pos[2]].v +
-				        f4_curr[0][pos[0]         ][pos[1]-shift[1]][pos[2]].v
+				        f4_curr(1, pos[0],          pos[1],          pos[2]).v -
+				        f4_curr(1, pos[0]-shift[0], pos[1],          pos[2]).v -
+				        f4_curr(0, pos[0],          pos[1],          pos[2]).v +
+				        f4_curr(0, pos[0],          pos[1]-shift[1], pos[2]).v
 				    );
 			}
 
@@ -93,54 +96,54 @@ void Engine_SSE_Compressed::UpdateVoltages(unsigned int startX, unsigned int num
 			index = Op->m_Op_index[pos[0]][pos[1]][0];
 #ifdef __SSE2__
 			temp.v = (__m128)_mm_slli_si128(
-			             (__m128i)f4_curr[1][pos[0]][pos[1]][numVectors-1].v, 4
+			             (__m128i)f4_curr(1, pos[0], pos[1], numVectors-1).v, 4
 			         );
 #else
 			temp.f[0] = 0;
-			temp.f[1] = f4_curr[1][pos[0]][pos[1]][numVectors-1].f[0];
-			temp.f[2] = f4_curr[1][pos[0]][pos[1]][numVectors-1].f[1];
-			temp.f[3] = f4_curr[1][pos[0]][pos[1]][numVectors-1].f[2];
+			temp.f[1] = f4_curr(1, pos[0], pos[1], numVectors-1).f[0];
+			temp.f[2] = f4_curr(1, pos[0], pos[1], numVectors-1).f[1];
+			temp.f[3] = f4_curr(1, pos[0], pos[1], numVectors-1).f[2];
 #endif
-			f4_volt[0][pos[0]][pos[1]][0].v *=
+			f4_volt(0, pos[0], pos[1], 0).v *=
 			    Op->f4_vv_Compressed[0][index].v;
-			f4_volt[0][pos[0]][pos[1]][0].v +=
+			f4_volt(0, pos[0], pos[1], 0).v +=
 			    Op->f4_vi_Compressed[0][index].v * (
-			        f4_curr[2][pos[0]][pos[1]         ][0].v -
-			        f4_curr[2][pos[0]][pos[1]-shift[1]][0].v -
-			        f4_curr[1][pos[0]][pos[1]         ][0].v +
+			        f4_curr(2, pos[0], pos[1],          0).v -
+			        f4_curr(2, pos[0], pos[1]-shift[1], 0).v -
+			        f4_curr(1, pos[0], pos[1],          0).v +
 			        temp.v
 			    );
 
 			// y-polarization
 #ifdef __SSE2__
 			temp.v = (__m128)_mm_slli_si128(
-			             (__m128i)f4_curr[0][pos[0]][pos[1]][numVectors-1].v, 4
+			             (__m128i)f4_curr(0, pos[0], pos[1], numVectors-1).v, 4
 			         );
 #else
 			temp.f[0] = 0;
-			temp.f[1] = f4_curr[0][pos[0]][pos[1]][numVectors-1].f[0];
-			temp.f[2] = f4_curr[0][pos[0]][pos[1]][numVectors-1].f[1];
-			temp.f[3] = f4_curr[0][pos[0]][pos[1]][numVectors-1].f[2];
+			temp.f[1] = f4_curr(0, pos[0], pos[1], numVectors-1).f[0];
+			temp.f[2] = f4_curr(0, pos[0], pos[1], numVectors-1).f[1];
+			temp.f[3] = f4_curr(0, pos[0], pos[1], numVectors-1).f[2];
 #endif
-			f4_volt[1][pos[0]][pos[1]][0].v *=
+			f4_volt(1, pos[0], pos[1], 0).v *=
 			    Op->f4_vv_Compressed[1][index].v;
-			f4_volt[1][pos[0]][pos[1]][0].v +=
+			f4_volt(1, pos[0], pos[1], 0).v +=
 			    Op->f4_vi_Compressed[1][index].v * (
-			        f4_curr[0][pos[0]         ][pos[1]][0].v -
+			        f4_curr(0, pos[0],          pos[1], 0).v -
 			        temp.v -
-			        f4_curr[2][pos[0]         ][pos[1]][0].v +
-			        f4_curr[2][pos[0]-shift[0]][pos[1]][0].v
+			        f4_curr(2, pos[0],          pos[1], 0).v +
+			        f4_curr(2, pos[0]-shift[0], pos[1], 0).v
 			    );
 
 			// z-polarization
-			f4_volt[2][pos[0]][pos[1]][0].v *=
+			f4_volt(2, pos[0], pos[1], 0).v *=
 			    Op->f4_vv_Compressed[2][index].v;
-			f4_volt[2][pos[0]][pos[1]][0].v +=
+			f4_volt(2, pos[0], pos[1], 0).v +=
 			    Op->f4_vi_Compressed[2][index].v * (
-			        f4_curr[1][pos[0]         ][pos[1]         ][0].v -
-			        f4_curr[1][pos[0]-shift[0]][pos[1]         ][0].v -
-			        f4_curr[0][pos[0]         ][pos[1]         ][0].v +
-			        f4_curr[0][pos[0]         ][pos[1]-shift[1]][0].v
+			        f4_curr(1, pos[0],          pos[1],          0).v -
+			        f4_curr(1, pos[0]-shift[0], pos[1],          0).v -
+			        f4_curr(0, pos[0],          pos[1],          0).v +
+			        f4_curr(0, pos[0],          pos[1]-shift[1], 0).v
 			    );
 		}
 		++pos[0];
@@ -149,6 +152,9 @@ void Engine_SSE_Compressed::UpdateVoltages(unsigned int startX, unsigned int num
 
 void Engine_SSE_Compressed::UpdateCurrents(unsigned int startX, unsigned int numX)
 {
+	Flat_N_3DArray<f4vector> &f4_volt = *f4_volt_ptr;
+	Flat_N_3DArray<f4vector> &f4_curr = *f4_curr_ptr;
+
 	unsigned int pos[3];
 	f4vector temp;
 
@@ -162,36 +168,36 @@ void Engine_SSE_Compressed::UpdateCurrents(unsigned int startX, unsigned int num
 			{
 				index = Op->m_Op_index[pos[0]][pos[1]][pos[2]];
 				// x-pol
-				f4_curr[0][pos[0]][pos[1]][pos[2]].v *=
+				f4_curr(0, pos[0], pos[1], pos[2]).v *=
 				    Op->f4_ii_Compressed[0][index].v;
-				f4_curr[0][pos[0]][pos[1]][pos[2]].v +=
+				f4_curr(0, pos[0], pos[1], pos[2]).v +=
 				    Op->f4_iv_Compressed[0][index].v * (
-				        f4_volt[2][pos[0]][pos[1]  ][pos[2]  ].v -
-				        f4_volt[2][pos[0]][pos[1]+1][pos[2]  ].v -
-				        f4_volt[1][pos[0]][pos[1]  ][pos[2]  ].v +
-				        f4_volt[1][pos[0]][pos[1]  ][pos[2]+1].v
+				        f4_volt(2, pos[0], pos[1],   pos[2]  ).v -
+				        f4_volt(2, pos[0], pos[1]+1, pos[2]  ).v -
+				        f4_volt(1, pos[0], pos[1],   pos[2]  ).v +
+				        f4_volt(1, pos[0], pos[1],   pos[2]+1).v
 				    );
 
 				// y-pol
-				f4_curr[1][pos[0]][pos[1]][pos[2]].v *=
+				f4_curr(1, pos[0], pos[1], pos[2]).v *=
 				    Op->f4_ii_Compressed[1][index].v;
-				f4_curr[1][pos[0]][pos[1]][pos[2]].v +=
+				f4_curr(1, pos[0], pos[1], pos[2]).v +=
 				    Op->f4_iv_Compressed[1][index].v * (
-				        f4_volt[0][pos[0]  ][pos[1]][pos[2]  ].v -
-				        f4_volt[0][pos[0]  ][pos[1]][pos[2]+1].v -
-				        f4_volt[2][pos[0]  ][pos[1]][pos[2]  ].v +
-				        f4_volt[2][pos[0]+1][pos[1]][pos[2]  ].v
+				        f4_volt(0, pos[0],   pos[1], pos[2]  ).v -
+				        f4_volt(0, pos[0],   pos[1], pos[2]+1).v -
+				        f4_volt(2, pos[0],   pos[1], pos[2]  ).v +
+				        f4_volt(2, pos[0]+1, pos[1], pos[2]  ).v
 				    );
 
 				// z-pol
-				f4_curr[2][pos[0]][pos[1]][pos[2]].v *=
+				f4_curr(2, pos[0], pos[1], pos[2]).v *=
 				    Op->f4_ii_Compressed[2][index].v;
-				f4_curr[2][pos[0]][pos[1]][pos[2]].v +=
+				f4_curr(2, pos[0], pos[1], pos[2]).v +=
 				    Op->f4_iv_Compressed[2][index].v * (
-				        f4_volt[1][pos[0]  ][pos[1]  ][pos[2]].v -
-				        f4_volt[1][pos[0]+1][pos[1]  ][pos[2]].v -
-				        f4_volt[0][pos[0]  ][pos[1]  ][pos[2]].v +
-				        f4_volt[0][pos[0]  ][pos[1]+1][pos[2]].v
+				        f4_volt(1, pos[0],   pos[1],   pos[2]).v -
+				        f4_volt(1, pos[0]+1, pos[1],   pos[2]).v -
+				        f4_volt(0, pos[0],   pos[1],   pos[2]).v +
+				        f4_volt(0, pos[0],   pos[1]+1, pos[2]).v
 				    );
 			}
 
@@ -200,54 +206,54 @@ void Engine_SSE_Compressed::UpdateCurrents(unsigned int startX, unsigned int num
 			// x-pol
 #ifdef __SSE2__
 			temp.v = (__m128)_mm_srli_si128(
-			             (__m128i)f4_volt[1][pos[0]][pos[1]][0].v, 4
+			             (__m128i)f4_volt(1, pos[0], pos[1], 0).v, 4
 			         );
 #else
-			temp.f[0] = f4_volt[1][pos[0]][pos[1]][0].f[1];
-			temp.f[1] = f4_volt[1][pos[0]][pos[1]][0].f[2];
-			temp.f[2] = f4_volt[1][pos[0]][pos[1]][0].f[3];
+			temp.f[0] = f4_volt(1, pos[0], pos[1], 0).f[1];
+			temp.f[1] = f4_volt(1, pos[0], pos[1], 0).f[2];
+			temp.f[2] = f4_volt(1, pos[0], pos[1], 0).f[3];
 			temp.f[3] = 0;
 #endif
-			f4_curr[0][pos[0]][pos[1]][numVectors-1].v *=
+			f4_curr(0, pos[0], pos[1], numVectors-1).v *=
 			    Op->f4_ii_Compressed[0][index].v;
-			f4_curr[0][pos[0]][pos[1]][numVectors-1].v +=
+			f4_curr(0, pos[0], pos[1], numVectors-1).v +=
 			    Op->f4_iv_Compressed[0][index].v * (
-			        f4_volt[2][pos[0]][pos[1]  ][numVectors-1].v -
-			        f4_volt[2][pos[0]][pos[1]+1][numVectors-1].v -
-			        f4_volt[1][pos[0]][pos[1]  ][numVectors-1].v +
+			        f4_volt(2, pos[0], pos[1],   numVectors-1).v -
+			        f4_volt(2, pos[0], pos[1]+1, numVectors-1).v -
+			        f4_volt(1, pos[0], pos[1],   numVectors-1).v +
 			        temp.v
 			    );
 
 			// y-pol
 #ifdef __SSE2__
 			temp.v = (__m128)_mm_srli_si128(
-			             (__m128i)f4_volt[0][pos[0]][pos[1]][0].v, 4
+			             (__m128i)f4_volt(0, pos[0], pos[1], 0).v, 4
 			         );
 #else
-			temp.f[0] = f4_volt[0][pos[0]][pos[1]][0].f[1];
-			temp.f[1] = f4_volt[0][pos[0]][pos[1]][0].f[2];
-			temp.f[2] = f4_volt[0][pos[0]][pos[1]][0].f[3];
+			temp.f[0] = f4_volt(0, pos[0], pos[1], 0).f[1];
+			temp.f[1] = f4_volt(0, pos[0], pos[1], 0).f[2];
+			temp.f[2] = f4_volt(0, pos[0], pos[1], 0).f[3];
 			temp.f[3] = 0;
 #endif
-			f4_curr[1][pos[0]][pos[1]][numVectors-1].v *=
+			f4_curr(1, pos[0], pos[1], numVectors-1).v *=
 			    Op->f4_ii_Compressed[1][index].v;
-			f4_curr[1][pos[0]][pos[1]][numVectors-1].v +=
+			f4_curr(1, pos[0], pos[1], numVectors-1).v +=
 			    Op->f4_iv_Compressed[1][index].v * (
-			        f4_volt[0][pos[0]  ][pos[1]][numVectors-1].v -
+			        f4_volt(0, pos[0],   pos[1], numVectors-1).v -
 			        temp.v -
-			        f4_volt[2][pos[0]  ][pos[1]][numVectors-1].v +
-			        f4_volt[2][pos[0]+1][pos[1]][numVectors-1].v
+			        f4_volt(2, pos[0],   pos[1], numVectors-1).v +
+			        f4_volt(2, pos[0]+1, pos[1], numVectors-1).v
 			    );
 
 			// z-pol
-			f4_curr[2][pos[0]][pos[1]][numVectors-1].v *=
+			f4_curr(2, pos[0], pos[1], numVectors-1).v *=
 			    Op->f4_ii_Compressed[2][index].v;
-			f4_curr[2][pos[0]][pos[1]][numVectors-1].v +=
+			f4_curr(2, pos[0], pos[1], numVectors-1).v +=
 			    Op->f4_iv_Compressed[2][index].v * (
-			        f4_volt[1][pos[0]  ][pos[1]  ][numVectors-1].v -
-			        f4_volt[1][pos[0]+1][pos[1]  ][numVectors-1].v -
-			        f4_volt[0][pos[0]  ][pos[1]  ][numVectors-1].v +
-			        f4_volt[0][pos[0]  ][pos[1]+1][numVectors-1].v
+			        f4_volt(1, pos[0],   pos[1],   numVectors-1).v -
+			        f4_volt(1, pos[0]+1, pos[1],   numVectors-1).v -
+			        f4_volt(0, pos[0],   pos[1],   numVectors-1).v +
+			        f4_volt(0, pos[0],   pos[1]+1, numVectors-1).v
 			    );
 		}
 		++pos[0];

--- a/FDTD/engine_sse_compressed.cpp
+++ b/FDTD/engine_sse_compressed.cpp
@@ -55,47 +55,93 @@ void Engine_SSE_Compressed::UpdateVoltages(unsigned int startX, unsigned int num
 			{
 				index = Op->m_Op_index[pos[0]][pos[1]][pos[2]];
 				// x-polarization
-				f4_volt[0][pos[0]][pos[1]][pos[2]].v *= Op->f4_vv_Compressed[0][index].v;
-				f4_volt[0][pos[0]][pos[1]][pos[2]].v += Op->f4_vi_Compressed[0][index].v * ( f4_curr[2][pos[0]][pos[1]][pos[2]].v - f4_curr[2][pos[0]][pos[1]-shift[1]][pos[2]].v - f4_curr[1][pos[0]][pos[1]][pos[2]].v + f4_curr[1][pos[0]][pos[1]][pos[2]-1].v );
+				f4_volt[0][pos[0]][pos[1]][pos[2]].v *=
+				    Op->f4_vv_Compressed[0][index].v;
+				f4_volt[0][pos[0]][pos[1]][pos[2]].v +=
+				    Op->f4_vi_Compressed[0][index].v * (
+				        f4_curr[2][pos[0]][pos[1]         ][pos[2]  ].v -
+				        f4_curr[2][pos[0]][pos[1]-shift[1]][pos[2]  ].v -
+				        f4_curr[1][pos[0]][pos[1]         ][pos[2]  ].v +
+				        f4_curr[1][pos[0]][pos[1]         ][pos[2]-1].v
+				    );
 
 				// y-polarization
-				f4_volt[1][pos[0]][pos[1]][pos[2]].v *= Op->f4_vv_Compressed[1][index].v;
-				f4_volt[1][pos[0]][pos[1]][pos[2]].v += Op->f4_vi_Compressed[1][index].v * ( f4_curr[0][pos[0]][pos[1]][pos[2]].v - f4_curr[0][pos[0]][pos[1]][pos[2]-1].v - f4_curr[2][pos[0]][pos[1]][pos[2]].v + f4_curr[2][pos[0]-shift[0]][pos[1]][pos[2]].v);
+				f4_volt[1][pos[0]][pos[1]][pos[2]].v *=
+				    Op->f4_vv_Compressed[1][index].v;
+				f4_volt[1][pos[0]][pos[1]][pos[2]].v +=
+				    Op->f4_vi_Compressed[1][index].v * (
+				        f4_curr[0][pos[0]         ][pos[1]][pos[2]  ].v -
+				        f4_curr[0][pos[0]         ][pos[1]][pos[2]-1].v -
+				        f4_curr[2][pos[0]         ][pos[1]][pos[2]  ].v +
+				        f4_curr[2][pos[0]-shift[0]][pos[1]][pos[2]  ].v
+				    );
 
 				// z-polarization
-				f4_volt[2][pos[0]][pos[1]][pos[2]].v *= Op->f4_vv_Compressed[2][index].v;
-				f4_volt[2][pos[0]][pos[1]][pos[2]].v += Op->f4_vi_Compressed[2][index].v * ( f4_curr[1][pos[0]][pos[1]][pos[2]].v - f4_curr[1][pos[0]-shift[0]][pos[1]][pos[2]].v - f4_curr[0][pos[0]][pos[1]][pos[2]].v + f4_curr[0][pos[0]][pos[1]-shift[1]][pos[2]].v);
+				f4_volt[2][pos[0]][pos[1]][pos[2]].v *=
+				    Op->f4_vv_Compressed[2][index].v;
+				f4_volt[2][pos[0]][pos[1]][pos[2]].v +=
+				    Op->f4_vi_Compressed[2][index].v * (
+				        f4_curr[1][pos[0]         ][pos[1]]         [pos[2]].v -
+				        f4_curr[1][pos[0]-shift[0]][pos[1]]         [pos[2]].v -
+				        f4_curr[0][pos[0]         ][pos[1]]         [pos[2]].v +
+				        f4_curr[0][pos[0]         ][pos[1]-shift[1]][pos[2]].v
+				    );
 			}
 
 			// for pos[2] = 0
 			// x-polarization
 			index = Op->m_Op_index[pos[0]][pos[1]][0];
 #ifdef __SSE2__
-			temp.v = (__m128)_mm_slli_si128( (__m128i)f4_curr[1][pos[0]][pos[1]][numVectors-1].v, 4 );
+			temp.v = (__m128)_mm_slli_si128(
+			             (__m128i)f4_curr[1][pos[0]][pos[1]][numVectors-1].v, 4
+			         );
 #else
 			temp.f[0] = 0;
 			temp.f[1] = f4_curr[1][pos[0]][pos[1]][numVectors-1].f[0];
 			temp.f[2] = f4_curr[1][pos[0]][pos[1]][numVectors-1].f[1];
 			temp.f[3] = f4_curr[1][pos[0]][pos[1]][numVectors-1].f[2];
 #endif
-			f4_volt[0][pos[0]][pos[1]][0].v *= Op->f4_vv_Compressed[0][index].v;
-			f4_volt[0][pos[0]][pos[1]][0].v += Op->f4_vi_Compressed[0][index].v * ( f4_curr[2][pos[0]][pos[1]][0].v - f4_curr[2][pos[0]][pos[1]-shift[1]][0].v - f4_curr[1][pos[0]][pos[1]][0].v + temp.v );
+			f4_volt[0][pos[0]][pos[1]][0].v *=
+			    Op->f4_vv_Compressed[0][index].v;
+			f4_volt[0][pos[0]][pos[1]][0].v +=
+			    Op->f4_vi_Compressed[0][index].v * (
+			        f4_curr[2][pos[0]][pos[1]         ][0].v -
+			        f4_curr[2][pos[0]][pos[1]-shift[1]][0].v -
+			        f4_curr[1][pos[0]][pos[1]         ][0].v +
+			        temp.v
+			    );
 
 			// y-polarization
 #ifdef __SSE2__
-			temp.v = (__m128)_mm_slli_si128( (__m128i)f4_curr[0][pos[0]][pos[1]][numVectors-1].v, 4 );
+			temp.v = (__m128)_mm_slli_si128(
+			             (__m128i)f4_curr[0][pos[0]][pos[1]][numVectors-1].v, 4
+			         );
 #else
 			temp.f[0] = 0;
 			temp.f[1] = f4_curr[0][pos[0]][pos[1]][numVectors-1].f[0];
 			temp.f[2] = f4_curr[0][pos[0]][pos[1]][numVectors-1].f[1];
 			temp.f[3] = f4_curr[0][pos[0]][pos[1]][numVectors-1].f[2];
 #endif
-			f4_volt[1][pos[0]][pos[1]][0].v *= Op->f4_vv_Compressed[1][index].v;
-			f4_volt[1][pos[0]][pos[1]][0].v += Op->f4_vi_Compressed[1][index].v * ( f4_curr[0][pos[0]][pos[1]][0].v - temp.v - f4_curr[2][pos[0]][pos[1]][0].v + f4_curr[2][pos[0]-shift[0]][pos[1]][0].v);
+			f4_volt[1][pos[0]][pos[1]][0].v *=
+			    Op->f4_vv_Compressed[1][index].v;
+			f4_volt[1][pos[0]][pos[1]][0].v +=
+			    Op->f4_vi_Compressed[1][index].v * (
+			        f4_curr[0][pos[0]         ][pos[1]][0].v -
+			        temp.v -
+			        f4_curr[2][pos[0]         ][pos[1]][0].v +
+			        f4_curr[2][pos[0]-shift[0]][pos[1]][0].v
+			    );
 
 			// z-polarization
-			f4_volt[2][pos[0]][pos[1]][0].v *= Op->f4_vv_Compressed[2][index].v;
-			f4_volt[2][pos[0]][pos[1]][0].v += Op->f4_vi_Compressed[2][index].v * ( f4_curr[1][pos[0]][pos[1]][0].v - f4_curr[1][pos[0]-shift[0]][pos[1]][0].v - f4_curr[0][pos[0]][pos[1]][0].v + f4_curr[0][pos[0]][pos[1]-shift[1]][0].v);
+			f4_volt[2][pos[0]][pos[1]][0].v *=
+			    Op->f4_vv_Compressed[2][index].v;
+			f4_volt[2][pos[0]][pos[1]][0].v +=
+			    Op->f4_vi_Compressed[2][index].v * (
+			        f4_curr[1][pos[0]         ][pos[1]         ][0].v -
+			        f4_curr[1][pos[0]-shift[0]][pos[1]         ][0].v -
+			        f4_curr[0][pos[0]         ][pos[1]         ][0].v +
+			        f4_curr[0][pos[0]         ][pos[1]-shift[1]][0].v
+			    );
 		}
 		++pos[0];
 	}
@@ -116,47 +162,93 @@ void Engine_SSE_Compressed::UpdateCurrents(unsigned int startX, unsigned int num
 			{
 				index = Op->m_Op_index[pos[0]][pos[1]][pos[2]];
 				// x-pol
-				f4_curr[0][pos[0]][pos[1]][pos[2]].v *= Op->f4_ii_Compressed[0][index].v;
-				f4_curr[0][pos[0]][pos[1]][pos[2]].v += Op->f4_iv_Compressed[0][index].v * ( f4_volt[2][pos[0]][pos[1]][pos[2]].v - f4_volt[2][pos[0]][pos[1]+1][pos[2]].v - f4_volt[1][pos[0]][pos[1]][pos[2]].v + f4_volt[1][pos[0]][pos[1]][pos[2]+1].v);
+				f4_curr[0][pos[0]][pos[1]][pos[2]].v *=
+				    Op->f4_ii_Compressed[0][index].v;
+				f4_curr[0][pos[0]][pos[1]][pos[2]].v +=
+				    Op->f4_iv_Compressed[0][index].v * (
+				        f4_volt[2][pos[0]][pos[1]  ][pos[2]  ].v -
+				        f4_volt[2][pos[0]][pos[1]+1][pos[2]  ].v -
+				        f4_volt[1][pos[0]][pos[1]  ][pos[2]  ].v +
+				        f4_volt[1][pos[0]][pos[1]  ][pos[2]+1].v
+				    );
 
 				// y-pol
-				f4_curr[1][pos[0]][pos[1]][pos[2]].v *= Op->f4_ii_Compressed[1][index].v;
-				f4_curr[1][pos[0]][pos[1]][pos[2]].v += Op->f4_iv_Compressed[1][index].v * ( f4_volt[0][pos[0]][pos[1]][pos[2]].v - f4_volt[0][pos[0]][pos[1]][pos[2]+1].v - f4_volt[2][pos[0]][pos[1]][pos[2]].v + f4_volt[2][pos[0]+1][pos[1]][pos[2]].v);
+				f4_curr[1][pos[0]][pos[1]][pos[2]].v *=
+				    Op->f4_ii_Compressed[1][index].v;
+				f4_curr[1][pos[0]][pos[1]][pos[2]].v +=
+				    Op->f4_iv_Compressed[1][index].v * (
+				        f4_volt[0][pos[0]  ][pos[1]][pos[2]  ].v -
+				        f4_volt[0][pos[0]  ][pos[1]][pos[2]+1].v -
+				        f4_volt[2][pos[0]  ][pos[1]][pos[2]  ].v +
+				        f4_volt[2][pos[0]+1][pos[1]][pos[2]  ].v
+				    );
 
 				// z-pol
-				f4_curr[2][pos[0]][pos[1]][pos[2]].v *= Op->f4_ii_Compressed[2][index].v;
-				f4_curr[2][pos[0]][pos[1]][pos[2]].v += Op->f4_iv_Compressed[2][index].v * ( f4_volt[1][pos[0]][pos[1]][pos[2]].v - f4_volt[1][pos[0]+1][pos[1]][pos[2]].v - f4_volt[0][pos[0]][pos[1]][pos[2]].v + f4_volt[0][pos[0]][pos[1]+1][pos[2]].v);
+				f4_curr[2][pos[0]][pos[1]][pos[2]].v *=
+				    Op->f4_ii_Compressed[2][index].v;
+				f4_curr[2][pos[0]][pos[1]][pos[2]].v +=
+				    Op->f4_iv_Compressed[2][index].v * (
+				        f4_volt[1][pos[0]  ][pos[1]  ][pos[2]].v -
+				        f4_volt[1][pos[0]+1][pos[1]  ][pos[2]].v -
+				        f4_volt[0][pos[0]  ][pos[1]  ][pos[2]].v +
+				        f4_volt[0][pos[0]  ][pos[1]+1][pos[2]].v
+				    );
 			}
 
 			index = Op->m_Op_index[pos[0]][pos[1]][numVectors-1];
 			// for pos[2] = numVectors-1
 			// x-pol
 #ifdef __SSE2__
-			temp.v = (__m128)_mm_srli_si128( (__m128i)f4_volt[1][pos[0]][pos[1]][0].v, 4 );
+			temp.v = (__m128)_mm_srli_si128(
+			             (__m128i)f4_volt[1][pos[0]][pos[1]][0].v, 4
+			         );
 #else
 			temp.f[0] = f4_volt[1][pos[0]][pos[1]][0].f[1];
 			temp.f[1] = f4_volt[1][pos[0]][pos[1]][0].f[2];
 			temp.f[2] = f4_volt[1][pos[0]][pos[1]][0].f[3];
 			temp.f[3] = 0;
 #endif
-			f4_curr[0][pos[0]][pos[1]][numVectors-1].v *= Op->f4_ii_Compressed[0][index].v;
-			f4_curr[0][pos[0]][pos[1]][numVectors-1].v += Op->f4_iv_Compressed[0][index].v * ( f4_volt[2][pos[0]][pos[1]][numVectors-1].v - f4_volt[2][pos[0]][pos[1]+1][numVectors-1].v - f4_volt[1][pos[0]][pos[1]][numVectors-1].v + temp.v);
+			f4_curr[0][pos[0]][pos[1]][numVectors-1].v *=
+			    Op->f4_ii_Compressed[0][index].v;
+			f4_curr[0][pos[0]][pos[1]][numVectors-1].v +=
+			    Op->f4_iv_Compressed[0][index].v * (
+			        f4_volt[2][pos[0]][pos[1]  ][numVectors-1].v -
+			        f4_volt[2][pos[0]][pos[1]+1][numVectors-1].v -
+			        f4_volt[1][pos[0]][pos[1]  ][numVectors-1].v +
+			        temp.v
+			    );
 
 			// y-pol
 #ifdef __SSE2__
-			temp.v = (__m128)_mm_srli_si128( (__m128i)f4_volt[0][pos[0]][pos[1]][0].v, 4 );
+			temp.v = (__m128)_mm_srli_si128(
+			             (__m128i)f4_volt[0][pos[0]][pos[1]][0].v, 4
+			         );
 #else
 			temp.f[0] = f4_volt[0][pos[0]][pos[1]][0].f[1];
 			temp.f[1] = f4_volt[0][pos[0]][pos[1]][0].f[2];
 			temp.f[2] = f4_volt[0][pos[0]][pos[1]][0].f[3];
 			temp.f[3] = 0;
 #endif
-			f4_curr[1][pos[0]][pos[1]][numVectors-1].v *= Op->f4_ii_Compressed[1][index].v;
-			f4_curr[1][pos[0]][pos[1]][numVectors-1].v += Op->f4_iv_Compressed[1][index].v * ( f4_volt[0][pos[0]][pos[1]][numVectors-1].v - temp.v - f4_volt[2][pos[0]][pos[1]][numVectors-1].v + f4_volt[2][pos[0]+1][pos[1]][numVectors-1].v);
+			f4_curr[1][pos[0]][pos[1]][numVectors-1].v *=
+			    Op->f4_ii_Compressed[1][index].v;
+			f4_curr[1][pos[0]][pos[1]][numVectors-1].v +=
+			    Op->f4_iv_Compressed[1][index].v * (
+			        f4_volt[0][pos[0]  ][pos[1]][numVectors-1].v -
+			        temp.v -
+			        f4_volt[2][pos[0]  ][pos[1]][numVectors-1].v +
+			        f4_volt[2][pos[0]+1][pos[1]][numVectors-1].v
+			    );
 
 			// z-pol
-			f4_curr[2][pos[0]][pos[1]][numVectors-1].v *= Op->f4_ii_Compressed[2][index].v;
-			f4_curr[2][pos[0]][pos[1]][numVectors-1].v += Op->f4_iv_Compressed[2][index].v * ( f4_volt[1][pos[0]][pos[1]][numVectors-1].v - f4_volt[1][pos[0]+1][pos[1]][numVectors-1].v - f4_volt[0][pos[0]][pos[1]][numVectors-1].v + f4_volt[0][pos[0]][pos[1]+1][numVectors-1].v);
+			f4_curr[2][pos[0]][pos[1]][numVectors-1].v *=
+			    Op->f4_ii_Compressed[2][index].v;
+			f4_curr[2][pos[0]][pos[1]][numVectors-1].v +=
+			    Op->f4_iv_Compressed[2][index].v * (
+			        f4_volt[1][pos[0]  ][pos[1]  ][numVectors-1].v -
+			        f4_volt[1][pos[0]+1][pos[1]  ][numVectors-1].v -
+			        f4_volt[0][pos[0]  ][pos[1]  ][numVectors-1].v +
+			        f4_volt[0][pos[0]  ][pos[1]+1][numVectors-1].v
+			    );
 		}
 		++pos[0];
 	}

--- a/FDTD/extensions/engine_ext_cylindermultigrid.cpp
+++ b/FDTD/extensions/engine_ext_cylindermultigrid.cpp
@@ -93,6 +93,9 @@ void Engine_Ext_CylinderMultiGrid::SyncVoltages()
 	Engine_Multithread* m_InnerEng = m_Eng_MG->m_InnerEngine;
 
 	//interpolate voltages from base engine to child engine...
+	Flat_N_3DArray<f4vector> eng_inner_f4_volt = *m_InnerEng->f4_volt_ptr;
+	Flat_N_3DArray<f4vector> eng_mg_f4_volt = *m_Eng_MG->f4_volt_ptr;
+
 	unsigned int pos[3];
 	pos[0] = m_Eng_MG->Op_CMG->GetSplitPos()-1;
 	unsigned int pos1_half = 0;
@@ -107,14 +110,14 @@ void Engine_Ext_CylinderMultiGrid::SyncVoltages()
 		for (pos[2]=0; pos[2]<m_Eng_MG->numVectors; ++pos[2])
 		{
 			//r - direczion
-			m_InnerEng->f4_volt[0][pos[0]][pos1_half][pos[2]].v = v_null.v;
+			eng_inner_f4_volt(0, pos[0], pos1_half, pos[2]).v = v_null.v;
 
 			//z - direction
-			m_InnerEng->f4_volt[2][pos[0]][pos1_half][pos[2]].v = m_Eng_MG->f4_volt[2][pos[0]][pos[1]][pos[2]].v;
+			eng_inner_f4_volt(2, pos[0], pos1_half, pos[2]).v = eng_mg_f4_volt(2, pos[0], pos[1], pos[2]).v;
 
 			//alpha - direction
-			m_InnerEng->f4_volt[1][pos[0]][pos1_half][pos[2]].v  = m_Eng_MG->f4_volt[1][pos[0]][pos[1]][pos[2]].v;
-			m_InnerEng->f4_volt[1][pos[0]][pos1_half][pos[2]].v += m_Eng_MG->f4_volt[1][pos[0]][pos[1]+1][pos[2]].v;
+			eng_inner_f4_volt(1, pos[0], pos1_half, pos[2]).v  = eng_mg_f4_volt(1, pos[0], pos[1], pos[2]).v;
+			eng_inner_f4_volt(1, pos[0], pos1_half, pos[2]).v += eng_mg_f4_volt(1, pos[0], pos[1]+1, pos[2]).v;
 		}
 	}
 }

--- a/FDTD/extensions/engine_ext_upml.h
+++ b/FDTD/extensions/engine_ext_upml.h
@@ -21,6 +21,8 @@
 #include "engine_extension.h"
 #include "FDTD/engine.h"
 #include "FDTD/operator.h"
+#include "tools/array_ops.h"
+#include "tools/flat_array_ops.h"
 
 class Operator_Ext_UPML;
 
@@ -48,8 +50,8 @@ protected:
 	vector<unsigned int> m_start;
 	vector<unsigned int> m_numX;
 
-	FDTD_FLOAT**** volt_flux;
-	FDTD_FLOAT**** curr_flux;
+	Flat_N_3DArray<FDTD_FLOAT>* volt_flux_ptr;
+	Flat_N_3DArray<FDTD_FLOAT>* curr_flux_ptr;
 };
 
 #endif // ENGINE_EXT_UPML_H

--- a/FDTD/extensions/operator_ext_upml.cpp
+++ b/FDTD/extensions/operator_ext_upml.cpp
@@ -18,7 +18,6 @@
 #include "operator_ext_upml.h"
 #include "FDTD/operator_cylindermultigrid.h"
 #include "engine_ext_upml.h"
-#include "tools/array_ops.h"
 #include "fparser.hh"
 
 using namespace std;
@@ -41,12 +40,12 @@ Operator_Ext_UPML::Operator_Ext_UPML(Operator* op) : Operator_Extension(op)
 		m_numLines[n]=0;
 	}
 
-	vv = NULL;
-	vvfo = NULL;
-	vvfn = NULL;
-	ii = NULL;
-	iifo = NULL;
-	iifn = NULL;
+	vv_ptr = NULL;
+	vvfo_ptr = NULL;
+	vvfn_ptr = NULL;
+	ii_ptr = NULL;
+	iifo_ptr = NULL;
+	iifn_ptr = NULL;
 }
 
 Operator_Ext_UPML::~Operator_Ext_UPML()
@@ -257,18 +256,18 @@ bool Operator_Ext_UPML::Create_UPML(Operator* op, const int ui_BC[6], const unsi
 
 void Operator_Ext_UPML::DeleteOp()
 {
-	Delete_N_3DArray<FDTD_FLOAT>(vv,m_numLines);
-	vv = NULL;
-	Delete_N_3DArray<FDTD_FLOAT>(vvfo,m_numLines);
-	vvfo = NULL;
-	Delete_N_3DArray<FDTD_FLOAT>(vvfn,m_numLines);
-	vvfn = NULL;
-	Delete_N_3DArray<FDTD_FLOAT>(ii,m_numLines);
-	ii = NULL;
-	Delete_N_3DArray<FDTD_FLOAT>(iifo,m_numLines);
-	iifo = NULL;
-	Delete_N_3DArray<FDTD_FLOAT>(iifn,m_numLines);
-	iifn = NULL;
+	Delete_Flat_N_3DArray(vv_ptr,m_numLines);
+	vv_ptr = NULL;
+	Delete_Flat_N_3DArray(vvfo_ptr,m_numLines);
+	vvfo_ptr = NULL;
+	Delete_Flat_N_3DArray(vvfn_ptr,m_numLines);
+	vvfn_ptr = NULL;
+	Delete_Flat_N_3DArray(ii_ptr,m_numLines);
+	ii_ptr = NULL;
+	Delete_Flat_N_3DArray(iifo_ptr,m_numLines);
+	iifo_ptr = NULL;
+	Delete_Flat_N_3DArray(iifn_ptr,m_numLines);
+	iifn_ptr = NULL;
 }
 
 
@@ -373,12 +372,12 @@ bool Operator_Ext_UPML::BuildExtension()
 		return false;
 
 	DeleteOp();
-	vv = Create_N_3DArray<FDTD_FLOAT>(m_numLines);
-	vvfo = Create_N_3DArray<FDTD_FLOAT>(m_numLines);
-	vvfn = Create_N_3DArray<FDTD_FLOAT>(m_numLines);
-	ii = Create_N_3DArray<FDTD_FLOAT>(m_numLines);
-	iifo = Create_N_3DArray<FDTD_FLOAT>(m_numLines);
-	iifn = Create_N_3DArray<FDTD_FLOAT>(m_numLines);
+	vv_ptr = Create_Flat_N_3DArray<FDTD_FLOAT>(m_numLines);
+	vvfo_ptr = Create_Flat_N_3DArray<FDTD_FLOAT>(m_numLines);
+	vvfn_ptr = Create_Flat_N_3DArray<FDTD_FLOAT>(m_numLines);
+	ii_ptr = Create_Flat_N_3DArray<FDTD_FLOAT>(m_numLines);
+	iifo_ptr = Create_Flat_N_3DArray<FDTD_FLOAT>(m_numLines);
+	iifn_ptr = Create_Flat_N_3DArray<FDTD_FLOAT>(m_numLines);
 
 	unsigned int pos[3];
 	unsigned int loc_pos[3];

--- a/FDTD/extensions/operator_ext_upml.h
+++ b/FDTD/extensions/operator_ext_upml.h
@@ -20,6 +20,8 @@
 
 #include "FDTD/operator.h"
 #include "operator_extension.h"
+#include "tools/array_ops.h"
+#include "tools/flat_array_ops.h"
 
 class FunctionParser;
 
@@ -88,19 +90,43 @@ protected:
 
 	void DeleteOp();
 
-	virtual FDTD_FLOAT& GetVV(int ny, unsigned int pos[3]) {return vv[ny][pos[0]][pos[1]][pos[2]];}
-	virtual FDTD_FLOAT& GetVVFO(int ny, unsigned int pos[3]) {return vvfo[ny][pos[0]][pos[1]][pos[2]];}
-	virtual FDTD_FLOAT& GetVVFN(int ny, unsigned int pos[3]) {return vvfn[ny][pos[0]][pos[1]][pos[2]];}
-	virtual FDTD_FLOAT& GetII(int ny, unsigned int pos[3]) {return ii[ny][pos[0]][pos[1]][pos[2]];}
-	virtual FDTD_FLOAT& GetIIFO(int ny, unsigned int pos[3]) {return iifo[ny][pos[0]][pos[1]][pos[2]];}
-	virtual FDTD_FLOAT& GetIIFN(int ny, unsigned int pos[3]) {return iifn[ny][pos[0]][pos[1]][pos[2]];}
+	virtual FDTD_FLOAT& GetVV(int ny, unsigned int pos[3])
+	{
+		Flat_N_3DArray<FDTD_FLOAT>& vv = *vv_ptr;
+		return vv(ny, pos[0], pos[1], pos[2]);
+	}
+	virtual FDTD_FLOAT& GetVVFO(int ny, unsigned int pos[3])
+	{
+		Flat_N_3DArray<FDTD_FLOAT>& vvfo = *vvfo_ptr;
+		return vvfo(ny, pos[0], pos[1], pos[2]);
+	}
+	virtual FDTD_FLOAT& GetVVFN(int ny, unsigned int pos[3])
+	{
+		Flat_N_3DArray<FDTD_FLOAT>& vvfn = *vvfn_ptr;
+		return vvfn(ny, pos[0], pos[1], pos[2]);
+	}
+	virtual FDTD_FLOAT& GetII(int ny, unsigned int pos[3])
+	{
+		Flat_N_3DArray<FDTD_FLOAT>& ii = *ii_ptr;
+		return ii(ny, pos[0], pos[1], pos[2]);
+	}
+	virtual FDTD_FLOAT& GetIIFO(int ny, unsigned int pos[3])
+	{
+		Flat_N_3DArray<FDTD_FLOAT>& iifo = *iifo_ptr;
+		return iifo(ny, pos[0], pos[1], pos[2]);
+	}
+	virtual FDTD_FLOAT& GetIIFN(int ny, unsigned int pos[3])
+	{
+		Flat_N_3DArray<FDTD_FLOAT>& iifn = *iifn_ptr;
+		return iifn(ny, pos[0], pos[1], pos[2]);
+	}
 
-	FDTD_FLOAT**** vv;   //calc new voltage from old voltage
-	FDTD_FLOAT**** vvfo; //calc new voltage from old voltage flux
-	FDTD_FLOAT**** vvfn; //calc new voltage from new voltage flux
-	FDTD_FLOAT**** ii;   //calc new current from old current
-	FDTD_FLOAT**** iifo; //calc new current from old current flux
-	FDTD_FLOAT**** iifn; //calc new current from new current flux
+	Flat_N_3DArray<FDTD_FLOAT>* vv_ptr;   //calc new voltage from old voltage
+	Flat_N_3DArray<FDTD_FLOAT>* vvfo_ptr; //calc new voltage from old voltage flux
+	Flat_N_3DArray<FDTD_FLOAT>* vvfn_ptr; //calc new voltage from new voltage flux
+	Flat_N_3DArray<FDTD_FLOAT>* ii_ptr;   //calc new current from old current
+	Flat_N_3DArray<FDTD_FLOAT>* iifo_ptr; //calc new current from old current flux
+	Flat_N_3DArray<FDTD_FLOAT>* iifn_ptr; //calc new current from new current flux
 };
 
 #endif // OPERATOR_EXT_UPML_H

--- a/FDTD/operator_sse.cpp
+++ b/FDTD/operator_sse.cpp
@@ -30,10 +30,10 @@ Operator_sse* Operator_sse::New()
 
 Operator_sse::Operator_sse() : Operator()
 {
-	f4_vv = 0;
-	f4_vi = 0;
-	f4_iv = 0;
-	f4_ii = 0;
+	f4_vv_ptr = 0;
+	f4_vi_ptr = 0;
+	f4_iv_ptr = 0;
+	f4_ii_ptr = 0;
 }
 
 Operator_sse::~Operator_sse()
@@ -51,22 +51,22 @@ Engine* Operator_sse::CreateEngine()
 void Operator_sse::Init()
 {
 	Operator::Init();
-	f4_vv = 0;
-	f4_vi = 0;
-	f4_iv = 0;
-	f4_ii = 0;
+	f4_vv_ptr = 0;
+	f4_vi_ptr = 0;
+	f4_iv_ptr = 0;
+	f4_ii_ptr = 0;
 }
 
 void Operator_sse::Delete()
 {
-	Delete_N_3DArray_v4sf(f4_vv,numLines);
-	Delete_N_3DArray_v4sf(f4_vi,numLines);
-	Delete_N_3DArray_v4sf(f4_iv,numLines);
-	Delete_N_3DArray_v4sf(f4_ii,numLines);
-	f4_vv = 0;
-	f4_vi = 0;
-	f4_iv = 0;
-	f4_ii = 0;
+	Delete_Flat_N_3DArray(f4_vv_ptr,numLines);
+	Delete_Flat_N_3DArray(f4_vi_ptr,numLines);
+	Delete_Flat_N_3DArray(f4_iv_ptr,numLines);
+	Delete_Flat_N_3DArray(f4_ii_ptr,numLines);
+	f4_vv_ptr = 0;
+	f4_vi_ptr = 0;
+	f4_iv_ptr = 0;
+	f4_ii_ptr = 0;
 }
 
 void Operator_sse::Reset()
@@ -78,14 +78,14 @@ void Operator_sse::Reset()
 
 void Operator_sse::InitOperator()
 {
-	Delete_N_3DArray_v4sf(f4_vv,numLines);
-	Delete_N_3DArray_v4sf(f4_vi,numLines);
-	Delete_N_3DArray_v4sf(f4_iv,numLines);
-	Delete_N_3DArray_v4sf(f4_ii,numLines);
-	f4_vv = Create_N_3DArray_v4sf(numLines);
-	f4_vi = Create_N_3DArray_v4sf(numLines);
-	f4_iv = Create_N_3DArray_v4sf(numLines);
-	f4_ii = Create_N_3DArray_v4sf(numLines);
+	Delete_Flat_N_3DArray(f4_vv_ptr,numLines);
+	Delete_Flat_N_3DArray(f4_vi_ptr,numLines);
+	Delete_Flat_N_3DArray(f4_iv_ptr,numLines);
+	Delete_Flat_N_3DArray(f4_ii_ptr,numLines);
+	f4_vv_ptr = Create_Flat_N_3DArray<f4vector>(numLines);
+	f4_vi_ptr = Create_Flat_N_3DArray<f4vector>(numLines);
+	f4_iv_ptr = Create_Flat_N_3DArray<f4vector>(numLines);
+	f4_ii_ptr = Create_Flat_N_3DArray<f4vector>(numLines);
 
 	numVectors =  ceil((double)numLines[2]/4.0);
 }

--- a/FDTD/operator_sse.h
+++ b/FDTD/operator_sse.h
@@ -19,7 +19,7 @@
 #define OPERATOR_SSE_H
 
 #include "operator.h"
-#include "tools/array_ops.h"
+#include "tools/flat_array_ops.h"
 
 class Operator_sse : public Operator
 {
@@ -31,15 +31,47 @@ public:
 
 	virtual Engine* CreateEngine();
 
-	inline virtual FDTD_FLOAT GetVV( unsigned int n, unsigned int x, unsigned int y, unsigned int z ) const { return f4_vv[n][x][y][z%numVectors].f[z/numVectors]; }
-	inline virtual FDTD_FLOAT GetVI( unsigned int n, unsigned int x, unsigned int y, unsigned int z ) const { return f4_vi[n][x][y][z%numVectors].f[z/numVectors]; }
-	inline virtual FDTD_FLOAT GetII( unsigned int n, unsigned int x, unsigned int y, unsigned int z ) const { return f4_ii[n][x][y][z%numVectors].f[z/numVectors]; }
-	inline virtual FDTD_FLOAT GetIV( unsigned int n, unsigned int x, unsigned int y, unsigned int z ) const { return f4_iv[n][x][y][z%numVectors].f[z/numVectors]; }
+	inline virtual FDTD_FLOAT GetVV( unsigned int n, unsigned int x, unsigned int y, unsigned int z ) const
+	{
+		Flat_N_3DArray<f4vector> &f4_vv = *f4_vv_ptr;
+		return f4_vv(n, x, y, z%numVectors).f[z/numVectors];
+	}
+	inline virtual FDTD_FLOAT GetVI( unsigned int n, unsigned int x, unsigned int y, unsigned int z ) const
+	{
+		Flat_N_3DArray<f4vector> &f4_vi = *f4_vi_ptr;
+		return f4_vi(n, x, y, z%numVectors).f[z/numVectors];
+	}
+	inline virtual FDTD_FLOAT GetII( unsigned int n, unsigned int x, unsigned int y, unsigned int z ) const
+	{
+		Flat_N_3DArray<f4vector> &f4_ii = *f4_ii_ptr;
+		return f4_ii(n, x, y, z%numVectors).f[z/numVectors];
+	}
+	inline virtual FDTD_FLOAT GetIV( unsigned int n, unsigned int x, unsigned int y, unsigned int z ) const
+	{
+		Flat_N_3DArray<f4vector> &f4_iv = *f4_iv_ptr;
+		return f4_iv(n, x, y, z%numVectors).f[z/numVectors];
+	}
 
-	inline virtual void SetVV( unsigned int n, unsigned int x, unsigned int y, unsigned int z, FDTD_FLOAT value ) { f4_vv[n][x][y][z%numVectors].f[z/numVectors] = value; }
-	inline virtual void SetVI( unsigned int n, unsigned int x, unsigned int y, unsigned int z, FDTD_FLOAT value ) { f4_vi[n][x][y][z%numVectors].f[z/numVectors] = value; }
-	inline virtual void SetII( unsigned int n, unsigned int x, unsigned int y, unsigned int z, FDTD_FLOAT value ) { f4_ii[n][x][y][z%numVectors].f[z/numVectors] = value; }
-	inline virtual void SetIV( unsigned int n, unsigned int x, unsigned int y, unsigned int z, FDTD_FLOAT value ) { f4_iv[n][x][y][z%numVectors].f[z/numVectors] = value; }
+	inline virtual void SetVV( unsigned int n, unsigned int x, unsigned int y, unsigned int z, FDTD_FLOAT value )
+	{
+		Flat_N_3DArray<f4vector> &f4_vv = *f4_vv_ptr;
+		f4_vv(n, x, y, z%numVectors).f[z/numVectors] = value;
+	}
+	inline virtual void SetVI( unsigned int n, unsigned int x, unsigned int y, unsigned int z, FDTD_FLOAT value )
+	{
+		Flat_N_3DArray<f4vector> &f4_vi = *f4_vi_ptr;
+		f4_vi(n, x, y, z%numVectors).f[z/numVectors] = value;
+	}
+	inline virtual void SetII( unsigned int n, unsigned int x, unsigned int y, unsigned int z, FDTD_FLOAT value )
+	{
+		Flat_N_3DArray<f4vector> &f4_ii = *f4_ii_ptr;
+		f4_ii(n, x, y, z%numVectors).f[z/numVectors] = value;
+	}
+	inline virtual void SetIV( unsigned int n, unsigned int x, unsigned int y, unsigned int z, FDTD_FLOAT value )
+	{
+		Flat_N_3DArray<f4vector> &f4_iv = *f4_iv_ptr;
+		f4_iv(n, x, y, z%numVectors).f[z/numVectors] = value;
+	}
 
 protected:
 	//! use New() for creating a new Operator
@@ -54,10 +86,10 @@ protected:
 
 	// engine/post-proc needs access
 public:
-	f4vector**** f4_vv; //calc new voltage from old voltage
-	f4vector**** f4_vi; //calc new voltage from old current
-	f4vector**** f4_iv; //calc new current from old current
-	f4vector**** f4_ii; //calc new current from old voltage
+	Flat_N_3DArray<f4vector>* f4_vv_ptr; //calc new voltage from old voltage
+	Flat_N_3DArray<f4vector>* f4_vi_ptr; //calc new voltage from old current
+	Flat_N_3DArray<f4vector>* f4_iv_ptr; //calc new current from old current
+	Flat_N_3DArray<f4vector>* f4_ii_ptr; //calc new current from old voltage
 };
 
 #endif // OPERATOR_SSE_H

--- a/FDTD/operator_sse_compressed.cpp
+++ b/FDTD/operator_sse_compressed.cpp
@@ -124,6 +124,11 @@ bool Operator_SSE_Compressed::CompressOperator()
 
 	map<SSE_coeff,unsigned int> lookUpMap;
 
+	Flat_N_3DArray<f4vector> &f4_vv = *f4_vv_ptr;
+	Flat_N_3DArray<f4vector> &f4_vi = *f4_vi_ptr;
+	Flat_N_3DArray<f4vector> &f4_iv = *f4_iv_ptr;
+	Flat_N_3DArray<f4vector> &f4_ii = *f4_ii_ptr;
+
 	unsigned int pos[3];
 	for (pos[0]=0; pos[0]<numLines[0]; ++pos[0])
 	{
@@ -131,10 +136,10 @@ bool Operator_SSE_Compressed::CompressOperator()
 		{
 			for (pos[2]=0; pos[2]<numVectors; ++pos[2])
 			{
-				f4vector vv[3] = { f4_vv[0][pos[0]][pos[1]][pos[2]], f4_vv[1][pos[0]][pos[1]][pos[2]], f4_vv[2][pos[0]][pos[1]][pos[2]] };
-				f4vector vi[3] = { f4_vi[0][pos[0]][pos[1]][pos[2]], f4_vi[1][pos[0]][pos[1]][pos[2]], f4_vi[2][pos[0]][pos[1]][pos[2]] };
-				f4vector iv[3] = { f4_iv[0][pos[0]][pos[1]][pos[2]], f4_iv[1][pos[0]][pos[1]][pos[2]], f4_iv[2][pos[0]][pos[1]][pos[2]] };
-				f4vector ii[3] = { f4_ii[0][pos[0]][pos[1]][pos[2]], f4_ii[1][pos[0]][pos[1]][pos[2]], f4_ii[2][pos[0]][pos[1]][pos[2]] };
+				f4vector vv[3] = { f4_vv(0, pos[0], pos[1], pos[2]), f4_vv(1, pos[0], pos[1], pos[2]), f4_vv(2, pos[0], pos[1], pos[2]) };
+				f4vector vi[3] = { f4_vi(0, pos[0], pos[1], pos[2]), f4_vi(1, pos[0], pos[1], pos[2]), f4_vi(2, pos[0], pos[1], pos[2]) };
+				f4vector iv[3] = { f4_iv(0, pos[0], pos[1], pos[2]), f4_iv(1, pos[0], pos[1], pos[2]), f4_iv(2, pos[0], pos[1], pos[2]) };
+				f4vector ii[3] = { f4_ii(0, pos[0], pos[1], pos[2]), f4_ii(1, pos[0], pos[1], pos[2]), f4_ii(2, pos[0], pos[1], pos[2]) };
 				SSE_coeff c( vv, vi, iv, ii );
 
 				map<SSE_coeff,unsigned int>::iterator it;
@@ -163,14 +168,14 @@ bool Operator_SSE_Compressed::CompressOperator()
 		}
 	}
 
-	Delete_N_3DArray_v4sf(f4_vv,numLines);
-	Delete_N_3DArray_v4sf(f4_vi,numLines);
-	Delete_N_3DArray_v4sf(f4_iv,numLines);
-	Delete_N_3DArray_v4sf(f4_ii,numLines);
-	f4_vv = 0;
-	f4_vi = 0;
-	f4_iv = 0;
-	f4_ii = 0;
+	Delete_Flat_N_3DArray(f4_vv_ptr,numLines);
+	Delete_Flat_N_3DArray(f4_vi_ptr,numLines);
+	Delete_Flat_N_3DArray(f4_iv_ptr,numLines);
+	Delete_Flat_N_3DArray(f4_ii_ptr,numLines);
+	f4_vv_ptr = 0;
+	f4_vi_ptr = 0;
+	f4_iv_ptr = 0;
+	f4_ii_ptr = 0;
 
 	return true;
 }

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -16,6 +16,7 @@ set(SOURCES
 #set(HEADERS
 #  constants.h
 #  array_ops.h
+#  flat_array_ops.h
 #  global.h
 #  useful.h
 #  aligned_allocator.h

--- a/tools/array_ops.cpp
+++ b/tools/array_ops.cpp
@@ -20,15 +20,6 @@
 
 using namespace std;
 
-#ifdef WIN32
-#include <malloc.h>
-#define MEMALIGN( array, alignment, size ) !(*array = _mm_malloc( size, alignment ))
-#define FREE( array ) _mm_free( array )
-#else
-#define MEMALIGN( array, alignment, size ) posix_memalign( array, alignment, size )
-#define FREE( array ) free( array )
-#endif
-
 void Delete1DArray_v4sf(f4vector* array)
 {
 	if (array==NULL) return;

--- a/tools/array_ops.h
+++ b/tools/array_ops.h
@@ -33,6 +33,15 @@
 
 #define F4VECTOR_SIZE 16 // sizeof(typeid(f4vector))
 
+#ifdef WIN32
+#include <malloc.h>
+#define MEMALIGN( array, alignment, size ) !(*array = _mm_malloc( size, alignment ))
+#define FREE( array ) _mm_free( array )
+#else
+#define MEMALIGN( array, alignment, size ) posix_memalign( array, alignment, size )
+#define FREE( array ) free( array )
+#endif
+
 #ifdef __GNUC__ // GCC
 typedef float v4sf __attribute__ ((vector_size (F4VECTOR_SIZE))); // vector of four single floats
 union f4vector

--- a/tools/flat_array_ops.h
+++ b/tools/flat_array_ops.h
@@ -1,0 +1,149 @@
+/*
+*	Copyright (C) 2023 Yifeng Li <tomli@tomli.me>
+*
+*	This program is free software: you can redistribute it and/or modify
+*	it under the terms of the GNU General Public License as published by
+*	the Free Software Foundation, either version 3 of the License, or
+*	(at your option) any later version.
+*
+*	This program is distributed in the hope that it will be useful,
+*	but WITHOUT ANY WARRANTY; without even the implied warranty of
+*	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*	GNU General Public License for more details.
+*
+*	You should have received a copy of the GNU General Public License
+*	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef FLAT_ARRAY_OPS_H
+#define FLAT_ARRAY_OPS_H
+
+#include <cstring>
+#include "array_ops.h"
+#include <ostream>
+
+template <typename T>
+struct Flat_N_3DArray
+{
+	inline T& operator() (const unsigned int n, const unsigned int x, const unsigned int y, const unsigned int z)
+	{
+		return array[
+		           x * x_stride +
+		           y * y_stride +
+		           z * (3) +
+		           n
+		       ];
+	}
+
+	const inline T operator() (const unsigned int &n, const unsigned int &x, const unsigned int &y, const unsigned int &z) const
+	{
+		return array[
+		           x * x_stride +
+		           y * y_stride +
+		           z * (3) +
+		           n
+		       ];
+	}
+
+	unsigned long x_stride, y_stride;
+
+	// This is a flexible array member, the size of 1 is just a place-
+	// holder and its actual size is determined by how much memory is
+	// allocated beyond the end of the array at runtime via malloc()
+	// or posix_memalign().
+	//
+	// It's technically a standard-nonconforming undefined behavior,
+	// but is a well-known technique and it's important here to
+	// avoid the cost of extra dereferencing. GCC officially supports
+	// the "size 0" extension, so we use this well-defined option when
+	// it's available. C99 standardized "array[]" for the same purpose
+	// but it's never added to C++.
+	//
+	// Ensure array starts at an address divisible by 16 to satisfy
+	// SSE alignment requirement, adding new fields to the header
+	// may require manual padding.
+#ifdef __GNUC__
+	T array[0];
+#else
+	T array[1];
+#endif
+};
+
+template <typename T>
+Flat_N_3DArray<T>* Create_Flat_N_3DArray(const unsigned int* numLines)
+{
+	unsigned int n_max = 3;
+	unsigned int x_max = numLines[0];
+	unsigned int y_max = numLines[1];
+	unsigned int z_max = numLines[2];
+
+	// size of the Flat_N_3DArray class itself.
+	size_t size = sizeof(Flat_N_3DArray<T>);
+
+	// and the actual memory of the array[0] flexible array member
+	size += sizeof(T) * n_max * x_max * y_max * z_max;
+
+	void *buf;
+	if (MEMALIGN(&buf, 64, size))
+	{
+		std::cerr << "cannot allocate aligned memory" << std::endl;
+		exit(3);
+	}
+	memset(buf, 0, size);
+
+	// create Flat_N_3DArray inside manually allocated memory "buf".
+	Flat_N_3DArray<T>* array = new (buf) Flat_N_3DArray<T>;
+	array->x_stride = y_max * z_max * n_max;
+	array->y_stride = z_max * n_max;
+
+	return array;
+}
+
+template <>
+inline Flat_N_3DArray<f4vector>* Create_Flat_N_3DArray<f4vector>(const unsigned int* numLines)
+{
+	unsigned int n_max = 3;
+	unsigned int x_max = numLines[0];
+	unsigned int y_max = numLines[1];
+	unsigned int z_max = ceil((double) numLines[2] / 4.0);
+
+	// If the definition of Flat_N_3DArray<f4vector> has been changed,
+	// the underlying array must start at an address that is a multiple
+	// of 16 (F4VECTOR_SIZE) to satisfy SSE alignment requirement. Thus,
+	// adding new fields to the header may require manual padding.
+	static_assert(offsetof(Flat_N_3DArray<f4vector>, array) % F4VECTOR_SIZE == 0);
+
+	// Size of the header itself.
+	size_t size = sizeof(Flat_N_3DArray<f4vector>);
+
+	// and the actual memory of the array[0] flexible array member
+	size += F4VECTOR_SIZE * n_max * x_max * y_max * z_max;
+
+	void *buf;
+	if (MEMALIGN(&buf, 64, size))
+	{
+		std::cerr << "cannot allocate aligned memory" << std::endl;
+		exit(3);
+	}
+	memset(buf, 0, size);
+
+	// create Flat_N_3DArray inside manually allocated memory "buf".
+	Flat_N_3DArray<f4vector>* array = new (buf) Flat_N_3DArray<f4vector>;
+	array->x_stride = y_max * z_max * n_max;
+	array->y_stride = z_max * n_max;
+
+	return array;
+}
+
+template <typename T>
+void Delete_Flat_N_3DArray(Flat_N_3DArray<T>* array, const unsigned int* numLines)
+{
+	if (!array)
+	{
+		return;
+	}
+
+	FREE(array);
+}
+
+#endif


### PR DESCRIPTION
Update (2023/05/20): 

* In the original publication, the "NXYZ" should've been called "XYZN", and vice verse. Unfortunately the names were accidentally swapped due to mistake. This mistake has now been fixed in text and graphs.
* Relative instead of absolute speed is used to avoid off-scale problems.
* Results of AMD Ryzen 9 7950X (Zen 4) have been added.

## Abstract

In this Pull Request, a new implementation of multi-dimensional arrays is introduced in the file `flat_array_ops.h`, with the advantage of contiguous memory, as originally proposed in Issue #100. This is represented by a new data type `Flat_N_3DArray<T>`, created and destroyed by `Create_Flat_N_3DArray<T>()` and `Delete_Flat_N_3DArray<T>()`. A template specialization is also provided to handle the special case of`Create_Flat_N_3DArray<f4vector>` without the need of a separate `_v4sf()` function.

The uses of `Create_N_3DArray()` and `Create_N_3DArray_v4sf()` in the existing FDTD kernel and the UPML extension are converted to the new `Create_Flat_N_3DArray<T>()` implementation.

The tradeoff between memory layout `NXYZ` and `XYZN` is discussed, and the `XYZN` layout was eventually selected.

Benchmarks have shown a speedup around 20%-30% in many different simulation setups.

## Programming

### Disadvantages of Existing Multi-dimensional Arrays

Currently, the file `array_ops.h` provides helper functions to allocate 2D, 3D, and N_3D arrays by offering `Create2DArray()`, `Create3DArray()`, and `Create_N_3DArray()`. Further, the file `array_ops.cpp` provides additional functions `Create3DArray_v4sf()` and `Create_N_3DArray_v4sf()` for allocating vectorized arrays.

However, these functions have several disadvantages due to the use of a non-contiguous memory layout.

To allow the access of an element in a multi-dimensional array from a pointer using the C syntax `array_ptr[x][y][z]`, the multi-dimensional array is allocated in the following way: First, an allocation of an 1D array of pointers with size "x", each pointer is pointed to another dynamically-allocated 1D array of pointers with size "y", then each pointer within this array is pointed to another dynamically-allocated 1D array with size "z".

![iliffe vector example: array of 3x3 matrices aligned with 64 bytes](https://user-images.githubusercontent.com/1310693/220278930-05f95392-1c9b-4d29-bdb2-d42ca6232fa3.png)

This is essentially an unoptimized form of "iliffe vector", with significant performance bottleneck (image taken from *Batched Cholesky factorization for tiny matrices* by Florian Lemaitre and Lionel Lacassagne).

First, poor memory spatial locality. If two elements are stored next to each other in memory and shares the same cacheline, accessing the first element effectively fetches the next element at the same time, saving valuable memory bandwidth - this is advantageous since openEMS's FDTD kernel is a linear walk of all points in 3D space. Similarly, when an element in memory is accessed with a regular stride size, the CPU can correctly predict and prefetch the next elements.

However, in the current implementation, only the last dimension of a multi-dimensional array is stored contiguously in memory, what's found in between is bookkeeping data used internally by `malloc()` (it can be worse if the system is running with fragmented memory due to other workloads). As a result, a linear walk of the array cannot take full advantage of memory locality. When we're accessing `array[x][y][Z_MAX]` in a linear walk, `array[x][y + 1][0]` should be prefetched, but this is not possible if the last dimension of the array is not contiguous in memory.

Second, using such an iliffe vector means accessing each element in the array involves multiple levels of pointer dereferencing, to access a single element, multiple unrelated memory addresses must be read first, this further increases memory latency and reduces the effectiveness of the CPU prefetcher.

The most seriously affected array is the N_3D arrays. These arrays are effectively 4D arrays as N is currently hardcoded to 3. This kind of arrays are used to store the polarization of the electromagnetic field in the X, Y, Z axis at each point (A, B, C) in 3D space, and they're the most heavily used data structure.

### New Arrays in `flat_array_ops.h`

The new template functions in flat_array_ops.h provides a solution to these problems. It creates a new class named `Flat_N_3DArray<T>`. By calling the function `Create_Flat_N_3DArray<T>`, it allocates a contiguous 1D array in memory.

The `operator()` of `Flat_N_3DArray<T>` is then overloaded, allowing one to access the element transparently. This practice is consistent with other existing C++ libraries developed for scientific computing. It will be easy to replace `Flat_N_3DArray<T>` with another professional multi-dimensional array library if there's ever a need in the future.

Furthermore, instead of creating an unnecessary `Create_N_3DArray_v4sf()` to handle vector data types, it instead uses a template specialization for the type f4vector.  Thus, both scalar and vector arrays can be created using the same template syntax.

Since the the most seriously affected array is the N_3D arrays, only the function `Create_Flat_N_3DArray<T>` at this time, and the plan is to replace all occurrence of `Create_N_3DArray()` and `Create_N_3DArray_v4sf()` completely with `Create_Flat_N_3DArray()`. Currently, only the FDTD kernel and the UPML extension has been converted. In the future, the plan is to also replace `Create3DArray()` and `Create2DArray()` by their "flat" equivalent too to ensure a consistent coding style, eventually deprecating the entire file `array_ops.h`.

### Micro-optimizations

The Flat_N_3DArray also contains three micro-optimizations.

1. Flexible array member

    The last member of the struct Flat_N_3DArray is an array with a size of 1, the size of 1 is just a placeholder and its actual size is determined by how much memory is allocated beyond the end of the array at runtime via `malloc()` or `posix_memalign()`. It's technically a standard-nonconforming undefined behavior, but is a well-known technique in system programming, usage can even be found in Unix and Windows itself. It has an important advantage of avoid the cost of extra dereferencing. On Unix, GCC/clang officially supports the "size 0" extension, so we use this well-defined option when it's available. C99 standardized `array[]` for the same purpose but it's never added to C++.

2. XYZN instead of NXYZ layout

    In openEMS, many memory accesses have the pattern of `array(0, x, y, z)`, `array(1, x, y, z)`, `array(2, x, y, z)`. Experiment showed that storing the element N as the last dimension of the array has slightly better performance on most platforms, likely due to the fact that the cacheline hit rate is increased. The the vast majority of hardware platforms tested, the XYZN layout has a significant advantage.
    
    However, for some simulations on some platforms, this produces performance degradation instead of improvement. This point will be further discussed later.

3. Hardcoded N = 3

    Currently, there's no need for an 4D array that stores more than 3 values at each point in 3D space. Thus, the first dimension 3 is hardcoded.

4. padding or alignment 

    No special padding or alignment was attempted in the array, except that all memory allocations starts at a multiple of 64 bytes, the cacheline size. Because of the header, array itself starts the 16-byte offset. Experiments showed aligning to 64 bytes produces more consistent performance. Quick experiments with other padding schemes, such as making the array itself to start at a multiple of 64 bytes, or inserting padding at the end of dimension Z, showed no improvement or a significant slowdown. 

### Using the New Arrays

To move the existing code `Create_N_3DArray()` and `Create_N_3DArray_v4sf()` to `Create_Flat_N_3DArray()`, the following change is needed. If the original code is

    // initialization
    FDTD_FLOAT**** array;
    array = Create_N_3DArray<FDTD_FLOAT>(...);

    // use
    array[n][x][y][z] = 42;
    
    // release
    Delete_Flat_N_3DArray(array);

It should be replaced with:

    // initialization
    Flat_N_3DArray<FDTD_FLOAT>* array;
    array = Create_Flat_N_3DArray<FDTD_FLOAT>(...);

    // use
    (*array)(n, x, y, z) = 42;
    
    // release
    Delete_Flat_N_3DArray(array);

However, since syntax `(*array)(n, x, y, z)` is ugly and confusing, it's recommended to keep the pointer to the array in a data structure, but when an access to the array is needed, the pointer is converted a reference at the beginning of a function, in a style similar to:

    // initialization
    Flat_N_3DArray<FDTD_FLOAT>* array_ptr;
    array_ptr = Create_Flat_N_3DArray<FDTD_FLOAT>(...);

    // use
    Flat_N_3DArray<FDTD_FLOAT>& array = *array_ptr;
    array(n, x, y, z) = 42;
    
    // release
    Delete_Flat_N_3DArray(array_ptr);

## Results

### Hardware Configuration

To examine the effect of the optimization, benchmarking has been performed on 8 different CPU microarchitectures, six of them are virtual machines on Amazon Web Services, the other two are physical computers. Hardware configuration is summarized in the following table.

|   Nickname    |    Type    |            CPU                  |  Cores   |        Memory            |
|---------------|------------|---------------------------------|----------|--------------------------|
|  sandybridge  |  Physical  |  Core i7-2600K @ 3.4 GHz        |  4C/8T   | DDR3-1600 Dual-Channel   |
|  zen2         |  Physical  |  Ryzen 3 3100  @ 3.6 GHz        |  4C/8T   | DDR4-3200 Single-Channel |
|  haswell      |  c4.xlarge |  Xeon E5-2666 v3 @ 2.9 GHz      |  2C/4T   | DDR4                     |
|  skylake      | c5n.xlarge |  Xeon Platinum 8124M @ 3.0 GHz  |  2C/4T   | DDR4                     |
|  icelake      | c6i.xlarge |  Xeon Platinum 8375C @ 2.9 GHz  |  2C/4T   | DDR4                     |
|  zen3         | c6a.xlarge |  AMD EPYC 7R13 @ 3.0 GHz        |  2C/4T   | DDR4                     |
|  graviton2    | c6g.xlarge |  ARM Neoverse-N1 @ 2.5 GHz      |   4C     | DDR4                     |
|  graviton3    | c7g.xlarge |  ARM Neoverse-V1 @ 2.6 GHz      |   4C     | DDR5                     |
| zen4-7950x  |  Physical | Ryzen 9 7950X @ 4.5 GHz     |  16C/32T | DDR5-4800 Dual-Channel |

### Test Method

In total, 14 simulations were selected to compare the performance of upstream code and patched code, including 7 Python scripts and 3 Octave script from the openEMS official demo, and 4 Python scripts from pyEMS. They're: 

* openEMS Python scripts: These are the official Python tutorials from the openEMS repository, including `Bent_Patch_Antenna.py`, `Helical_Antenna.py`, `RCS_Sphere.py`, `Simple_Patch_Antenna.py`, `CRLH_Extraction.py`, `MSL_NotchFilter.py`, `Rect_Waveguide.py`.
    
* openEMS Octave scripts: These are the official Octave tutorials from the openEMS repository, including `CRLH_LeakyWaveAnt.m`, `CylindricalWave_CC.m`, and `StripLine2MSL.m`.
    
* pyEMS Python scripts: From the unofficial pyEMS project. This project, developed by Matt Huszagh, aims to create a high-level framework for modeling circuit boards and components. Instead of creating geometry shapes, it would allow the creation of high-level objects like PCB layers, vias, resistors. At present, the project is still in a highly preliminary and experimental stage. Four demo scripts were used, `coupler.py`, `gcpw.py`, `microstrip_sma_transition.py`, `rf_via.py`. They represent practical problems encountered by PCB designers. 

In order to test the FDTD engine, all post-processing steps, such as plotting or near-field to far-field transformation, have been deleted from the script. Other elements, such as dumpboxes, were kept as-is. The full benchmarking test suite can be found at [this repository](https://github.com/biergaizi/openems-bench).

Each benchmark was repeatedly executed from 1 threads to 4 threads, and the entire benchmark process was repeated for 3 times. The fastest speed record for each script is used for comparison. The speed record for each script is used for comparison regardless of the number of threads, since different kind of simulations have different memory access patterns, the optimal number of thread is different.

Both memory layouts NXYZ and XYZN have been tested.

Most simulations have been programmed to end within 30 seconds, well before reaching sufficient number of timesteps to allow a reasoanble runtime. Otherwise, even with reduced timesteps or restricted maximum runtime, the full benchmark may take multiple days to finish. My experience suggests that the speed of a simulation usually does not vary during its runtime.

### Speed

![sandybridge](https://github.com/thliebig/openEMS/assets/1310693/270ef351-4993-49f6-873a-f2da7d7ad23c)

![haswell](https://github.com/thliebig/openEMS/assets/1310693/ca30432a-bb04-4d18-8d50-576957084964)

![zen2](https://github.com/thliebig/openEMS/assets/1310693/f18fb05d-bce4-4363-87ca-6c84d9aaf450)

![skylake](https://github.com/thliebig/openEMS/assets/1310693/18359627-ca9a-49c7-a068-182298098cb6)

![icelake](https://github.com/thliebig/openEMS/assets/1310693/cdac6f21-3d10-49d2-9269-afae9560944c)

![zen3](https://github.com/thliebig/openEMS/assets/1310693/12b6e12e-e706-4453-b057-a9cf9fbb5981)

![graviton2](https://github.com/thliebig/openEMS/assets/1310693/ba377232-e8a9-45a0-9e85-c6882b6e1965)

![graviton3](https://github.com/thliebig/openEMS/assets/1310693/8298ad6e-98ec-47d6-87c9-2038bba78bbe)

![zen4-7950x](https://github.com/thliebig/openEMS/assets/1310693/9413e1d0-d926-4e8a-aaea-9a5ae35c5b69)

## Discussion and Conclusion

After running these benchmarks, it can be concluded that:

1. 20%-30% performance improvement is demostrated for many simulation tasks.

2. Some simulations showed little to no improvement, because they're bottlenecked by the field dump, this is mainly a problem for small simulation domains. But in some cases, also a problem for large simulation domains. Experiments showed a similar memory layout optimization allows a 5% to 10% speedup for field dumps, but it's beyond the scope of this Pull Request.

3. Occasionally, for one or two benchmarks, huge performance increases around 150% to 200% have been observed. These are not mistakes but real results. These situations occurs when the Z-dimension of the simulation domain is small. The performance penalty of non-contiguous memory allocations in these cases are particularly high, which is easily avoided in both new layouts.

    For example, `MSL_NotchFilter.py` only has 14 cells on the Z axis, and one often sees a 150% speedup. Similarly, `CylindricalWave_CC.m` only has 5 cells on the Z axis, on Haswell, the new memory layout runs 200% as fast.

    Nevertheless, these pathological outliers are likely not relevant for practical applications.

4. On the vast majority of the hardware platforms, using the NXYZ memory layout has a significant performance advantage than the XYZN memory layout, especially on AMD Zen 3 - although both layouts are faster the unoptimized layout. 

  Unfortunately, on Graviton3, although the NXYZ layout brings improvement in some simulations, but in others simulations (including simulations with only the FDTD kernel without any plugin), there's a 20% performance hit, making it even slower than unoptimized upstream code. On the other hand, the XYZN memory layout doesn't have this performance penalty.

   However, I believe using NXYZ is a worthwhile tradeoff. In the future, both memory layouts can be made available using a runtime option. Though it's outside the scope of this pull request. 

5. The performance of physical and virtual machines are not directly comparable. Due to limited number of cores and resource contention, a 4-core virtual machine is usually slower than even a desktop computer with similar CPU microarchitecture, in spite of increased memory bandwidth of servers. 

6. AMD Zen 2 performed much slower than anticipated. It's likely due to the use of Ryzen 3 3100, the least expensive Zen 2 desktop processor. Its 4 cores are distributed across two silicon dies. This likely reduced cache hits and increased memory access overhead.

## Future Work

### Deprecating array_ops.h 

After this patch, there are currently three seperate multi-dimensional array implementations in the codebase. This is redudant and confusing to new developers. In the future, I plan to convert all existing uses of `array_ops.h` to `flat_array_ops.h`, including adding Flat 2D array and 3D array implementations. Thus, all uses of the old array_ops.h can be eliminated.

### Moving to std:mdspan

A standard multi-dimensional array implementation, called `std::mdspan`, will be added to C++23, with backports available for previous C++ versions. This array is specifically designed for scientific computing community, with many advantages in the context of HPC. See the [US government presentation](https://www.osti.gov/servlets/purl/1646434) and the [C++ standard committe report](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p0009r16.html#description) for more information. it's intended to be the new uniserval standard, with serious support from US supercomputing centers like Sandia, Oak Ridge, and Argonne National Lab.

So far there's no particular performance reason to perform this conversion, but if there's a future need, the existing homegrown `flat_array_ops.h` code can be completely converted to use `std::mdspan` for the sake of aligning with current practice.

### Engine Architecture Improvement

Despite the micro-optimization, openEMS's architecture is still fundamentally disadvantaged in terms of performance. As an academic field solver, the idea is to keep the core engine as simple as possible (MIT's MEEP also used a similar design), with  a simple kernel with standard FDTD equations, everything else like excitation signals, lossy metals, or PML/ABC, is implemented as plugins. To run a simulation, the flowchart is basically: run most points in 3D space through the plugins to do pre-update, run all points in 3D space again through the main FDTD kernel, and finally run most points in 3D space again through the plugin to do post-update. The extra redundant loads and stores create significant memory bandwidth overhead...

Now the problem is whether it can be optimized without sacrificing modularity. I'm now seeing two potential solution.

First is to use (single-thread) domain decomposition. Instead of going through the entire 3D space at a time, perhaps the update can be splitted into multiple blocks. Instead of running pre-update, main-update and post-update across the entire 3D space at once, as in:

    for (int x = 0; x < x_max; x++) {
        for (int y = 0; y < y_max; y++) {
            for (int z = 0; z < z_max; z++) {
                pre_update(x, y, z)
            }
        }
    }
    
    for (int x = 0; x < x_max; x++) {
        for (int y = 0; y < y_max; y++) {
            for (int z = 0; z < z_max; z++) {
                fdtd_kernel(x, y, z)
            }
        }
    }
    
    for (int x = 0; x < x_max; x++) {
        for (int y = 0; y < y_max; y++) {
            for (int z = 0; z < z_max; z++) {
                post_update(x, y, z)
            }
        }
    }

It can perhaps be performed in a piecewise manner, allowing the main FDTD kernel and the plugins can reuse the data in CPU cache.

    int x_start[], x_end[];
    int y_start[], y_end[];
    int z_start[], z_end[];
    int domain_len;
    
    for (int domain = 0; domain < domain_len; domain++) {
        for (int x = x_start[domain] x < x_end[domain]; x++) {
            for (int y = y_start[domain]; y < y_end[domain]; y++) {
                for (int z = z_start[domain]; z < z_end[domain]; z++) {
                    pre_update(x, y, z)
                }
            }
        }
    
        for (int x = x_start[domain] x < x_end[domain]; x++) {
            for (int y = y_start[domain]; y < y_end[domain]; y++) {
                for (int z = z_start[domain]; z < z_end[domain]; z++) {
                    fdtd_kernel(x, y, z)
                }
            }
        }
        for (int x = x_start[domain] x < x_end[domain]; x++) {
            for (int y = y_start[domain]; y < y_end[domain]; y++) {
                for (int z = z_start[domain]; z < z_end[domain]; z++) {
                    post_update(x, y, z)
                }
            }
        }
    }

Another possible solution is allowing a plugin to insert itself dynamically into main field update loop of the main kernel, rather than using its own redundant loop.

    for (int x = 0; x < x_max; x++) {
        for (int y = 0; y < y_max; y++) {
            for (int z = 0; z < z_max; z++) {
                if (has_extension(x, y, z)) {
                    pre_update(x, y, z);
                    fdtd_kernel(x, y, z);
                    post_update(x, y, z);
                }
                else {
                    fdtd_kernel(x, y, z)
                }
            }
        }
    }

Modularity can still be somewhat preserved by using function pointers instead of hardcoding extension into the main engine.

Both solutions also have the problem of losing the ability to randomly access a coherent electromagnetic field at any point in space from a plugin, so it cannot be applied to all extensions. However, it can perhaps at least be a fast path for plugins that don't need that, like PML.