### PR TITLE
Eliminate Code Duplication in Engine_Extension classes using a Helper Macro

### DIFF
--- a/FDTD/extensions/engine_ext_dispersive.cpp
+++ b/FDTD/extensions/engine_ext_dispersive.cpp
@@ -73,7 +73,8 @@ Engine_Ext_Dispersive::~Engine_Ext_Dispersive()
 	volt_ADE=NULL;
 }
 
-void Engine_Ext_Dispersive::Apply2Voltages()
+template <typename EngineType>
+void Engine_Ext_Dispersive::Apply2VoltagesImpl(EngineType* eng)
 {
 	for (int o=0;o<m_Op_Ext_Disp->m_Order;++o)
 	{
@@ -81,43 +82,28 @@ void Engine_Ext_Dispersive::Apply2Voltages()
 
 		unsigned int **pos = m_Op_Ext_Disp->m_LM_pos[o];
 
-		//switch for different engine types to access faster inline engine functions
-		switch (m_Eng->GetType())
+		for (unsigned int i=0; i<m_Op_Ext_Disp->m_LM_Count.at(o); ++i)
 		{
-		case Engine::BASIC:
-		{
-			for (unsigned int i=0; i<m_Op_Ext_Disp->m_LM_Count.at(o); ++i)
-			{
-				m_Eng->Engine::SetVolt(0,pos[0][i],pos[1][i],pos[2][i], m_Eng->Engine::GetVolt(0,pos[0][i],pos[1][i],pos[2][i]) - volt_ADE[o][0][i]);
-				m_Eng->Engine::SetVolt(1,pos[0][i],pos[1][i],pos[2][i], m_Eng->Engine::GetVolt(1,pos[0][i],pos[1][i],pos[2][i]) - volt_ADE[o][1][i]);
-				m_Eng->Engine::SetVolt(2,pos[0][i],pos[1][i],pos[2][i], m_Eng->Engine::GetVolt(2,pos[0][i],pos[1][i],pos[2][i]) - volt_ADE[o][2][i]);
-			}
-			break;
-		}
-		case Engine::SSE:
-		{
-			Engine_sse* eng_sse = (Engine_sse*)m_Eng;
-			for (unsigned int i=0; i<m_Op_Ext_Disp->m_LM_Count.at(o); ++i)
-			{
-				eng_sse->Engine_sse::SetVolt(0,pos[0][i],pos[1][i],pos[2][i], eng_sse->Engine_sse::GetVolt(0,pos[0][i],pos[1][i],pos[2][i]) - volt_ADE[o][0][i]);
-				eng_sse->Engine_sse::SetVolt(1,pos[0][i],pos[1][i],pos[2][i], eng_sse->Engine_sse::GetVolt(1,pos[0][i],pos[1][i],pos[2][i]) - volt_ADE[o][1][i]);
-				eng_sse->Engine_sse::SetVolt(2,pos[0][i],pos[1][i],pos[2][i], eng_sse->Engine_sse::GetVolt(2,pos[0][i],pos[1][i],pos[2][i]) - volt_ADE[o][2][i]);
-			}
-			break;
-		}
-		default:
-			for (unsigned int i=0; i<m_Op_Ext_Disp->m_LM_Count.at(o); ++i)
-			{
-				m_Eng->SetVolt(0,pos[0][i],pos[1][i],pos[2][i], m_Eng->GetVolt(0,pos[0][i],pos[1][i],pos[2][i]) - volt_ADE[o][0][i]);
-				m_Eng->SetVolt(1,pos[0][i],pos[1][i],pos[2][i], m_Eng->GetVolt(1,pos[0][i],pos[1][i],pos[2][i]) - volt_ADE[o][1][i]);
-				m_Eng->SetVolt(2,pos[0][i],pos[1][i],pos[2][i], m_Eng->GetVolt(2,pos[0][i],pos[1][i],pos[2][i]) - volt_ADE[o][2][i]);
-			}
-			break;
+			eng->EngineType::SetVolt(0,pos[0][i],pos[1][i],pos[2][i],
+				eng->EngineType::GetVolt(0,pos[0][i],pos[1][i],pos[2][i]) - volt_ADE[o][0][i]
+			);
+			eng->EngineType::SetVolt(1,pos[0][i],pos[1][i],pos[2][i],
+				eng->EngineType::GetVolt(1,pos[0][i],pos[1][i],pos[2][i]) - volt_ADE[o][1][i]
+			);
+			eng->EngineType::SetVolt(2,pos[0][i],pos[1][i],pos[2][i],
+				eng->EngineType::GetVolt(2,pos[0][i],pos[1][i],pos[2][i]) - volt_ADE[o][2][i]
+			);
 		}
 	}
 }
 
-void Engine_Ext_Dispersive::Apply2Current()
+void Engine_Ext_Dispersive::Apply2Voltages()
+{
+	ENG_DISPATCH(Apply2VoltagesImpl);
+}
+
+template <typename EngineType>
+void Engine_Ext_Dispersive::Apply2CurrentImpl(EngineType* eng)
 {
 	for (int o=0;o<m_Op_Ext_Disp->m_Order;++o)
 	{
@@ -125,38 +111,22 @@ void Engine_Ext_Dispersive::Apply2Current()
 
 		unsigned int **pos = m_Op_Ext_Disp->m_LM_pos[o];
 
-		//switch for different engine types to access faster inline engine functions
-		switch (m_Eng->GetType())
+		for (unsigned int i=0; i<m_Op_Ext_Disp->m_LM_Count.at(o); ++i)
 		{
-		case Engine::BASIC:
-		{
-			for (unsigned int i=0; i<m_Op_Ext_Disp->m_LM_Count.at(o); ++i)
-			{
-				m_Eng->Engine::SetCurr(0,pos[0][i],pos[1][i],pos[2][i], m_Eng->Engine::GetCurr(0,pos[0][i],pos[1][i],pos[2][i]) - curr_ADE[o][0][i]);
-				m_Eng->Engine::SetCurr(1,pos[0][i],pos[1][i],pos[2][i], m_Eng->Engine::GetCurr(1,pos[0][i],pos[1][i],pos[2][i]) - curr_ADE[o][1][i]);
-				m_Eng->Engine::SetCurr(2,pos[0][i],pos[1][i],pos[2][i], m_Eng->Engine::GetCurr(2,pos[0][i],pos[1][i],pos[2][i]) - curr_ADE[o][2][i]);
-			}
-			break;
-		}
-		case Engine::SSE:
-		{
-			Engine_sse* eng_sse = (Engine_sse*)m_Eng;
-			for (unsigned int i=0; i<m_Op_Ext_Disp->m_LM_Count.at(o); ++i)
-			{
-				eng_sse->Engine_sse::SetCurr(0,pos[0][i],pos[1][i],pos[2][i], eng_sse->Engine_sse::GetCurr(0,pos[0][i],pos[1][i],pos[2][i]) - curr_ADE[o][0][i]);
-				eng_sse->Engine_sse::SetCurr(1,pos[0][i],pos[1][i],pos[2][i], eng_sse->Engine_sse::GetCurr(1,pos[0][i],pos[1][i],pos[2][i]) - curr_ADE[o][1][i]);
-				eng_sse->Engine_sse::SetCurr(2,pos[0][i],pos[1][i],pos[2][i], eng_sse->Engine_sse::GetCurr(2,pos[0][i],pos[1][i],pos[2][i]) - curr_ADE[o][2][i]);
-			}
-			break;
-		}
-		default:
-			for (unsigned int i=0; i<m_Op_Ext_Disp->m_LM_Count.at(o); ++i)
-			{
-				m_Eng->SetCurr(0,pos[0][i],pos[1][i],pos[2][i], m_Eng->GetCurr(0,pos[0][i],pos[1][i],pos[2][i]) - curr_ADE[o][0][i]);
-				m_Eng->SetCurr(1,pos[0][i],pos[1][i],pos[2][i], m_Eng->GetCurr(1,pos[0][i],pos[1][i],pos[2][i]) - curr_ADE[o][1][i]);
-				m_Eng->SetCurr(2,pos[0][i],pos[1][i],pos[2][i], m_Eng->GetCurr(2,pos[0][i],pos[1][i],pos[2][i]) - curr_ADE[o][2][i]);
-			}
-			break;
+			eng->EngineType::SetCurr(0,pos[0][i],pos[1][i],pos[2][i],
+				eng->EngineType::GetCurr(0,pos[0][i],pos[1][i],pos[2][i]) - curr_ADE[o][0][i]
+			);
+			eng->EngineType::SetCurr(1,pos[0][i],pos[1][i],pos[2][i],
+				eng->EngineType::GetCurr(1,pos[0][i],pos[1][i],pos[2][i]) - curr_ADE[o][1][i]
+			);
+			eng->EngineType::SetCurr(2,pos[0][i],pos[1][i],pos[2][i],
+				eng->EngineType::GetCurr(2,pos[0][i],pos[1][i],pos[2][i]) - curr_ADE[o][2][i]
+			);
 		}
 	}
+}
+
+void Engine_Ext_Dispersive::Apply2Current()
+{
+	ENG_DISPATCH(Apply2CurrentImpl);
 }

--- a/FDTD/extensions/engine_ext_dispersive.h
+++ b/FDTD/extensions/engine_ext_dispersive.h
@@ -21,6 +21,7 @@
 #include "engine_extension.h"
 #include "FDTD/engine.h"
 #include "FDTD/operator.h"
+#include "engine_extension_dispatcher.h"
 
 class Operator_Ext_Dispersive;
 
@@ -34,6 +35,12 @@ public:
 	virtual void Apply2Current();
 
 protected:
+	template <typename EngineType>
+	void Apply2VoltagesImpl(EngineType* eng);
+
+	template <typename EngineType>
+	void Apply2CurrentImpl(EngineType* eng);
+
 	Operator_Ext_Dispersive* m_Op_Ext_Disp;
 
 	//! Dispersive order

--- a/FDTD/extensions/engine_ext_excitation.cpp
+++ b/FDTD/extensions/engine_ext_excitation.cpp
@@ -30,7 +30,8 @@ Engine_Ext_Excitation::~Engine_Ext_Excitation()
 
 }
 
-void Engine_Ext_Excitation::Apply2Voltages()
+template <typename EngineType>
+void Engine_Ext_Excitation::Apply2VoltagesImpl(EngineType* eng)
 {
 	//soft voltage excitation here (E-field excite)
 	int exc_pos;
@@ -44,65 +45,29 @@ void Engine_Ext_Excitation::Apply2Voltages()
 	if (m_Op_Exc->m_Exc->GetSignalPeriod()>0)
 		p = int(m_Op_Exc->m_Exc->GetSignalPeriod()/m_Op_Exc->m_Exc->GetTimestep());
 
-	//switch for different engine types to access faster inline engine functions
-	switch (m_Eng->GetType())
+	for (unsigned int n=0; n<m_Op_Exc->Volt_Count; ++n)
 	{
-	case Engine::BASIC:
-		{
-			for (unsigned int n=0; n<m_Op_Exc->Volt_Count; ++n)
-			{
-				exc_pos = numTS - (int)m_Op_Exc->Volt_delay[n];
-				exc_pos *= (exc_pos>0);
-				exc_pos %= p;
-				exc_pos *= (exc_pos<(int)length);
-				ny = m_Op_Exc->Volt_dir[n];
-				pos[0]=m_Op_Exc->Volt_index[0][n];
-				pos[1]=m_Op_Exc->Volt_index[1][n];
-				pos[2]=m_Op_Exc->Volt_index[2][n];
-				m_Eng->Engine::SetVolt(ny,pos, m_Eng->Engine::GetVolt(ny,pos) + m_Op_Exc->Volt_amp[n]*exc_volt[exc_pos]);
-			}
-			break;
-		}
-	case Engine::SSE:
-		{
-			for (unsigned int n=0; n<m_Op_Exc->Volt_Count; ++n)
-			{
-				Engine_sse* eng_sse = (Engine_sse*) m_Eng;
-				exc_pos = numTS - (int)m_Op_Exc->Volt_delay[n];
-				exc_pos *= (exc_pos>0);
-				exc_pos %= p;
-				exc_pos *= (exc_pos<(int)length);
-				ny = m_Op_Exc->Volt_dir[n];
-				pos[0]=m_Op_Exc->Volt_index[0][n];
-				pos[1]=m_Op_Exc->Volt_index[1][n];
-				pos[2]=m_Op_Exc->Volt_index[2][n];
-				eng_sse->Engine_sse::SetVolt(ny,pos, eng_sse->Engine_sse::GetVolt(ny,pos) + m_Op_Exc->Volt_amp[n]*exc_volt[exc_pos]);
-			}
-			break;
-		}
-	default:
-		{
-			for (unsigned int n=0; n<m_Op_Exc->Volt_Count; ++n)
-			{
-				exc_pos = numTS - (int)m_Op_Exc->Volt_delay[n];
-				exc_pos *= (exc_pos>0);
-				exc_pos %= p;
-				exc_pos *= (exc_pos<(int)length);
-				ny = m_Op_Exc->Volt_dir[n];
-				pos[0]=m_Op_Exc->Volt_index[0][n];
-				pos[1]=m_Op_Exc->Volt_index[1][n];
-				pos[2]=m_Op_Exc->Volt_index[2][n];
-				m_Eng->SetVolt(ny,pos, m_Eng->GetVolt(ny,pos) + m_Op_Exc->Volt_amp[n]*exc_volt[exc_pos]);
-			}
-			break;
-		}
+		exc_pos = numTS - (int)m_Op_Exc->Volt_delay[n];
+		exc_pos *= (exc_pos>0);
+		exc_pos %= p;
+		exc_pos *= (exc_pos<(int)length);
+		ny = m_Op_Exc->Volt_dir[n];
+		pos[0]=m_Op_Exc->Volt_index[0][n];
+		pos[1]=m_Op_Exc->Volt_index[1][n];
+		pos[2]=m_Op_Exc->Volt_index[2][n];
+		eng->EngineType::SetVolt(ny,pos, eng->EngineType::GetVolt(ny,pos) + m_Op_Exc->Volt_amp[n]*exc_volt[exc_pos]);
 	}
 }
 
