### PR TITLE
python/ports.py: replace deprecated "np.int" with "int".

### DIFF
--- a/python/openEMS/ports.py
+++ b/python/openEMS/ports.py
@@ -243,7 +243,7 @@ class MSLPort(Port):
         if meas_pos_idx>=len(prop_lines)-1:
             meas_pos_idx=len(prop_lines)-2
         self.measplane_shift = np.abs(self.start[self.prop_ny]-prop_lines[meas_pos_idx])
-        prope_idx = np.array([meas_pos_idx-1, meas_pos_idx, meas_pos_idx+1], np.int)
+        prope_idx = np.array([meas_pos_idx-1, meas_pos_idx, meas_pos_idx+1], int)
         if self.direction<0:
             prope_idx = np.flipud(prope_idx)
         u_prope_pos = prop_lines[prope_idx]


### PR DESCRIPTION
Accroding to NumPy's development team, "for a long time, np.int has been an alias of the builtin int. This is repeatedly a cause of confusion for newcomers, and existed mainly for historic reasons."

This and many other aliases have been deprecated since NumPy v1.20.0, and at this point they've been completely removed. Replace "np.int" with "int" allows ports.py to run again.