### PR TITLE
Implement mesh_estimate_cfl_timestep

### DIFF
--- a/python/openEMS/automesh.py
+++ b/python/openEMS/automesh.py
@@ -75,26 +75,19 @@ def mesh_hint_from_box(box, dirs, **kw):
             hint[ny].append(start[ny])
     return hint
 
-def mesh_estimate_cfl_timestep(box):
-    """ mesh_estimate_cfl_timestep(box)
+def mesh_estimate_cfl_timestep(mesh):
+    """ mesh_estimate_cfl_timestep(mesh)
 
-    Estimate the maximum CFL time step of the given box needed to ensure numerical stability,
+    Estimate the maximum CFL time step of the given mesh needed to ensure numerical stability,
     assuming propagation in pure vacuum.
 
     :returns: the maximum CFL time step, in seconds
     """
-    minDiff = [None, None, None]
+    invMinDiff = [None, None, None]
     for ny in range(3):
-        lines = box.GetQtyLines(ny)
-        for i in range(1, lines):
-            delta = box.GetLine(ny, i) - box.GetLine(ny, i - 1)
-            if minDiff[ny] is None or delta < minDiff[ny]:
-                minDiff[ny] = delta
-    if None in minDiff:
-        sys.stderr.write('FDTD::automesh: Warning, mesh is ill-defined (no lines in certain directions?)\n')
-        return 0
+        invMinDiff[ny] = np.min(np.diff(mesh.GetLines(ny))) ** -2
 
-    delta_t = box.GetDeltaUnit() / (C0 * np.sqrt(np.sum(np.array(minDiff) ** -2)))
+    delta_t = mesh.GetDeltaUnit() / (C0 * np.sqrt(np.sum(invMinDiff)))
 
     return delta_t
 

--- a/python/openEMS/automesh.py
+++ b/python/openEMS/automesh.py
@@ -10,6 +10,7 @@ import numpy as np
 
 from CSXCAD import CSPrimitives
 from CSXCAD.Utilities import CheckNyDir, GetMultiDirs
+from openEMS.physical_constants import C0
 
 def mesh_hint_from_primitive(primitive, dirs, **kw):
     if primitive.GetType() is CSPrimitives.POINT:

--- a/python/openEMS/automesh.py
+++ b/python/openEMS/automesh.py
@@ -75,3 +75,26 @@ def mesh_hint_from_box(box, dirs, **kw):
             hint[ny].append(start[ny])
     return hint
 
+def mesh_estimate_cfl_timestep(box):
+    """ mesh_estimate_cfl_timestep(box)
+
+    Estimate the maximum CFL time step of the given box needed to ensure numerical stability,
+    assuming propagation in pure vacuum.
+
+    :returns: the maximum CFL time step, in seconds
+    """
+    minDiff = [None, None, None]
+    for ny in range(3):
+        lines = box.GetQtyLines(ny)
+        for i in range(1, lines):
+            delta = box.GetLine(ny, i) - box.GetLine(ny, i - 1)
+            if minDiff[ny] is None or delta < minDiff[ny]:
+                minDiff[ny] = delta
+    if None in minDiff:
+        sys.stderr.write('FDTD::automesh: Warning, mesh is ill-defined (no lines in certain directions?)\n')
+        return 0
+
+    delta_t = box.GetDeltaUnit() / (C0 * np.sqrt(np.sum(np.array(minDiff) ** -2)))
+
+    return delta_t
+


### PR DESCRIPTION
This PR provides `mesh_estimate_cfl_timestep`, a function that accepts a `CSRectGrid` mesh and provides a crude estimate of the maximum CFL time step (in seconds), assuming vacuum propagation. Since adding materials with different permittivities / permeabilities will simply slow the propagation of EM waves in the medium, this is actually an underestimation of the true maximum time step.