-void Engine_Ext_Excitation::Apply2Current()
+void Engine_Ext_Excitation::Apply2Voltages()
+{
+	ENG_DISPATCH(Apply2VoltagesImpl);
+}
+
+template <typename EngineType>
+void Engine_Ext_Excitation::Apply2CurrentImpl(EngineType* eng)
 {
 	//soft current excitation here (H-field excite)
-
 	int exc_pos;
 	unsigned int ny;
 	unsigned int pos[3];
@@ -114,57 +79,21 @@ void Engine_Ext_Excitation::Apply2Current()
 	if (m_Op_Exc->m_Exc->GetSignalPeriod()>0)
 		p = int(m_Op_Exc->m_Exc->GetSignalPeriod()/m_Op_Exc->m_Exc->GetTimestep());
 
-	//switch for different engine types to access faster inline engine functions
-	switch (m_Eng->GetType())
+	for (unsigned int n=0; n<m_Op_Exc->Curr_Count; ++n)
 	{
-	case Engine::BASIC:
-		{
-			for (unsigned int n=0; n<m_Op_Exc->Curr_Count; ++n)
-			{
-				exc_pos = numTS - (int)m_Op_Exc->Curr_delay[n];
-				exc_pos *= (exc_pos>0);
-				exc_pos %= p;
-				exc_pos *= (exc_pos<(int)length);
-				ny = m_Op_Exc->Curr_dir[n];
-				pos[0]=m_Op_Exc->Curr_index[0][n];
-				pos[1]=m_Op_Exc->Curr_index[1][n];
-				pos[2]=m_Op_Exc->Curr_index[2][n];
-				m_Eng->Engine::SetCurr(ny,pos, m_Eng->Engine::GetCurr(ny,pos) + m_Op_Exc->Curr_amp[n]*exc_curr[exc_pos]);
-			}
-			break;
-		}
-	case Engine::SSE:
-		{
-			for (unsigned int n=0; n<m_Op_Exc->Curr_Count; ++n)
-			{
-				Engine_sse* eng_sse = (Engine_sse*) m_Eng;
-				exc_pos = numTS - (int)m_Op_Exc->Curr_delay[n];
-				exc_pos *= (exc_pos>0);
-				exc_pos %= p;
-				exc_pos *= (exc_pos<(int)length);
-				ny = m_Op_Exc->Curr_dir[n];
-				pos[0]=m_Op_Exc->Curr_index[0][n];
-				pos[1]=m_Op_Exc->Curr_index[1][n];
-				pos[2]=m_Op_Exc->Curr_index[2][n];
-				eng_sse->Engine_sse::SetCurr(ny,pos, eng_sse->Engine_sse::GetCurr(ny,pos) + m_Op_Exc->Curr_amp[n]*exc_curr[exc_pos]);
-			}
-			break;
-		}
-	default:
-		{
-			for (unsigned int n=0; n<m_Op_Exc->Curr_Count; ++n)
-			{
-				exc_pos = numTS - (int)m_Op_Exc->Curr_delay[n];
-				exc_pos *= (exc_pos>0);
-				exc_pos %= p;
-				exc_pos *= (exc_pos<(int)length);
-				ny = m_Op_Exc->Curr_dir[n];
-				pos[0]=m_Op_Exc->Curr_index[0][n];
-				pos[1]=m_Op_Exc->Curr_index[1][n];
-				pos[2]=m_Op_Exc->Curr_index[2][n];
-				m_Eng->SetCurr(ny,pos, m_Eng->GetCurr(ny,pos) + m_Op_Exc->Curr_amp[n]*exc_curr[exc_pos]);
-			}
-			break;
-		}
+		exc_pos = numTS - (int)m_Op_Exc->Curr_delay[n];
+		exc_pos *= (exc_pos>0);
+		exc_pos %= p;
+		exc_pos *= (exc_pos<(int)length);
+		ny = m_Op_Exc->Curr_dir[n];
+		pos[0]=m_Op_Exc->Curr_index[0][n];
+		pos[1]=m_Op_Exc->Curr_index[1][n];
+		pos[2]=m_Op_Exc->Curr_index[2][n];
+		eng->EngineType::SetCurr(ny,pos, eng->EngineType::GetCurr(ny,pos) + m_Op_Exc->Curr_amp[n]*exc_curr[exc_pos]);
 	}
+}
+
+void Engine_Ext_Excitation::Apply2Current()
+{
+	ENG_DISPATCH(Apply2CurrentImpl);
 }

--- a/FDTD/extensions/engine_ext_excitation.h
+++ b/FDTD/extensions/engine_ext_excitation.h
@@ -21,6 +21,7 @@
 #include "engine_extension.h"
 #include "FDTD/engine.h"
 #include "FDTD/operator.h"
+#include "engine_extension_dispatcher.h"
 
 class Operator_Ext_Excitation;
 
@@ -34,6 +35,12 @@ public:
 	virtual void Apply2Current();
 
 protected:
+	template <typename EngineType>
+	void Apply2VoltagesImpl(EngineType* eng);
+
+	template <typename EngineType>
+	void Apply2CurrentImpl(EngineType* eng);
+
 	Operator_Ext_Excitation* m_Op_Exc;
 };
 

--- a/FDTD/extensions/engine_ext_lorentzmaterial.cpp
+++ b/FDTD/extensions/engine_ext_lorentzmaterial.cpp
@@ -76,7 +76,8 @@ Engine_Ext_LorentzMaterial::~Engine_Ext_LorentzMaterial()
 	volt_Lor_ADE=NULL;
 }
 
