### PR TITLE
Fixed HDF5 library path import

### DIFF
--- a/matlab/setup.m
+++ b/matlab/setup.m
@@ -25,7 +25,7 @@ if isOctave()
             [res, search_path] = unix('brew --prefix');
             search_path = strtrim(search_path);
         end
-        [res, fn_so] = unix(['find ' search_path '/lib     -name libhdf5.' dylib_extension]);
+        [res, fn_so] = unix(['find ' search_path '/lib     -name libhdf5.' dylib_extension ' | head -1']);
         [res, fn_h]  = unix(['find ' search_path '/include -name hdf5.h | grep -v opencv | sort -r | head -1']);
         if length(fn_so)>0 && length(fn_h)>0
             [hdf5lib_dir, hdf5lib_fn, ext] = fileparts(fn_so);


### PR DESCRIPTION
As stated in the last comment of issue https://github.com/thliebig/openEMS/issues/36, there is still an issue with the setup.m in Linux when both the serial and openmpi versions of hdf5 are installed.
This simple fix applies the same correction that was already done to the hdf5 include path.

Before fix:
```matlab
>> setup
setting up openEMS matlab/octave interface
compiling oct files
HDF5 library path found at: /usr/lib/x86_64-linux-gnu/hdf5/openmpi/libhdf5.so
/usr/lib/x86_64-linux-gnu/hdf5/serial
HDF5 include path found at: /usr/include/hdf5/serial
/usr/bin/ld: /usr/lib/gcc/x86_64-linux-gnu/12/../../../x86_64-linux-gnu/Scrt1.o: in function `_start':
(.text+0x1b): undefined reference to `main'
collect2: error: ld returned 1 exit status
sh: 2: /usr/lib/x86_64-linux-gnu/hdf5/serial: Permission denied
error: mkoctfile: building exited with failure status
```

After fix:
```matlab
>> setup
setting up openEMS matlab/octave interface
compiling oct files
HDF5 library path found at: /usr/lib/x86_64-linux-gnu/hdf5/openmpi
HDF5 include path found at: /usr/include/hdf5/serial
```

Thank you for the great work!