### PR TITLE
openEMS.pyx: check canonical path in assert, close #113.

### DIFF
--- a/python/openEMS/openEMS.pyx
+++ b/python/openEMS/openEMS.pyx
@@ -486,7 +486,7 @@ cdef class openEMS:
                 self.thisptr.DebugCSX()
         if 'numThreads' in kw:
             self.thisptr.SetNumberOfThreads(int(kw['numThreads']))
-        assert os.getcwd() == sim_path
+        assert os.getcwd() == os.path.realpath(sim_path)
         _openEMS.WelcomeScreen()
         cdef int EC
         with nogil:


### PR DESCRIPTION
Currently, running openEMS's example Python scripts on macOS always fails with the following error:

    $ python3 MSL_NotchFilter.py
    Traceback (most recent call last):
      File "/Users/gentoo/code/openEMS-Project/openEMS/python/Tutorials/MSL_NotchFilter.py", line 103, in <module>
        FDTD.Run(Sim_Path, cleanup=True)
      File "openEMS/openEMS.pyx", line 489, in openEMS.openEMS.openEMS.Run
    AssertionError

This is caused by an oversight of an assertion in openEMS.pyx:

    os.chdir(sim_path)
    # ...
    assert os.getcwd() == sim_path

The problem here is that "sim_path" is not a canonical path name, so the assertion would fail if the path we're switching into contains a symbolic link. This problem affects all operating systems, it's not limited to macOS. But on macOS, the problem is especially serious, since macOS's "/tmp" is a link to "/private/tmp" by default. Thus, it causes an AssertionError in all the included Python examples.

Instead of doing `assert os.getcwd() == sim_path`, we should do `assert os.getcwd() == os.path.realpath(sim_path)` instead to ensure we're checking a canonical path in order to fix Issue #113.