### PR TITLE
Set C++ version for boost thread

### DIFF
--- a/nf2ff/CMakeLists.txt
+++ b/nf2ff/CMakeLists.txt
@@ -33,6 +33,7 @@ set(HEADERS
 
 add_library( nf2ff SHARED ${SOURCES})
 set_target_properties(nf2ff PROPERTIES VERSION ${LIB_VERSION_STRING} SOVERSION ${LIB_VERSION_MAJOR})
+set_target_properties(nf2ff PROPERTIES CXX_STANDARD 11)
 if (WIN32)
     target_compile_definitions(nf2ff PRIVATE -DBUILD_NF2FF_LIB )
 endif (WIN32)


### PR DESCRIPTION
Fixes https://github.com/thliebig/openEMS-Project/issues/190

As of recent, `nf2ff` has been failing to compile with the latest version of boost (1.84.0):

```
In file included from /tmp/openEMS-Project/openEMS/nf2ff/nf2ff.cpp:19:
In file included from /tmp/openEMS-Project/openEMS/nf2ff/nf2ff_calc.h:26:
In file included from /usr/local/include/boost/thread.hpp:24:
In file included from /usr/local/include/boost/thread/future.hpp:31:
In file included from /usr/local/include/boost/thread/detail/invoker.hpp:32:
/usr/local/include/boost/thread/csbl/tuple.hpp:19:18: error: no member named 'tuple' in namespace 'std'
    using ::std::tuple;
          ~~~~~~~^
/usr/local/include/boost/thread/csbl/tuple.hpp:21:18: error: no member named 'make_tuple' in namespace 'std'
    using ::std::make_tuple;
          ~~~~~~~^
```

[They changed around some stuff in this header file.](https://github.com/boostorg/thread/commit/515d95c4413a28aaa822e48a7a2bbc5b71921528#diff-b84166086f26c96a822fcc2cff5174fc8888f84146ab68c76b80df7b7415aa8d)

Setting the C++ version to 11 fixes this for me on
```
% clang --version
Apple clang version 15.0.0 (clang-1500.1.0.2.5)
Target: x86_64-apple-darwin23.3.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
```