-void Engine_Ext_LorentzMaterial::DoPreVoltageUpdates()
+template <typename EngineType>
+void Engine_Ext_LorentzMaterial::DoPreVoltageUpdatesImpl(EngineType* eng)
 {
 	for (int o=0;o<m_Order;++o)
 	{
@@ -86,119 +87,45 @@ void Engine_Ext_LorentzMaterial::DoPreVoltageUpdates()
 
 		if (m_Op_Ext_Lor->m_volt_Lor_ADE_On[o])
 		{
-			//switch for different engine types to access faster inline engine functions
-			switch (m_Eng->GetType())
+			for (unsigned int i=0; i<m_Op_Ext_Lor->m_LM_Count.at(o); ++i)
 			{
-			case Engine::BASIC:
-			{
-				for (unsigned int i=0; i<m_Op_Ext_Lor->m_LM_Count.at(o); ++i)
-				{
-					volt_Lor_ADE[o][0][i]+=m_Op_Ext_Lor->v_Lor_ADE[o][0][i]*volt_ADE[o][0][i];
-					volt_ADE[o][0][i] *= m_Op_Ext_Lor->v_int_ADE[o][0][i];
-					volt_ADE[o][0][i] += m_Op_Ext_Lor->v_ext_ADE[o][0][i] * (m_Eng->Engine::GetVolt(0,pos[0][i],pos[1][i],pos[2][i])-volt_Lor_ADE[o][0][i]);
+				volt_Lor_ADE[o][0][i]+=m_Op_Ext_Lor->v_Lor_ADE[o][0][i]*volt_ADE[o][0][i];
+				volt_ADE[o][0][i] *= m_Op_Ext_Lor->v_int_ADE[o][0][i];
+				volt_ADE[o][0][i] += m_Op_Ext_Lor->v_ext_ADE[o][0][i] * (eng->EngineType::GetVolt(0,pos[0][i],pos[1][i],pos[2][i])-volt_Lor_ADE[o][0][i]);
 
-					volt_Lor_ADE[o][1][i]+=m_Op_Ext_Lor->v_Lor_ADE[o][1][i]*volt_ADE[o][1][i];
-					volt_ADE[o][1][i] *= m_Op_Ext_Lor->v_int_ADE[o][1][i];
-					volt_ADE[o][1][i] += m_Op_Ext_Lor->v_ext_ADE[o][1][i] * (m_Eng->Engine::GetVolt(1,pos[0][i],pos[1][i],pos[2][i])-volt_Lor_ADE[o][2][i]);
+				volt_Lor_ADE[o][1][i]+=m_Op_Ext_Lor->v_Lor_ADE[o][1][i]*volt_ADE[o][1][i];
+				volt_ADE[o][1][i] *= m_Op_Ext_Lor->v_int_ADE[o][1][i];
+				volt_ADE[o][1][i] += m_Op_Ext_Lor->v_ext_ADE[o][1][i] * (eng->EngineType::GetVolt(1,pos[0][i],pos[1][i],pos[2][i])-volt_Lor_ADE[o][1][i]);
 
-					volt_Lor_ADE[o][2][i]+=m_Op_Ext_Lor->v_Lor_ADE[o][2][i]*volt_ADE[o][2][i];
-					volt_ADE[o][2][i] *= m_Op_Ext_Lor->v_int_ADE[o][2][i];
-					volt_ADE[o][2][i] += m_Op_Ext_Lor->v_ext_ADE[o][2][i] * (m_Eng->Engine::GetVolt(2,pos[0][i],pos[1][i],pos[2][i])-volt_Lor_ADE[o][2][i]);
-				}
-				break;
-			}
-			case Engine::SSE:
-			{
-				Engine_sse* eng_sse = (Engine_sse*)m_Eng;
-				for (unsigned int i=0; i<m_Op_Ext_Lor->m_LM_Count.at(o); ++i)
-				{
-					volt_Lor_ADE[o][0][i]+=m_Op_Ext_Lor->v_Lor_ADE[o][0][i]*volt_ADE[o][0][i];
-					volt_ADE[o][0][i] *= m_Op_Ext_Lor->v_int_ADE[o][0][i];
-					volt_ADE[o][0][i] += m_Op_Ext_Lor->v_ext_ADE[o][0][i] * (eng_sse->Engine_sse::GetVolt(0,pos[0][i],pos[1][i],pos[2][i])-volt_Lor_ADE[o][0][i]);
-
-					volt_Lor_ADE[o][1][i]+=m_Op_Ext_Lor->v_Lor_ADE[o][1][i]*volt_ADE[o][1][i];
-					volt_ADE[o][1][i] *= m_Op_Ext_Lor->v_int_ADE[o][1][i];
-					volt_ADE[o][1][i] += m_Op_Ext_Lor->v_ext_ADE[o][1][i] * (eng_sse->Engine_sse::GetVolt(1,pos[0][i],pos[1][i],pos[2][i])-volt_Lor_ADE[o][1][i]);
-
-					volt_Lor_ADE[o][2][i]+=m_Op_Ext_Lor->v_Lor_ADE[o][2][i]*volt_ADE[o][2][i];
-					volt_ADE[o][2][i] *= m_Op_Ext_Lor->v_int_ADE[o][2][i];
-					volt_ADE[o][2][i] += m_Op_Ext_Lor->v_ext_ADE[o][2][i] * (eng_sse->Engine_sse::GetVolt(2,pos[0][i],pos[1][i],pos[2][i])-volt_Lor_ADE[o][2][i]);
-				}
-				break;
-			}
-			default:
-				for (unsigned int i=0; i<m_Op_Ext_Lor->m_LM_Count.at(o); ++i)
-				{
-					volt_Lor_ADE[o][0][i]+=m_Op_Ext_Lor->v_Lor_ADE[o][0][i]*volt_ADE[o][0][i];
-					volt_ADE[o][0][i] *= m_Op_Ext_Lor->v_int_ADE[o][0][i];
-					volt_ADE[o][0][i] += m_Op_Ext_Lor->v_ext_ADE[o][0][i] * (m_Eng->GetVolt(0,pos[0][i],pos[1][i],pos[2][i])-volt_Lor_ADE[o][0][i]);
-
-					volt_Lor_ADE[o][1][i]+=m_Op_Ext_Lor->v_Lor_ADE[o][1][i]*volt_ADE[o][1][i];
-					volt_ADE[o][1][i] *= m_Op_Ext_Lor->v_int_ADE[o][1][i];
-					volt_ADE[o][1][i] += m_Op_Ext_Lor->v_ext_ADE[o][1][i] * (m_Eng->GetVolt(1,pos[0][i],pos[1][i],pos[2][i])-volt_Lor_ADE[o][1][i]);
-
-					volt_Lor_ADE[o][2][i]+=m_Op_Ext_Lor->v_Lor_ADE[o][2][i]*volt_ADE[o][2][i];
-					volt_ADE[o][2][i] *= m_Op_Ext_Lor->v_int_ADE[o][2][i];
-					volt_ADE[o][2][i] += m_Op_Ext_Lor->v_ext_ADE[o][2][i] * (m_Eng->GetVolt(2,pos[0][i],pos[1][i],pos[2][i])-volt_Lor_ADE[o][2][i]);
-				}
-				break;
+				volt_Lor_ADE[o][2][i]+=m_Op_Ext_Lor->v_Lor_ADE[o][2][i]*volt_ADE[o][2][i];
+				volt_ADE[o][2][i] *= m_Op_Ext_Lor->v_int_ADE[o][2][i];
+				volt_ADE[o][2][i] += m_Op_Ext_Lor->v_ext_ADE[o][2][i] * (eng->EngineType::GetVolt(2,pos[0][i],pos[1][i],pos[2][i])-volt_Lor_ADE[o][2][i]);
 			}
 		}
 		else
 		{
-			//switch for different engine types to access faster inline engine functions
-			switch (m_Eng->GetType())
+			for (unsigned int i=0; i<m_Op_Ext_Lor->m_LM_Count.at(o); ++i)
 			{
-			case Engine::BASIC:
-			{
-				for (unsigned int i=0; i<m_Op_Ext_Lor->m_LM_Count.at(o); ++i)
-				{
-					volt_ADE[o][0][i] *= m_Op_Ext_Lor->v_int_ADE[o][0][i];
-					volt_ADE[o][0][i] += m_Op_Ext_Lor->v_ext_ADE[o][0][i] * m_Eng->Engine::GetVolt(0,pos[0][i],pos[1][i],pos[2][i]);
+				volt_ADE[o][0][i] *= m_Op_Ext_Lor->v_int_ADE[o][0][i];
+				volt_ADE[o][0][i] += m_Op_Ext_Lor->v_ext_ADE[o][0][i] * eng->EngineType::GetVolt(0,pos[0][i],pos[1][i],pos[2][i]);
 
-					volt_ADE[o][1][i] *= m_Op_Ext_Lor->v_int_ADE[o][1][i];
-					volt_ADE[o][1][i] += m_Op_Ext_Lor->v_ext_ADE[o][1][i] * m_Eng->Engine::GetVolt(1,pos[0][i],pos[1][i],pos[2][i]);
+				volt_ADE[o][1][i] *= m_Op_Ext_Lor->v_int_ADE[o][1][i];
+				volt_ADE[o][1][i] += m_Op_Ext_Lor->v_ext_ADE[o][1][i] * eng->EngineType::GetVolt(1,pos[0][i],pos[1][i],pos[2][i]);
 
-					volt_ADE[o][2][i] *= m_Op_Ext_Lor->v_int_ADE[o][2][i];
-					volt_ADE[o][2][i] += m_Op_Ext_Lor->v_ext_ADE[o][2][i] * m_Eng->Engine::GetVolt(2,pos[0][i],pos[1][i],pos[2][i]);
-				}
-				break;
-			}
-			case Engine::SSE:
-			{
-				Engine_sse* eng_sse = (Engine_sse*)m_Eng;
-				for (unsigned int i=0; i<m_Op_Ext_Lor->m_LM_Count.at(o); ++i)
-				{
-					volt_ADE[o][0][i] *= m_Op_Ext_Lor->v_int_ADE[o][0][i];
-					volt_ADE[o][0][i] += m_Op_Ext_Lor->v_ext_ADE[o][0][i] * eng_sse->Engine_sse::GetVolt(0,pos[0][i],pos[1][i],pos[2][i]);
-
-					volt_ADE[o][1][i] *= m_Op_Ext_Lor->v_int_ADE[o][1][i];
-					volt_ADE[o][1][i] += m_Op_Ext_Lor->v_ext_ADE[o][1][i] * eng_sse->Engine_sse::GetVolt(1,pos[0][i],pos[1][i],pos[2][i]);
-
-					volt_ADE[o][2][i] *= m_Op_Ext_Lor->v_int_ADE[o][2][i];
-					volt_ADE[o][2][i] += m_Op_Ext_Lor->v_ext_ADE[o][2][i] * eng_sse->Engine_sse::GetVolt(2,pos[0][i],pos[1][i],pos[2][i]);
-				}
-				break;
-			}
-			default:
-				for (unsigned int i=0; i<m_Op_Ext_Lor->m_LM_Count.at(o); ++i)
-				{
-					volt_ADE[o][0][i] *= m_Op_Ext_Lor->v_int_ADE[o][0][i];
-					volt_ADE[o][0][i] += m_Op_Ext_Lor->v_ext_ADE[o][0][i] * m_Eng->GetVolt(0,pos[0][i],pos[1][i],pos[2][i]);
-
-					volt_ADE[o][1][i] *= m_Op_Ext_Lor->v_int_ADE[o][1][i];
-					volt_ADE[o][1][i] += m_Op_Ext_Lor->v_ext_ADE[o][1][i] * m_Eng->GetVolt(1,pos[0][i],pos[1][i],pos[2][i]);
-
-					volt_ADE[o][2][i] *= m_Op_Ext_Lor->v_int_ADE[o][2][i];
-					volt_ADE[o][2][i] += m_Op_Ext_Lor->v_ext_ADE[o][2][i] * m_Eng->GetVolt(2,pos[0][i],pos[1][i],pos[2][i]);
-				}
-				break;
+				volt_ADE[o][2][i] *= m_Op_Ext_Lor->v_int_ADE[o][2][i];
+				volt_ADE[o][2][i] += m_Op_Ext_Lor->v_ext_ADE[o][2][i] * eng->EngineType::GetVolt(2,pos[0][i],pos[1][i],pos[2][i]);
 			}
 		}
 	}
 }
 
-void Engine_Ext_LorentzMaterial::DoPreCurrentUpdates()
+void Engine_Ext_LorentzMaterial::DoPreVoltageUpdates()
+{
+	ENG_DISPATCH(DoPreVoltageUpdatesImpl);
+}
+
+template <typename EngineType>
+void Engine_Ext_LorentzMaterial::DoPreCurrentUpdatesImpl(EngineType* eng)
 {
 	for (int o=0;o<m_Order;++o)
 	{
@@ -208,115 +135,39 @@ void Engine_Ext_LorentzMaterial::DoPreCurrentUpdates()
 
 		if (m_Op_Ext_Lor->m_curr_Lor_ADE_On[o])
 		{
-			//switch for different engine types to access faster inline engine functions
-			switch (m_Eng->GetType())
+			for (unsigned int i=0; i<m_Op_Ext_Lor->m_LM_Count.at(o); ++i)
 			{
-			case Engine::BASIC:
-			{
-				for (unsigned int i=0; i<m_Op_Ext_Lor->m_LM_Count.at(o); ++i)
-				{
-					curr_Lor_ADE[o][0][i]+=m_Op_Ext_Lor->i_Lor_ADE[o][0][i]*curr_ADE[o][0][i];
-					curr_ADE[o][0][i] *= m_Op_Ext_Lor->i_int_ADE[o][0][i];
-					curr_ADE[o][0][i] += m_Op_Ext_Lor->i_ext_ADE[o][0][i] * (m_Eng->Engine::GetCurr(0,pos[0][i],pos[1][i],pos[2][i])-curr_Lor_ADE[o][0][i]);
+				curr_Lor_ADE[o][0][i]+=m_Op_Ext_Lor->i_Lor_ADE[o][0][i]*curr_ADE[o][0][i];
+				curr_ADE[o][0][i] *= m_Op_Ext_Lor->i_int_ADE[o][0][i];
+				curr_ADE[o][0][i] += m_Op_Ext_Lor->i_ext_ADE[o][0][i] * (eng->EngineType::GetCurr(0,pos[0][i],pos[1][i],pos[2][i])-curr_Lor_ADE[o][0][i]);
 
-					curr_Lor_ADE[o][1][i]+=m_Op_Ext_Lor->i_Lor_ADE[o][1][i]*curr_ADE[o][1][i];
-					curr_ADE[o][1][i] *= m_Op_Ext_Lor->i_int_ADE[o][1][i];
-					curr_ADE[o][1][i] += m_Op_Ext_Lor->i_ext_ADE[o][1][i] * (m_Eng->Engine::GetCurr(1,pos[0][i],pos[1][i],pos[2][i])-curr_Lor_ADE[o][1][i]);
+				curr_Lor_ADE[o][1][i]+=m_Op_Ext_Lor->i_Lor_ADE[o][1][i]*curr_ADE[o][1][i];
+				curr_ADE[o][1][i] *= m_Op_Ext_Lor->i_int_ADE[o][1][i];
+				curr_ADE[o][1][i] += m_Op_Ext_Lor->i_ext_ADE[o][1][i] * (eng->EngineType::GetCurr(1,pos[0][i],pos[1][i],pos[2][i])-curr_Lor_ADE[o][1][i]);
 
-					curr_Lor_ADE[o][2][i]+=m_Op_Ext_Lor->i_Lor_ADE[o][2][i]*curr_ADE[o][2][i];
-					curr_ADE[o][2][i] *= m_Op_Ext_Lor->i_int_ADE[o][2][i];
-					curr_ADE[o][2][i] += m_Op_Ext_Lor->i_ext_ADE[o][2][i] * (m_Eng->Engine::GetCurr(2,pos[0][i],pos[1][i],pos[2][i])-curr_Lor_ADE[o][2][i]);
-				}
-				break;
-			}
-			case Engine::SSE:
-			{
-				Engine_sse* eng_sse = (Engine_sse*)m_Eng;
-				for (unsigned int i=0; i<m_Op_Ext_Lor->m_LM_Count.at(o); ++i)
-				{
-					curr_Lor_ADE[o][0][i]+=m_Op_Ext_Lor->i_Lor_ADE[o][0][i]*curr_ADE[o][0][i];
-					curr_ADE[o][0][i] *= m_Op_Ext_Lor->i_int_ADE[o][0][i];
-					curr_ADE[o][0][i] += m_Op_Ext_Lor->i_ext_ADE[o][0][i] * (eng_sse->Engine_sse::GetCurr(0,pos[0][i],pos[1][i],pos[2][i])-curr_Lor_ADE[o][0][i]);
-
-					curr_Lor_ADE[o][1][i]+=m_Op_Ext_Lor->i_Lor_ADE[o][1][i]*curr_ADE[o][1][i];
-					curr_ADE[o][1][i] *= m_Op_Ext_Lor->i_int_ADE[o][1][i];
-					curr_ADE[o][1][i] += m_Op_Ext_Lor->i_ext_ADE[o][1][i] * (eng_sse->Engine_sse::GetCurr(1,pos[0][i],pos[1][i],pos[2][i])-curr_Lor_ADE[o][1][i]);
-
-					curr_Lor_ADE[o][2][i]+=m_Op_Ext_Lor->i_Lor_ADE[o][2][i]*curr_ADE[o][2][i];
-					curr_ADE[o][2][i] *= m_Op_Ext_Lor->i_int_ADE[o][2][i];
-					curr_ADE[o][2][i] += m_Op_Ext_Lor->i_ext_ADE[o][2][i] * (eng_sse->Engine_sse::GetCurr(2,pos[0][i],pos[1][i],pos[2][i])-curr_Lor_ADE[o][2][i]);
-				}
-				break;
-			}
-			default:
-				for (unsigned int i=0; i<m_Op_Ext_Lor->m_LM_Count.at(o); ++i)
-				{
-					curr_Lor_ADE[o][0][i]+=m_Op_Ext_Lor->i_Lor_ADE[o][0][i]*curr_ADE[o][0][i];
-					curr_ADE[o][0][i] *= m_Op_Ext_Lor->i_int_ADE[o][0][i];
-					curr_ADE[o][0][i] += m_Op_Ext_Lor->i_ext_ADE[o][0][i] * (m_Eng->GetCurr(0,pos[0][i],pos[1][i],pos[2][i])-curr_Lor_ADE[o][0][i]);
-
-					curr_Lor_ADE[o][1][i]+=m_Op_Ext_Lor->i_Lor_ADE[o][1][i]*curr_ADE[o][1][i];
-					curr_ADE[o][1][i] *= m_Op_Ext_Lor->i_int_ADE[o][1][i];
-					curr_ADE[o][1][i] += m_Op_Ext_Lor->i_ext_ADE[o][1][i] * (m_Eng->GetCurr(1,pos[0][i],pos[1][i],pos[2][i])-curr_Lor_ADE[o][1][i]);
-
-					curr_Lor_ADE[o][2][i]+=m_Op_Ext_Lor->i_Lor_ADE[o][2][i]*curr_ADE[o][2][i];
-					curr_ADE[o][2][i] *= m_Op_Ext_Lor->i_int_ADE[o][2][i];
-					curr_ADE[o][2][i] += m_Op_Ext_Lor->i_ext_ADE[o][2][i] * (m_Eng->GetCurr(2,pos[0][i],pos[1][i],pos[2][i])-curr_Lor_ADE[o][2][i]);
-				}
-				break;
+				curr_Lor_ADE[o][2][i]+=m_Op_Ext_Lor->i_Lor_ADE[o][2][i]*curr_ADE[o][2][i];
+				curr_ADE[o][2][i] *= m_Op_Ext_Lor->i_int_ADE[o][2][i];
+				curr_ADE[o][2][i] += m_Op_Ext_Lor->i_ext_ADE[o][2][i] * (eng->EngineType::GetCurr(2,pos[0][i],pos[1][i],pos[2][i])-curr_Lor_ADE[o][2][i]);
 			}
 		}
 		else
 		{
-			//switch for different engine types to access faster inline engine functions
-			switch (m_Eng->GetType())
+			for (unsigned int i=0; i<m_Op_Ext_Lor->m_LM_Count.at(o); ++i)
 			{
-			case Engine::BASIC:
-			{
-				for (unsigned int i=0; i<m_Op_Ext_Lor->m_LM_Count.at(o); ++i)
-				{
-					curr_ADE[o][0][i] *= m_Op_Ext_Lor->i_int_ADE[o][0][i];
-					curr_ADE[o][0][i] += m_Op_Ext_Lor->i_ext_ADE[o][0][i] * m_Eng->Engine::GetCurr(0,pos[0][i],pos[1][i],pos[2][i]);
+				curr_ADE[o][0][i] *= m_Op_Ext_Lor->i_int_ADE[o][0][i];
+				curr_ADE[o][0][i] += m_Op_Ext_Lor->i_ext_ADE[o][0][i] * eng->EngineType::GetCurr(0,pos[0][i],pos[1][i],pos[2][i]);
 
-					curr_ADE[o][1][i] *= m_Op_Ext_Lor->i_int_ADE[o][1][i];
-					curr_ADE[o][1][i] += m_Op_Ext_Lor->i_ext_ADE[o][1][i] * m_Eng->Engine::GetCurr(1,pos[0][i],pos[1][i],pos[2][i]);
+				curr_ADE[o][1][i] *= m_Op_Ext_Lor->i_int_ADE[o][1][i];
+				curr_ADE[o][1][i] += m_Op_Ext_Lor->i_ext_ADE[o][1][i] * eng->EngineType::GetCurr(1,pos[0][i],pos[1][i],pos[2][i]);
 
-					curr_ADE[o][2][i] *= m_Op_Ext_Lor->i_int_ADE[o][2][i];
-					curr_ADE[o][2][i] += m_Op_Ext_Lor->i_ext_ADE[o][2][i] * m_Eng->Engine::GetCurr(2,pos[0][i],pos[1][i],pos[2][i]);
-				}
-				break;
-			}
-			case Engine::SSE:
-			{
-				Engine_sse* eng_sse = (Engine_sse*)m_Eng;
-				for (unsigned int i=0; i<m_Op_Ext_Lor->m_LM_Count.at(o); ++i)
-				{
-					curr_ADE[o][0][i] *= m_Op_Ext_Lor->i_int_ADE[o][0][i];
-					curr_ADE[o][0][i] += m_Op_Ext_Lor->i_ext_ADE[o][0][i] * eng_sse->Engine_sse::GetCurr(0,pos[0][i],pos[1][i],pos[2][i]);
-
-					curr_ADE[o][1][i] *= m_Op_Ext_Lor->i_int_ADE[o][1][i];
-					curr_ADE[o][1][i] += m_Op_Ext_Lor->i_ext_ADE[o][1][i] * eng_sse->Engine_sse::GetCurr(1,pos[0][i],pos[1][i],pos[2][i]);
-
-					curr_ADE[o][2][i] *= m_Op_Ext_Lor->i_int_ADE[o][2][i];
-					curr_ADE[o][2][i] += m_Op_Ext_Lor->i_ext_ADE[o][2][i] * eng_sse->Engine_sse::GetCurr(2,pos[0][i],pos[1][i],pos[2][i]);
-				}
-				break;
-			}
-			default:
-				for (unsigned int i=0; i<m_Op_Ext_Lor->m_LM_Count.at(o); ++i)
-				{
-					curr_ADE[o][0][i] *= m_Op_Ext_Lor->i_int_ADE[o][0][i];
-					curr_ADE[o][0][i] += m_Op_Ext_Lor->i_ext_ADE[o][0][i] * m_Eng->GetCurr(0,pos[0][i],pos[1][i],pos[2][i]);
-
-					curr_ADE[o][1][i] *= m_Op_Ext_Lor->i_int_ADE[o][1][i];
-					curr_ADE[o][1][i] += m_Op_Ext_Lor->i_ext_ADE[o][1][i] * m_Eng->GetCurr(1,pos[0][i],pos[1][i],pos[2][i]);
-
-					curr_ADE[o][2][i] *= m_Op_Ext_Lor->i_int_ADE[o][2][i];
-					curr_ADE[o][2][i] += m_Op_Ext_Lor->i_ext_ADE[o][2][i] * m_Eng->GetCurr(2,pos[0][i],pos[1][i],pos[2][i]);
-				}
-				break;
+				curr_ADE[o][2][i] *= m_Op_Ext_Lor->i_int_ADE[o][2][i];
+				curr_ADE[o][2][i] += m_Op_Ext_Lor->i_ext_ADE[o][2][i] * eng->EngineType::GetCurr(2,pos[0][i],pos[1][i],pos[2][i]);
 			}
 		}
 	}
 }
 
+void Engine_Ext_LorentzMaterial::DoPreCurrentUpdates()
+{
+	ENG_DISPATCH(DoPreCurrentUpdatesImpl);
+}

--- a/FDTD/extensions/engine_ext_lorentzmaterial.h
+++ b/FDTD/extensions/engine_ext_lorentzmaterial.h
@@ -33,6 +33,12 @@ public:
 	virtual void DoPreCurrentUpdates();
 
 protected:
+	template <typename EngineType>
+	void DoPreVoltageUpdatesImpl(EngineType* eng);
+
+	template <typename EngineType>
+	void DoPreCurrentUpdatesImpl(EngineType* eng);
+
 	Operator_Ext_LorentzMaterial* m_Op_Ext_Lor;
 
 	//! ADE Lorentz voltages

--- a/FDTD/extensions/engine_ext_lumpedRLC.cpp
+++ b/FDTD/extensions/engine_ext_lumpedRLC.cpp
@@ -99,7 +99,8 @@ void Engine_Ext_LumpedRLC::DoPreVoltageUpdates()
 	return;
 }
 
-void Engine_Ext_LumpedRLC::Apply2Voltages()
+template <typename EngineType>
+void Engine_Ext_LumpedRLC::Apply2VoltagesImpl(EngineType* eng)
 {
 	unsigned int **pos = m_Op_Ext_RLC->v_RLC_pos;
 	int *dir = m_Op_Ext_RLC->v_RLC_dir;
@@ -113,31 +114,8 @@ void Engine_Ext_LumpedRLC::Apply2Voltages()
 
 
 	// Read engine calculated node voltage
-	switch (m_Eng->GetType())
-	{
-		case Engine::BASIC:
-		{
-			for (unsigned int pIdx = 0 ; pIdx < m_Op_Ext_RLC->RLC_count ; pIdx++)
-				v_Vdn[0][pIdx] = m_Eng->Engine::GetVolt(dir[pIdx],pos[0][pIdx],pos[1][pIdx],pos[2][pIdx]);
-
-			break;
-		}
-		case Engine::SSE:
-		{
-			Engine_sse* eng_sse = (Engine_sse*)m_Eng;
-			for (unsigned int pIdx = 0 ; pIdx < m_Op_Ext_RLC->RLC_count ; pIdx++)
-				v_Vdn[0][pIdx] = eng_sse->Engine_sse::GetVolt(dir[pIdx],pos[0][pIdx],pos[1][pIdx],pos[2][pIdx]);
-
-			break;
-		}
-		default:
-		{
-			for (unsigned int pIdx = 0 ; pIdx < m_Op_Ext_RLC->RLC_count ; pIdx++)
-				v_Vdn[0][pIdx] = m_Eng->GetVolt(dir[pIdx],pos[0][pIdx],pos[1][pIdx],pos[2][pIdx]);;
-
-			break;
-		}
-	}
+	for (unsigned int pIdx = 0 ; pIdx < m_Op_Ext_RLC->RLC_count ; pIdx++)
+		v_Vdn[0][pIdx] = eng->EngineType::GetVolt(dir[pIdx],pos[0][pIdx],pos[1][pIdx],pos[2][pIdx]);
 
 	// Post process: Calculate node voltage with respect to the lumped RLC auxilliary quantity, J
 	for (unsigned int pIdx = 0 ; pIdx < m_Op_Ext_RLC->RLC_count ; pIdx++)
@@ -162,34 +140,11 @@ void Engine_Ext_LumpedRLC::Apply2Voltages()
 
 
 	// Update node voltage
-	switch (m_Eng->GetType())
-	{
-		case Engine::BASIC:
-		{
-			for (unsigned int pIdx = 0 ; pIdx < m_Op_Ext_RLC->RLC_count ; pIdx++)
-				m_Eng->Engine::SetVolt(dir[pIdx],pos[0][pIdx],pos[1][pIdx],pos[2][pIdx],v_Vdn[0][pIdx]);
-
-			break;
-		}
-		case Engine::SSE:
-		{
-			Engine_sse* eng_sse = (Engine_sse*)m_Eng;
-			for (unsigned int pIdx = 0 ; pIdx < m_Op_Ext_RLC->RLC_count ; pIdx++)
-				eng_sse->Engine_sse::SetVolt(dir[pIdx],pos[0][pIdx],pos[1][pIdx],pos[2][pIdx],v_Vdn[0][pIdx]);
-
-			break;
-		}
-		default:
-		{
-			for (unsigned int pIdx = 0 ; pIdx < m_Op_Ext_RLC->RLC_count ; pIdx++)
-				m_Eng->SetVolt(dir[pIdx],pos[0][pIdx],pos[1][pIdx],pos[2][pIdx],v_Vdn[0][pIdx]);
-
-			break;
-		}
-	}
-
-
-	return;
+	for (unsigned int pIdx = 0 ; pIdx < m_Op_Ext_RLC->RLC_count ; pIdx++)
+		eng->EngineType::SetVolt(dir[pIdx],pos[0][pIdx],pos[1][pIdx],pos[2][pIdx],v_Vdn[0][pIdx]);
 }
 
-
+void Engine_Ext_LumpedRLC::Apply2Voltages()
+{
+	ENG_DISPATCH(Apply2VoltagesImpl);
+}

--- a/FDTD/extensions/engine_ext_lumpedRLC.h
+++ b/FDTD/extensions/engine_ext_lumpedRLC.h
@@ -21,6 +21,7 @@
 #include "engine_extension.h"
 #include "FDTD/engine.h"
 #include "FDTD/operator.h"
+#include "engine_extension_dispatcher.h"
 
 class Operator_Ext_LumpedRLC;
 
@@ -39,6 +40,9 @@ public:
 	virtual void Apply2Voltages();
 
 protected:
+	template <typename EngineType>
+	void Apply2VoltagesImpl(EngineType* eng);
+
 	Operator_Ext_LumpedRLC* m_Op_Ext_RLC;
 
 	// Auxilliary containers

--- a/FDTD/extensions/engine_ext_mur_abc.h
+++ b/FDTD/extensions/engine_ext_mur_abc.h
@@ -21,6 +21,7 @@
 #include "engine_extension.h"
 #include "FDTD/engine.h"
 #include "FDTD/operator.h"
+#include "engine_extension_dispatcher.h"
 
 class Operator_Ext_Mur_ABC;
 
@@ -40,6 +41,15 @@ public:
 	virtual void Apply2Voltages(int threadID);
 
 protected:
+	template <typename EngineType>
+	void DoPreVoltageUpdatesImpl(EngineType* eng, int threadID);
+
+	template <typename EngineType>
+	void DoPostVoltageUpdatesImpl(EngineType* eng, int threadID);
+
+	template <typename EngineType>
+	void Apply2VoltagesImpl(EngineType* eng, int threadID);
+
 	Operator_Ext_Mur_ABC* m_Op_mur;
 
 	inline bool IsActive() {if (m_Eng->GetNumberOfTimesteps()<m_start_TS) return false; return true;}

--- a/FDTD/extensions/engine_ext_upml.cpp
+++ b/FDTD/extensions/engine_ext_upml.cpp
@@ -54,8 +54,8 @@ void Engine_Ext_UPML::SetNumberOfThreads(int nrThread)
 		m_start.at(n) = m_start.at(n-1) + m_numX.at(n-1);
 }
 
-
-void Engine_Ext_UPML::DoPreVoltageUpdates(int threadID)
+template <typename EngineType>
+void Engine_Ext_UPML::DoPreVoltageUpdatesImpl(EngineType* eng, int threadID)
 {
 	if (m_Eng==NULL)
 		return;
@@ -66,215 +66,88 @@ void Engine_Ext_UPML::DoPreVoltageUpdates(int threadID)
 	unsigned int pos[3];
 	unsigned int loc_pos[3];
 	FDTD_FLOAT f_help;
-	switch (m_Eng->GetType())
+
+	for (unsigned int lineX=0; lineX<m_numX.at(threadID); ++lineX)
 	{
-	case Engine::BASIC:
+		loc_pos[0]=lineX+m_start.at(threadID);
+		pos[0] = loc_pos[0] + m_Op_UPML->m_StartPos[0];
+		for (loc_pos[1]=0; loc_pos[1]<m_Op_UPML->m_numLines[1]; ++loc_pos[1])
 		{
-			for (unsigned int lineX=0; lineX<m_numX.at(threadID); ++lineX)
+			pos[1] = loc_pos[1] + m_Op_UPML->m_StartPos[1];
+			for (loc_pos[2]=0; loc_pos[2]<m_Op_UPML->m_numLines[2]; ++loc_pos[2])
 			{
-				loc_pos[0]=lineX+m_start.at(threadID);
-				pos[0] = loc_pos[0] + m_Op_UPML->m_StartPos[0];
-				for (loc_pos[1]=0; loc_pos[1]<m_Op_UPML->m_numLines[1]; ++loc_pos[1])
-				{
-					pos[1] = loc_pos[1] + m_Op_UPML->m_StartPos[1];
-					for (loc_pos[2]=0; loc_pos[2]<m_Op_UPML->m_numLines[2]; ++loc_pos[2])
-					{
-						pos[2] = loc_pos[2] + m_Op_UPML->m_StartPos[2];
+				pos[2] = loc_pos[2] + m_Op_UPML->m_StartPos[2];
 
-						f_help = m_Op_UPML->vv[0][loc_pos[0]][loc_pos[1]][loc_pos[2]]   * m_Eng->Engine::GetVolt(0,pos)
-						         - m_Op_UPML->vvfo[0][loc_pos[0]][loc_pos[1]][loc_pos[2]] * volt_flux[0][loc_pos[0]][loc_pos[1]][loc_pos[2]];
-						m_Eng->Engine::SetVolt(0,pos, volt_flux[0][loc_pos[0]][loc_pos[1]][loc_pos[2]]);
-						volt_flux[0][loc_pos[0]][loc_pos[1]][loc_pos[2]] = f_help;
+				f_help = m_Op_UPML->vv[0][loc_pos[0]][loc_pos[1]][loc_pos[2]]   * eng->EngineType::GetVolt(0,pos)
+						 - m_Op_UPML->vvfo[0][loc_pos[0]][loc_pos[1]][loc_pos[2]] * volt_flux[0][loc_pos[0]][loc_pos[1]][loc_pos[2]];
+				eng->EngineType::SetVolt(0,pos, volt_flux[0][loc_pos[0]][loc_pos[1]][loc_pos[2]]);
+				volt_flux[0][loc_pos[0]][loc_pos[1]][loc_pos[2]] = f_help;
 
-						f_help = m_Op_UPML->vv[1][loc_pos[0]][loc_pos[1]][loc_pos[2]]   * m_Eng->Engine::GetVolt(1,pos)
-						         - m_Op_UPML->vvfo[1][loc_pos[0]][loc_pos[1]][loc_pos[2]] * volt_flux[1][loc_pos[0]][loc_pos[1]][loc_pos[2]];
-						m_Eng->Engine::SetVolt(1,pos, volt_flux[1][loc_pos[0]][loc_pos[1]][loc_pos[2]]);
-						volt_flux[1][loc_pos[0]][loc_pos[1]][loc_pos[2]] = f_help;
+				f_help = m_Op_UPML->vv[1][loc_pos[0]][loc_pos[1]][loc_pos[2]]   * eng->EngineType::GetVolt(1,pos)
+						 - m_Op_UPML->vvfo[1][loc_pos[0]][loc_pos[1]][loc_pos[2]] * volt_flux[1][loc_pos[0]][loc_pos[1]][loc_pos[2]];
+				eng->EngineType::SetVolt(1,pos, volt_flux[1][loc_pos[0]][loc_pos[1]][loc_pos[2]]);
+				volt_flux[1][loc_pos[0]][loc_pos[1]][loc_pos[2]] = f_help;
 
-						f_help = m_Op_UPML->vv[2][loc_pos[0]][loc_pos[1]][loc_pos[2]]   * m_Eng->Engine::GetVolt(2,pos)
-						         - m_Op_UPML->vvfo[2][loc_pos[0]][loc_pos[1]][loc_pos[2]] * volt_flux[2][loc_pos[0]][loc_pos[1]][loc_pos[2]];
-						m_Eng->Engine::SetVolt(2,pos, volt_flux[2][loc_pos[0]][loc_pos[1]][loc_pos[2]]);
-						volt_flux[2][loc_pos[0]][loc_pos[1]][loc_pos[2]] = f_help;
-					}
-				}
+				f_help = m_Op_UPML->vv[2][loc_pos[0]][loc_pos[1]][loc_pos[2]]   * eng->EngineType::GetVolt(2,pos)
+						 - m_Op_UPML->vvfo[2][loc_pos[0]][loc_pos[1]][loc_pos[2]] * volt_flux[2][loc_pos[0]][loc_pos[1]][loc_pos[2]];
+				eng->EngineType::SetVolt(2,pos, volt_flux[2][loc_pos[0]][loc_pos[1]][loc_pos[2]]);
+				volt_flux[2][loc_pos[0]][loc_pos[1]][loc_pos[2]] = f_help;
 			}
-			break;
-		}
-	case Engine::SSE:
-		{
-			Engine_sse* eng_sse = (Engine_sse*) m_Eng;
-			for (unsigned int lineX=0; lineX<m_numX.at(threadID); ++lineX)
-			{
-				loc_pos[0]=lineX+m_start.at(threadID);
-				pos[0] = loc_pos[0] + m_Op_UPML->m_StartPos[0];
-				for (loc_pos[1]=0; loc_pos[1]<m_Op_UPML->m_numLines[1]; ++loc_pos[1])
-				{
-					pos[1] = loc_pos[1] + m_Op_UPML->m_StartPos[1];
-					for (loc_pos[2]=0; loc_pos[2]<m_Op_UPML->m_numLines[2]; ++loc_pos[2])
-					{
-						pos[2] = loc_pos[2] + m_Op_UPML->m_StartPos[2];
-
-						f_help = m_Op_UPML->vv[0][loc_pos[0]][loc_pos[1]][loc_pos[2]]   * eng_sse->Engine_sse::GetVolt(0,pos)
-						         - m_Op_UPML->vvfo[0][loc_pos[0]][loc_pos[1]][loc_pos[2]] * volt_flux[0][loc_pos[0]][loc_pos[1]][loc_pos[2]];
-						eng_sse->Engine_sse::SetVolt(0,pos, volt_flux[0][loc_pos[0]][loc_pos[1]][loc_pos[2]]);
-						volt_flux[0][loc_pos[0]][loc_pos[1]][loc_pos[2]] = f_help;
-
-						f_help = m_Op_UPML->vv[1][loc_pos[0]][loc_pos[1]][loc_pos[2]]   * eng_sse->Engine_sse::GetVolt(1,pos)
-						         - m_Op_UPML->vvfo[1][loc_pos[0]][loc_pos[1]][loc_pos[2]] * volt_flux[1][loc_pos[0]][loc_pos[1]][loc_pos[2]];
-						eng_sse->Engine_sse::SetVolt(1,pos, volt_flux[1][loc_pos[0]][loc_pos[1]][loc_pos[2]]);
-						volt_flux[1][loc_pos[0]][loc_pos[1]][loc_pos[2]] = f_help;
-
-						f_help = m_Op_UPML->vv[2][loc_pos[0]][loc_pos[1]][loc_pos[2]]   * eng_sse->Engine_sse::GetVolt(2,pos)
-						         - m_Op_UPML->vvfo[2][loc_pos[0]][loc_pos[1]][loc_pos[2]] * volt_flux[2][loc_pos[0]][loc_pos[1]][loc_pos[2]];
-						eng_sse->Engine_sse::SetVolt(2,pos, volt_flux[2][loc_pos[0]][loc_pos[1]][loc_pos[2]]);
-						volt_flux[2][loc_pos[0]][loc_pos[1]][loc_pos[2]] = f_help;
-					}
-				}
-			}
-			break;
-		}
-	default:
-		{
-			for (unsigned int lineX=0; lineX<m_numX.at(threadID); ++lineX)
-			{
-				loc_pos[0]=lineX+m_start.at(threadID);
-				pos[0] = loc_pos[0] + m_Op_UPML->m_StartPos[0];
-				for (loc_pos[1]=0; loc_pos[1]<m_Op_UPML->m_numLines[1]; ++loc_pos[1])
-				{
-					pos[1] = loc_pos[1] + m_Op_UPML->m_StartPos[1];
-					for (loc_pos[2]=0; loc_pos[2]<m_Op_UPML->m_numLines[2]; ++loc_pos[2])
-					{
-						pos[2] = loc_pos[2] + m_Op_UPML->m_StartPos[2];
-
-						f_help = m_Op_UPML->vv[0][loc_pos[0]][loc_pos[1]][loc_pos[2]]   * m_Eng->GetVolt(0,pos)
-						         - m_Op_UPML->vvfo[0][loc_pos[0]][loc_pos[1]][loc_pos[2]] * volt_flux[0][loc_pos[0]][loc_pos[1]][loc_pos[2]];
-						m_Eng->SetVolt(0,pos, volt_flux[0][loc_pos[0]][loc_pos[1]][loc_pos[2]]);
-						volt_flux[0][loc_pos[0]][loc_pos[1]][loc_pos[2]] = f_help;
-
-						f_help = m_Op_UPML->vv[1][loc_pos[0]][loc_pos[1]][loc_pos[2]]   * m_Eng->GetVolt(1,pos)
-						         - m_Op_UPML->vvfo[1][loc_pos[0]][loc_pos[1]][loc_pos[2]] * volt_flux[1][loc_pos[0]][loc_pos[1]][loc_pos[2]];
-						m_Eng->SetVolt(1,pos, volt_flux[1][loc_pos[0]][loc_pos[1]][loc_pos[2]]);
-						volt_flux[1][loc_pos[0]][loc_pos[1]][loc_pos[2]] = f_help;
-
-						f_help = m_Op_UPML->vv[2][loc_pos[0]][loc_pos[1]][loc_pos[2]]   * m_Eng->GetVolt(2,pos)
-						         - m_Op_UPML->vvfo[2][loc_pos[0]][loc_pos[1]][loc_pos[2]] * volt_flux[2][loc_pos[0]][loc_pos[1]][loc_pos[2]];
-						m_Eng->SetVolt(2,pos, volt_flux[2][loc_pos[0]][loc_pos[1]][loc_pos[2]]);
-						volt_flux[2][loc_pos[0]][loc_pos[1]][loc_pos[2]] = f_help;
-					}
-				}
-			}
-			break;
 		}
 	}
+}
 
+void Engine_Ext_UPML::DoPreVoltageUpdates(int threadID)
+{
+	ENG_DISPATCH_ARGS(DoPreVoltageUpdatesImpl, threadID);
+}
+
+template <typename EngineType>
+void Engine_Ext_UPML::DoPostVoltageUpdatesImpl(EngineType* eng, int threadID)
+{
+	if (m_Eng==NULL)
+		return;
+	if (threadID>=m_NrThreads)
+		return;
+
+	unsigned int pos[3];
+	unsigned int loc_pos[3];
+	FDTD_FLOAT f_help;
+
+	for (unsigned int lineX=0; lineX<m_numX.at(threadID); ++lineX)
+	{
+		loc_pos[0]=lineX+m_start.at(threadID);
+		pos[0] = loc_pos[0] + m_Op_UPML->m_StartPos[0];
+		for (loc_pos[1]=0; loc_pos[1]<m_Op_UPML->m_numLines[1]; ++loc_pos[1])
+		{
+			pos[1] = loc_pos[1] + m_Op_UPML->m_StartPos[1];
+			for (loc_pos[2]=0; loc_pos[2]<m_Op_UPML->m_numLines[2]; ++loc_pos[2])
+			{
+				pos[2] = loc_pos[2] + m_Op_UPML->m_StartPos[2];
+
+				f_help = volt_flux[0][loc_pos[0]][loc_pos[1]][loc_pos[2]];
+				volt_flux[0][loc_pos[0]][loc_pos[1]][loc_pos[2]] = eng->EngineType::GetVolt(0,pos);
+				eng->EngineType::SetVolt(0,pos, f_help + m_Op_UPML->vvfn[0][loc_pos[0]][loc_pos[1]][loc_pos[2]] * volt_flux[0][loc_pos[0]][loc_pos[1]][loc_pos[2]]);
+
+				f_help = volt_flux[1][loc_pos[0]][loc_pos[1]][loc_pos[2]];
+				volt_flux[1][loc_pos[0]][loc_pos[1]][loc_pos[2]] = eng->EngineType::GetVolt(1,pos);
+				eng->EngineType::SetVolt(1,pos, f_help + m_Op_UPML->vvfn[1][loc_pos[0]][loc_pos[1]][loc_pos[2]] * volt_flux[1][loc_pos[0]][loc_pos[1]][loc_pos[2]]);
+
+				f_help = volt_flux[2][loc_pos[0]][loc_pos[1]][loc_pos[2]];
+				volt_flux[2][loc_pos[0]][loc_pos[1]][loc_pos[2]] = eng->EngineType::GetVolt(2,pos);
+				eng->EngineType::SetVolt(2,pos, f_help + m_Op_UPML->vvfn[2][loc_pos[0]][loc_pos[1]][loc_pos[2]] * volt_flux[2][loc_pos[0]][loc_pos[1]][loc_pos[2]]);
+			}
+		}
+	}
 }
 
 void Engine_Ext_UPML::DoPostVoltageUpdates(int threadID)
 {
-	if (m_Eng==NULL)
-		return;
-	if (threadID>=m_NrThreads)
-		return;
-
-	unsigned int pos[3];
-	unsigned int loc_pos[3];
-	FDTD_FLOAT f_help;
-
-	switch (m_Eng->GetType())
-	{
-	case Engine::BASIC:
-		{
-			for (unsigned int lineX=0; lineX<m_numX.at(threadID); ++lineX)
-			{
-				loc_pos[0]=lineX+m_start.at(threadID);
-				pos[0] = loc_pos[0] + m_Op_UPML->m_StartPos[0];
-				for (loc_pos[1]=0; loc_pos[1]<m_Op_UPML->m_numLines[1]; ++loc_pos[1])
-				{
-					pos[1] = loc_pos[1] + m_Op_UPML->m_StartPos[1];
-					for (loc_pos[2]=0; loc_pos[2]<m_Op_UPML->m_numLines[2]; ++loc_pos[2])
-					{
-						pos[2] = loc_pos[2] + m_Op_UPML->m_StartPos[2];
-
-						f_help = volt_flux[0][loc_pos[0]][loc_pos[1]][loc_pos[2]];
-						volt_flux[0][loc_pos[0]][loc_pos[1]][loc_pos[2]] = m_Eng->Engine::GetVolt(0,pos);
-						m_Eng->Engine::SetVolt(0,pos, f_help + m_Op_UPML->vvfn[0][loc_pos[0]][loc_pos[1]][loc_pos[2]] * volt_flux[0][loc_pos[0]][loc_pos[1]][loc_pos[2]]);
-
-						f_help = volt_flux[1][loc_pos[0]][loc_pos[1]][loc_pos[2]];
-						volt_flux[1][loc_pos[0]][loc_pos[1]][loc_pos[2]] = m_Eng->Engine::GetVolt(1,pos);
-						m_Eng->Engine::SetVolt(1,pos, f_help + m_Op_UPML->vvfn[1][loc_pos[0]][loc_pos[1]][loc_pos[2]] * volt_flux[1][loc_pos[0]][loc_pos[1]][loc_pos[2]]);
-
-						f_help = volt_flux[2][loc_pos[0]][loc_pos[1]][loc_pos[2]];
-						volt_flux[2][loc_pos[0]][loc_pos[1]][loc_pos[2]] = m_Eng->Engine::GetVolt(2,pos);
-						m_Eng->Engine::SetVolt(2,pos, f_help + m_Op_UPML->vvfn[2][loc_pos[0]][loc_pos[1]][loc_pos[2]] * volt_flux[2][loc_pos[0]][loc_pos[1]][loc_pos[2]]);
-					}
-				}
-			}
-			break;
-		}
-	case Engine::SSE:
-		{
-			Engine_sse* eng_sse = (Engine_sse*) m_Eng;
-			for (unsigned int lineX=0; lineX<m_numX.at(threadID); ++lineX)
-			{
-				loc_pos[0]=lineX+m_start.at(threadID);
-				pos[0] = loc_pos[0] + m_Op_UPML->m_StartPos[0];
-				for (loc_pos[1]=0; loc_pos[1]<m_Op_UPML->m_numLines[1]; ++loc_pos[1])
-				{
-					pos[1] = loc_pos[1] + m_Op_UPML->m_StartPos[1];
-					for (loc_pos[2]=0; loc_pos[2]<m_Op_UPML->m_numLines[2]; ++loc_pos[2])
-					{
-						pos[2] = loc_pos[2] + m_Op_UPML->m_StartPos[2];
-
-						f_help = volt_flux[0][loc_pos[0]][loc_pos[1]][loc_pos[2]];
-						volt_flux[0][loc_pos[0]][loc_pos[1]][loc_pos[2]] = eng_sse->Engine_sse::GetVolt(0,pos);
-						eng_sse->Engine_sse::SetVolt(0,pos, f_help + m_Op_UPML->vvfn[0][loc_pos[0]][loc_pos[1]][loc_pos[2]] * volt_flux[0][loc_pos[0]][loc_pos[1]][loc_pos[2]]);
-
-						f_help = volt_flux[1][loc_pos[0]][loc_pos[1]][loc_pos[2]];
-						volt_flux[1][loc_pos[0]][loc_pos[1]][loc_pos[2]] = eng_sse->Engine_sse::GetVolt(1,pos);
-						eng_sse->Engine_sse::SetVolt(1,pos, f_help + m_Op_UPML->vvfn[1][loc_pos[0]][loc_pos[1]][loc_pos[2]] * volt_flux[1][loc_pos[0]][loc_pos[1]][loc_pos[2]]);
-
-						f_help = volt_flux[2][loc_pos[0]][loc_pos[1]][loc_pos[2]];
-						volt_flux[2][loc_pos[0]][loc_pos[1]][loc_pos[2]] = eng_sse->Engine_sse::GetVolt(2,pos);
-						eng_sse->Engine_sse::SetVolt(2,pos, f_help + m_Op_UPML->vvfn[2][loc_pos[0]][loc_pos[1]][loc_pos[2]] * volt_flux[2][loc_pos[0]][loc_pos[1]][loc_pos[2]]);
-					}
-				}
-			}
-			break;
-		}
-	default:
-		{
-			for (unsigned int lineX=0; lineX<m_numX.at(threadID); ++lineX)
-			{
-				loc_pos[0]=lineX+m_start.at(threadID);
-				pos[0] = loc_pos[0] + m_Op_UPML->m_StartPos[0];
-				for (loc_pos[1]=0; loc_pos[1]<m_Op_UPML->m_numLines[1]; ++loc_pos[1])
-				{
-					pos[1] = loc_pos[1] + m_Op_UPML->m_StartPos[1];
-					for (loc_pos[2]=0; loc_pos[2]<m_Op_UPML->m_numLines[2]; ++loc_pos[2])
-					{
-						pos[2] = loc_pos[2] + m_Op_UPML->m_StartPos[2];
-
-						f_help = volt_flux[0][loc_pos[0]][loc_pos[1]][loc_pos[2]];
-						volt_flux[0][loc_pos[0]][loc_pos[1]][loc_pos[2]] = m_Eng->GetVolt(0,pos);
-						m_Eng->SetVolt(0,pos, f_help + m_Op_UPML->vvfn[0][loc_pos[0]][loc_pos[1]][loc_pos[2]] * volt_flux[0][loc_pos[0]][loc_pos[1]][loc_pos[2]]);
-
-						f_help = volt_flux[1][loc_pos[0]][loc_pos[1]][loc_pos[2]];
-						volt_flux[1][loc_pos[0]][loc_pos[1]][loc_pos[2]] = m_Eng->GetVolt(1,pos);
-						m_Eng->SetVolt(1,pos, f_help + m_Op_UPML->vvfn[1][loc_pos[0]][loc_pos[1]][loc_pos[2]] * volt_flux[1][loc_pos[0]][loc_pos[1]][loc_pos[2]]);
-
-						f_help = volt_flux[2][loc_pos[0]][loc_pos[1]][loc_pos[2]];
-						volt_flux[2][loc_pos[0]][loc_pos[1]][loc_pos[2]] = m_Eng->GetVolt(2,pos);
-						m_Eng->SetVolt(2,pos, f_help + m_Op_UPML->vvfn[2][loc_pos[0]][loc_pos[1]][loc_pos[2]] * volt_flux[2][loc_pos[0]][loc_pos[1]][loc_pos[2]]);
-					}
-				}
-			}
-			break;
-		}
-	}
-
+	ENG_DISPATCH_ARGS(DoPostVoltageUpdatesImpl, threadID);
 }
 
-void Engine_Ext_UPML::DoPreCurrentUpdates(int threadID)
+template <typename EngineType>
+void Engine_Ext_UPML::DoPreCurrentUpdatesImpl(EngineType* eng, int threadID)
 {
 	if (m_Eng==NULL)
 		return;
@@ -285,209 +158,82 @@ void Engine_Ext_UPML::DoPreCurrentUpdates(int threadID)
 	unsigned int loc_pos[3];
 	FDTD_FLOAT f_help;
 
-	switch (m_Eng->GetType())
+	for (unsigned int lineX=0; lineX<m_numX.at(threadID); ++lineX)
 	{
-	case Engine::BASIC:
+		loc_pos[0]=lineX+m_start.at(threadID);
+		pos[0] = loc_pos[0] + m_Op_UPML->m_StartPos[0];
+		for (loc_pos[1]=0; loc_pos[1]<m_Op_UPML->m_numLines[1]; ++loc_pos[1])
 		{
-			for (unsigned int lineX=0; lineX<m_numX.at(threadID); ++lineX)
+			pos[1] = loc_pos[1] + m_Op_UPML->m_StartPos[1];
+			for (loc_pos[2]=0; loc_pos[2]<m_Op_UPML->m_numLines[2]; ++loc_pos[2])
 			{
-				loc_pos[0]=lineX+m_start.at(threadID);
-				pos[0] = loc_pos[0] + m_Op_UPML->m_StartPos[0];
-				for (loc_pos[1]=0; loc_pos[1]<m_Op_UPML->m_numLines[1]; ++loc_pos[1])
-				{
-					pos[1] = loc_pos[1] + m_Op_UPML->m_StartPos[1];
-					for (loc_pos[2]=0; loc_pos[2]<m_Op_UPML->m_numLines[2]; ++loc_pos[2])
-					{
-						pos[2] = loc_pos[2] + m_Op_UPML->m_StartPos[2];
+				pos[2] = loc_pos[2] + m_Op_UPML->m_StartPos[2];
 
-						f_help = m_Op_UPML->ii[0][loc_pos[0]][loc_pos[1]][loc_pos[2]]   * m_Eng->Engine::GetCurr(0,pos)
-						         - m_Op_UPML->iifo[0][loc_pos[0]][loc_pos[1]][loc_pos[2]] * curr_flux[0][loc_pos[0]][loc_pos[1]][loc_pos[2]];
-						m_Eng->Engine::SetCurr(0,pos, curr_flux[0][loc_pos[0]][loc_pos[1]][loc_pos[2]]);
-						curr_flux[0][loc_pos[0]][loc_pos[1]][loc_pos[2]] = f_help;
+				f_help = m_Op_UPML->ii[0][loc_pos[0]][loc_pos[1]][loc_pos[2]]   * eng->EngineType::GetCurr(0,pos)
+						 - m_Op_UPML->iifo[0][loc_pos[0]][loc_pos[1]][loc_pos[2]] * curr_flux[0][loc_pos[0]][loc_pos[1]][loc_pos[2]];
+				eng->EngineType::SetCurr(0,pos, curr_flux[0][loc_pos[0]][loc_pos[1]][loc_pos[2]]);
+				curr_flux[0][loc_pos[0]][loc_pos[1]][loc_pos[2]] = f_help;
 
-						f_help = m_Op_UPML->ii[1][loc_pos[0]][loc_pos[1]][loc_pos[2]]   * m_Eng->Engine::GetCurr(1,pos)
-						         - m_Op_UPML->iifo[1][loc_pos[0]][loc_pos[1]][loc_pos[2]] * curr_flux[1][loc_pos[0]][loc_pos[1]][loc_pos[2]];
-						m_Eng->Engine::SetCurr(1,pos, curr_flux[1][loc_pos[0]][loc_pos[1]][loc_pos[2]]);
-						curr_flux[1][loc_pos[0]][loc_pos[1]][loc_pos[2]] = f_help;
+				f_help = m_Op_UPML->ii[1][loc_pos[0]][loc_pos[1]][loc_pos[2]]   * eng->EngineType::GetCurr(1,pos)
+						 - m_Op_UPML->iifo[1][loc_pos[0]][loc_pos[1]][loc_pos[2]] * curr_flux[1][loc_pos[0]][loc_pos[1]][loc_pos[2]];
+				eng->EngineType::SetCurr(1,pos, curr_flux[1][loc_pos[0]][loc_pos[1]][loc_pos[2]]);
+				curr_flux[1][loc_pos[0]][loc_pos[1]][loc_pos[2]] = f_help;
 
-						f_help = m_Op_UPML->ii[2][loc_pos[0]][loc_pos[1]][loc_pos[2]]   * m_Eng->Engine::GetCurr(2,pos)
-						         - m_Op_UPML->iifo[2][loc_pos[0]][loc_pos[1]][loc_pos[2]] * curr_flux[2][loc_pos[0]][loc_pos[1]][loc_pos[2]];
-						m_Eng->Engine::SetCurr(2,pos, curr_flux[2][loc_pos[0]][loc_pos[1]][loc_pos[2]]);
-						curr_flux[2][loc_pos[0]][loc_pos[1]][loc_pos[2]] = f_help;
-					}
-				}
+				f_help = m_Op_UPML->ii[2][loc_pos[0]][loc_pos[1]][loc_pos[2]]   * eng->EngineType::GetCurr(2,pos)
+						 - m_Op_UPML->iifo[2][loc_pos[0]][loc_pos[1]][loc_pos[2]] * curr_flux[2][loc_pos[0]][loc_pos[1]][loc_pos[2]];
+				eng->EngineType::SetCurr(2,pos, curr_flux[2][loc_pos[0]][loc_pos[1]][loc_pos[2]]);
+				curr_flux[2][loc_pos[0]][loc_pos[1]][loc_pos[2]] = f_help;
+
 			}
-			break;
 		}
-	case Engine::SSE:
+	}
+}
+
+void Engine_Ext_UPML::DoPreCurrentUpdates(int threadID)
+{
+	ENG_DISPATCH_ARGS(DoPreCurrentUpdatesImpl, threadID);
+}
+
+template <typename EngineType>
+void Engine_Ext_UPML::DoPostCurrentUpdatesImpl(EngineType* eng, int threadID)
+{
+	if (m_Eng==NULL)
+		return;
+	if (threadID>=m_NrThreads)
+		return;
+
+	unsigned int pos[3];
+	unsigned int loc_pos[3];
+	FDTD_FLOAT f_help;
+
+	for (unsigned int lineX=0; lineX<m_numX.at(threadID); ++lineX)
+	{
+		loc_pos[0]=lineX+m_start.at(threadID);
+		pos[0] = loc_pos[0] + m_Op_UPML->m_StartPos[0];
+		for (loc_pos[1]=0; loc_pos[1]<m_Op_UPML->m_numLines[1]; ++loc_pos[1])
 		{
-			Engine_sse* eng_sse = (Engine_sse*) m_Eng;
-			for (unsigned int lineX=0; lineX<m_numX.at(threadID); ++lineX)
+			pos[1] = loc_pos[1] + m_Op_UPML->m_StartPos[1];
+			for (loc_pos[2]=0; loc_pos[2]<m_Op_UPML->m_numLines[2]; ++loc_pos[2])
 			{
-				loc_pos[0]=lineX+m_start.at(threadID);
-				pos[0] = loc_pos[0] + m_Op_UPML->m_StartPos[0];
-				for (loc_pos[1]=0; loc_pos[1]<m_Op_UPML->m_numLines[1]; ++loc_pos[1])
-				{
-					pos[1] = loc_pos[1] + m_Op_UPML->m_StartPos[1];
-					for (loc_pos[2]=0; loc_pos[2]<m_Op_UPML->m_numLines[2]; ++loc_pos[2])
-					{
-						pos[2] = loc_pos[2] + m_Op_UPML->m_StartPos[2];
+				pos[2] = loc_pos[2] + m_Op_UPML->m_StartPos[2];
 
-						f_help = m_Op_UPML->ii[0][loc_pos[0]][loc_pos[1]][loc_pos[2]]   * eng_sse->Engine_sse::GetCurr(0,pos)
-						         - m_Op_UPML->iifo[0][loc_pos[0]][loc_pos[1]][loc_pos[2]] * curr_flux[0][loc_pos[0]][loc_pos[1]][loc_pos[2]];
-						eng_sse->Engine_sse::SetCurr(0,pos, curr_flux[0][loc_pos[0]][loc_pos[1]][loc_pos[2]]);
-						curr_flux[0][loc_pos[0]][loc_pos[1]][loc_pos[2]] = f_help;
+				f_help = curr_flux[0][loc_pos[0]][loc_pos[1]][loc_pos[2]];
+				curr_flux[0][loc_pos[0]][loc_pos[1]][loc_pos[2]] = eng->EngineType::GetCurr(0,pos);
+				eng->EngineType::SetCurr(0,pos, f_help + m_Op_UPML->iifn[0][loc_pos[0]][loc_pos[1]][loc_pos[2]] * curr_flux[0][loc_pos[0]][loc_pos[1]][loc_pos[2]]);
 
-						f_help = m_Op_UPML->ii[1][loc_pos[0]][loc_pos[1]][loc_pos[2]]   * eng_sse->Engine_sse::GetCurr(1,pos)
-						         - m_Op_UPML->iifo[1][loc_pos[0]][loc_pos[1]][loc_pos[2]] * curr_flux[1][loc_pos[0]][loc_pos[1]][loc_pos[2]];
-						eng_sse->Engine_sse::SetCurr(1,pos, curr_flux[1][loc_pos[0]][loc_pos[1]][loc_pos[2]]);
-						curr_flux[1][loc_pos[0]][loc_pos[1]][loc_pos[2]] = f_help;
+				f_help = curr_flux[1][loc_pos[0]][loc_pos[1]][loc_pos[2]];
+				curr_flux[1][loc_pos[0]][loc_pos[1]][loc_pos[2]] = eng->EngineType::GetCurr(1,pos);
+				eng->EngineType::SetCurr(1,pos, f_help + m_Op_UPML->iifn[1][loc_pos[0]][loc_pos[1]][loc_pos[2]] * curr_flux[1][loc_pos[0]][loc_pos[1]][loc_pos[2]]);
 
-						f_help = m_Op_UPML->ii[2][loc_pos[0]][loc_pos[1]][loc_pos[2]]   * eng_sse->Engine_sse::GetCurr(2,pos)
-						         - m_Op_UPML->iifo[2][loc_pos[0]][loc_pos[1]][loc_pos[2]] * curr_flux[2][loc_pos[0]][loc_pos[1]][loc_pos[2]];
-						eng_sse->Engine_sse::SetCurr(2,pos, curr_flux[2][loc_pos[0]][loc_pos[1]][loc_pos[2]]);
-						curr_flux[2][loc_pos[0]][loc_pos[1]][loc_pos[2]] = f_help;
-
-					}
-				}
+				f_help = curr_flux[2][loc_pos[0]][loc_pos[1]][loc_pos[2]];
+				curr_flux[2][loc_pos[0]][loc_pos[1]][loc_pos[2]] = eng->EngineType::GetCurr(2,pos);
+				eng->EngineType::SetCurr(2,pos, f_help + m_Op_UPML->iifn[2][loc_pos[0]][loc_pos[1]][loc_pos[2]] * curr_flux[2][loc_pos[0]][loc_pos[1]][loc_pos[2]]);
 			}
-			break;
-		}
-	default:
-		{
-			for (unsigned int lineX=0; lineX<m_numX.at(threadID); ++lineX)
-			{
-				loc_pos[0]=lineX+m_start.at(threadID);
-				pos[0] = loc_pos[0] + m_Op_UPML->m_StartPos[0];
-				for (loc_pos[1]=0; loc_pos[1]<m_Op_UPML->m_numLines[1]; ++loc_pos[1])
-				{
-					pos[1] = loc_pos[1] + m_Op_UPML->m_StartPos[1];
-					for (loc_pos[2]=0; loc_pos[2]<m_Op_UPML->m_numLines[2]; ++loc_pos[2])
-					{
-						pos[2] = loc_pos[2] + m_Op_UPML->m_StartPos[2];
-
-						f_help = m_Op_UPML->ii[0][loc_pos[0]][loc_pos[1]][loc_pos[2]]   * m_Eng->GetCurr(0,pos)
-						         - m_Op_UPML->iifo[0][loc_pos[0]][loc_pos[1]][loc_pos[2]] * curr_flux[0][loc_pos[0]][loc_pos[1]][loc_pos[2]];
-						m_Eng->SetCurr(0,pos, curr_flux[0][loc_pos[0]][loc_pos[1]][loc_pos[2]]);
-						curr_flux[0][loc_pos[0]][loc_pos[1]][loc_pos[2]] = f_help;
-
-						f_help = m_Op_UPML->ii[1][loc_pos[0]][loc_pos[1]][loc_pos[2]]   * m_Eng->GetCurr(1,pos)
-						         - m_Op_UPML->iifo[1][loc_pos[0]][loc_pos[1]][loc_pos[2]] * curr_flux[1][loc_pos[0]][loc_pos[1]][loc_pos[2]];
-						m_Eng->SetCurr(1,pos, curr_flux[1][loc_pos[0]][loc_pos[1]][loc_pos[2]]);
-						curr_flux[1][loc_pos[0]][loc_pos[1]][loc_pos[2]] = f_help;
-
-						f_help = m_Op_UPML->ii[2][loc_pos[0]][loc_pos[1]][loc_pos[2]]   * m_Eng->GetCurr(2,pos)
-						         - m_Op_UPML->iifo[2][loc_pos[0]][loc_pos[1]][loc_pos[2]] * curr_flux[2][loc_pos[0]][loc_pos[1]][loc_pos[2]];
-						m_Eng->SetCurr(2,pos, curr_flux[2][loc_pos[0]][loc_pos[1]][loc_pos[2]]);
-						curr_flux[2][loc_pos[0]][loc_pos[1]][loc_pos[2]] = f_help;
-					}
-				}
-			}
-			break;
 		}
 	}
 }
 
 void Engine_Ext_UPML::DoPostCurrentUpdates(int threadID)
 {
-	if (m_Eng==NULL)
-		return;
-	if (threadID>=m_NrThreads)
-		return;
-
-	unsigned int pos[3];
-	unsigned int loc_pos[3];
-	FDTD_FLOAT f_help;
-
-	switch (m_Eng->GetType())
-	{
-	case Engine::BASIC:
-		{
-			for (unsigned int lineX=0; lineX<m_numX.at(threadID); ++lineX)
-			{
-				loc_pos[0]=lineX+m_start.at(threadID);
-				pos[0] = loc_pos[0] + m_Op_UPML->m_StartPos[0];
-				for (loc_pos[1]=0; loc_pos[1]<m_Op_UPML->m_numLines[1]; ++loc_pos[1])
-				{
-					pos[1] = loc_pos[1] + m_Op_UPML->m_StartPos[1];
-					for (loc_pos[2]=0; loc_pos[2]<m_Op_UPML->m_numLines[2]; ++loc_pos[2])
-					{
-						pos[2] = loc_pos[2] + m_Op_UPML->m_StartPos[2];
-
-						f_help = curr_flux[0][loc_pos[0]][loc_pos[1]][loc_pos[2]];
-						curr_flux[0][loc_pos[0]][loc_pos[1]][loc_pos[2]] = m_Eng->Engine::GetCurr(0,pos);
-						m_Eng->Engine::SetCurr(0,pos, f_help + m_Op_UPML->iifn[0][loc_pos[0]][loc_pos[1]][loc_pos[2]] * curr_flux[0][loc_pos[0]][loc_pos[1]][loc_pos[2]]);
-
-						f_help = curr_flux[1][loc_pos[0]][loc_pos[1]][loc_pos[2]];
-						curr_flux[1][loc_pos[0]][loc_pos[1]][loc_pos[2]] = m_Eng->Engine::GetCurr(1,pos);
-						m_Eng->Engine::SetCurr(1,pos, f_help + m_Op_UPML->iifn[1][loc_pos[0]][loc_pos[1]][loc_pos[2]] * curr_flux[1][loc_pos[0]][loc_pos[1]][loc_pos[2]]);
-
-						f_help = curr_flux[2][loc_pos[0]][loc_pos[1]][loc_pos[2]];
-						curr_flux[2][loc_pos[0]][loc_pos[1]][loc_pos[2]] = m_Eng->Engine::GetCurr(2,pos);
-						m_Eng->Engine::SetCurr(2,pos, f_help + m_Op_UPML->iifn[2][loc_pos[0]][loc_pos[1]][loc_pos[2]] * curr_flux[2][loc_pos[0]][loc_pos[1]][loc_pos[2]]);
-					}
-				}
-			}
-			break;
-		}
-	case Engine::SSE:
-		{
-			Engine_sse* eng_sse = (Engine_sse*) m_Eng;
-			for (unsigned int lineX=0; lineX<m_numX.at(threadID); ++lineX)
-			{
-				loc_pos[0]=lineX+m_start.at(threadID);
-				pos[0] = loc_pos[0] + m_Op_UPML->m_StartPos[0];
-				for (loc_pos[1]=0; loc_pos[1]<m_Op_UPML->m_numLines[1]; ++loc_pos[1])
-				{
-					pos[1] = loc_pos[1] + m_Op_UPML->m_StartPos[1];
-					for (loc_pos[2]=0; loc_pos[2]<m_Op_UPML->m_numLines[2]; ++loc_pos[2])
-					{
-						pos[2] = loc_pos[2] + m_Op_UPML->m_StartPos[2];
-
-						f_help = curr_flux[0][loc_pos[0]][loc_pos[1]][loc_pos[2]];
-						curr_flux[0][loc_pos[0]][loc_pos[1]][loc_pos[2]] = eng_sse->Engine_sse::GetCurr(0,pos);
-						eng_sse->Engine_sse::SetCurr(0,pos, f_help + m_Op_UPML->iifn[0][loc_pos[0]][loc_pos[1]][loc_pos[2]] * curr_flux[0][loc_pos[0]][loc_pos[1]][loc_pos[2]]);
-
-						f_help = curr_flux[1][loc_pos[0]][loc_pos[1]][loc_pos[2]];
-						curr_flux[1][loc_pos[0]][loc_pos[1]][loc_pos[2]] = eng_sse->Engine_sse::GetCurr(1,pos);
-						eng_sse->Engine_sse::SetCurr(1,pos, f_help + m_Op_UPML->iifn[1][loc_pos[0]][loc_pos[1]][loc_pos[2]] * curr_flux[1][loc_pos[0]][loc_pos[1]][loc_pos[2]]);
-
-						f_help = curr_flux[2][loc_pos[0]][loc_pos[1]][loc_pos[2]];
-						curr_flux[2][loc_pos[0]][loc_pos[1]][loc_pos[2]] = eng_sse->Engine_sse::GetCurr(2,pos);
-						eng_sse->Engine_sse::SetCurr(2,pos, f_help + m_Op_UPML->iifn[2][loc_pos[0]][loc_pos[1]][loc_pos[2]] * curr_flux[2][loc_pos[0]][loc_pos[1]][loc_pos[2]]);
-					}
-				}
-			}
-			break;
-		}
-	default:
-		{
-			for (unsigned int lineX=0; lineX<m_numX.at(threadID); ++lineX)
-			{
-				loc_pos[0]=lineX+m_start.at(threadID);
-				pos[0] = loc_pos[0] + m_Op_UPML->m_StartPos[0];
-				for (loc_pos[1]=0; loc_pos[1]<m_Op_UPML->m_numLines[1]; ++loc_pos[1])
-				{
-					pos[1] = loc_pos[1] + m_Op_UPML->m_StartPos[1];
-					for (loc_pos[2]=0; loc_pos[2]<m_Op_UPML->m_numLines[2]; ++loc_pos[2])
-					{
-						pos[2] = loc_pos[2] + m_Op_UPML->m_StartPos[2];
-
-						f_help = curr_flux[0][loc_pos[0]][loc_pos[1]][loc_pos[2]];
-						curr_flux[0][loc_pos[0]][loc_pos[1]][loc_pos[2]] = m_Eng->GetCurr(0,pos);
-						m_Eng->SetCurr(0,pos, f_help + m_Op_UPML->iifn[0][loc_pos[0]][loc_pos[1]][loc_pos[2]] * curr_flux[0][loc_pos[0]][loc_pos[1]][loc_pos[2]]);
-
-						f_help = curr_flux[1][loc_pos[0]][loc_pos[1]][loc_pos[2]];
-						curr_flux[1][loc_pos[0]][loc_pos[1]][loc_pos[2]] = m_Eng->GetCurr(1,pos);
-						m_Eng->SetCurr(1,pos, f_help + m_Op_UPML->iifn[1][loc_pos[0]][loc_pos[1]][loc_pos[2]] * curr_flux[1][loc_pos[0]][loc_pos[1]][loc_pos[2]]);
-
-						f_help = curr_flux[2][loc_pos[0]][loc_pos[1]][loc_pos[2]];
-						curr_flux[2][loc_pos[0]][loc_pos[1]][loc_pos[2]] = m_Eng->GetCurr(2,pos);
-						m_Eng->SetCurr(2,pos, f_help + m_Op_UPML->iifn[2][loc_pos[0]][loc_pos[1]][loc_pos[2]] * curr_flux[2][loc_pos[0]][loc_pos[1]][loc_pos[2]]);
-					}
-				}
-			}
-			break;
-		}
-	}
+	ENG_DISPATCH_ARGS(DoPostCurrentUpdatesImpl, threadID);
 }

--- a/FDTD/extensions/engine_ext_upml.h
+++ b/FDTD/extensions/engine_ext_upml.h
@@ -21,6 +21,7 @@
 #include "engine_extension.h"
 #include "FDTD/engine.h"
 #include "FDTD/operator.h"
+#include "engine_extension_dispatcher.h"
 
 class Operator_Ext_UPML;
 
@@ -43,6 +44,18 @@ public:
 	virtual void DoPostCurrentUpdates(int threadID);
 
 protected:
+	template <typename EngineType>
+	void DoPreVoltageUpdatesImpl(EngineType* eng, int threadID);
+
+	template <typename EngineType>
+	void DoPostVoltageUpdatesImpl(EngineType* eng, int threadID);
+
+	template <typename EngineType>
+	void DoPreCurrentUpdatesImpl(EngineType* eng, int threadID);
+
+	template <typename EngineType>
+	void DoPostCurrentUpdatesImpl(EngineType* eng, int threadID);
+
 	Operator_Ext_UPML* m_Op_UPML;
 
 	vector<unsigned int> m_start;

--- a/FDTD/extensions/engine_extension_dispatcher.h
+++ b/FDTD/extensions/engine_extension_dispatcher.h
@@ -1,0 +1,90 @@
+/*
+*	Copyright (C) 2024 Yifeng Li <tomli@tomli.me>
+*	Copyright (C) 2011 Thorsten Liebig (Thorsten.Liebig@gmx.de)
+*
+*	This program is free software: you can redistribute it and/or modify
+*	it under the terms of the GNU General Public License as published by
+*	the Free Software Foundation, either version 3 of the License, or
+*	(at your option) any later version.
+*
+*	This program is distributed in the hope that it will be useful,
+*	but WITHOUT ANY WARRANTY; without even the implied warranty of
+*	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*	GNU General Public License for more details.
+*
+*	You should have received a copy of the GNU General Public License
+*	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef ENGINE_EXTENSION_DISPATCHER_H
+#define ENGINE_EXTENSION_DISPATCHER_H
+
+#include "FDTD/engine.h"
+#include "FDTD/engine_sse.h"
+
+// In openEMS, all extensions are subclasses from the abstract Engine_Extension
+// to implement features like Engine_Extension::Apply2Voltages(). When an
+// Engine_Extension is created, it accepts a pointer to Engine. Simulation data
+// is taken from the Engine using virtual functions like Engine::GetVolt(). This
+// allows each Engine_Extension to work on all engines without consider their
+// underlying data format.
+//
+// But this architecture created a serious performance problem: access to every
+// cell requires a virtual function call, and performance was extremely low.
+// As a workaround, each extension has the same simulation code repeated many
+// times using non-virtual subclass engine functions in a big if/else check,
+// e.g. 2 different Apply2Voltages(), one calls Engine::GetVolt(), another calls
+// Engine_sse::GetVolt(). This led to code duplication and poor readability.
+//
+// This header solves the problem by the macro ENG_DISPATCH. Now within each
+// extension, features are first written as macros like:
+//
+//     Apply2VoltagesImpl<Engine>(Engine*)
+//
+// which are used internally by:
+//
+//     Apply2Voltages()
+//
+// by calling:
+//
+//     ENG_DISPATCH(Apply2VoltagesImpl)
+//     ENG_DISPATCH_ARGS(Apply2VoltagesImpl, arg1, arg2, ...)
+//
+// This is not pretty but it significantly reduces code duplication.
+//
+// In the future, all Extensions should probably be eventually converted be
+// templates.
+
+#define ENG_DISPATCH(impl) \
+	switch (m_Eng->GetType()) \
+	{ \
+	case Engine::SSE: \
+		(this)->template impl<Engine_sse>((Engine_sse*) m_Eng); \
+		break; \
+	case Engine::BASIC: \
+		(this)->template impl<Engine>((Engine*) m_Eng); \
+		break; \
+	default: \
+		/* requires change here if a new engine is added. */ \
+		throw std::runtime_error( \
+		    "Engine_Extension_Dispatcher: unknown engine!" \
+		); \
+	}
+
+#define ENG_DISPATCH_ARGS(impl, ...) \
+	switch (m_Eng->GetType()) \
+	{ \
+	case Engine::SSE: \
+		(this)->template impl<Engine_sse>((Engine_sse*) m_Eng, __VA_ARGS__); \
+		break; \
+	case Engine::BASIC: \
+		(this)->template impl<Engine>((Engine*) m_Eng, __VA_ARGS__); \
+		break; \
+	default: \
+		/* requires change here if a new engine is added. */ \
+		throw std::runtime_error( \
+		    "Engine_Extension_Dispatcher: unknown engine!" \
+		); \
+	}
+
+#endif // ENGINE_EXTENSION_DISPATCHER_H


### PR DESCRIPTION
In openEMS, all extensions are subclasses from the abstract `Engine_Extension` to implement features like `Engine_Extension::Apply2Voltages()`. When an `Engine_Extension` is created, it accepts a pointer to `Engine`. Simulation data is taken from the `Engine` using virtual functions like `Engine::GetVolt()`.

Because virtual functions prevent the compiler from inlining the code, in order to select the non-virtual functions, each extension repeats the same simulation code repeated many times using non-virtual subclass engine functions in a big if/else check, e.g. 2 different `Apply2Voltages()`, one calls `Engine::GetVolt()`, another calls `Engine_sse::GetVolt()`. This led to code duplication and poor readability.

I found it's extremely difficult to do any development within these Extensions due to the code duplication problem. I've already tried 2 solutions:

1. Convert all `Engine_Extension` classes to a template `Engine_Extension<typename Engine>`
2. Convert the `Engine_Extension` class into a static [Curiously Recurring Template Pattern](https://en.wikipedia.org/wiki/Curiously_recurring_template_pattern) (CRTP)

while these solutions are cleaner, but I found the change required is too disruptive. What we need is a stop-gap solution for now, thus, I decide to add a new helper macro called `ENG_DISPATCH`. Now within each extension, features are first written as macros like:
    
    Apply2VoltagesImpl<Engine>(Engine*)
    
which are used internally by:
    
    Apply2Voltages()
    
by calling:
    
    ENG_DISPATCH(Apply2VoltagesImpl)
    // or ENG_THREAD_DISPATCH(Apply2VoltagesImpl, threadId)
    
This is not pretty but it significantly reduces code duplication. Using this macro, it allows me to remove 917 lines of code and would significantly simplify future programming, which will be implemented later this year.

In the long run, the proper solution should probably be converting all Extensions classes to templates. But that is left for the future.