### PR TITLE
Completely Rewrite Command-Line Argument Parsing, and Support Passing All Arguments via Python

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,6 +127,7 @@ find_package(Boost 1.46 COMPONENTS
   date_time
   serialization
   chrono
+  program_options
   REQUIRED
 )
 message(STATUS "Boost_INCLUDE_DIRS: ${Boost_INCLUDE_DIRS}")

--- a/main.cpp
+++ b/main.cpp
@@ -36,7 +36,7 @@
 
 using namespace std;
 
-int main(int argc, char *argv[])
+int main(int argc, const char* argv[])
 {
 #ifdef MPI_SUPPORT
 	//init MPI
@@ -54,18 +54,11 @@ int main(int argc, char *argv[])
 
 	if (argc<=1)
 	{
-		openEMS::showUsage();
+		FDTD.showUsage();
 		exit(-1);
 	}
 
-	if (argc>=3)
-	{
-		for (int n=2; n<argc; ++n)
-		{
-			if ( (!FDTD.parseCommandLineArgument(argv[n])) && (!g_settings.parseCommandLineArgument(argv[n])))
-				cout << "openEMS - unknown argument: " << argv[n] << endl;
-		}
-	}
+	g_settings.parseCommandLineArguments(argc, argv);
 
 	int EC = FDTD.ParseFDTDSetup(argv[1]);
 	if(!EC) {

--- a/openems.h
+++ b/openems.h
@@ -27,6 +27,7 @@
 #include <time.h>
 #include <vector>
 
+#include <boost/program_options.hpp>
 #include "openems_global.h"
 
 #define __OPENEMS_STAT_FILE__ "openEMS_stats.txt"
@@ -51,8 +52,8 @@ public:
 	openEMS();
 	virtual ~openEMS();
 
-	virtual bool parseCommandLineArgument( const char *argv );
-	static void showUsage();
+	boost::program_options::options_description optionDesc();
+	virtual void showUsage();
 
 	bool ParseFDTDSetup(std::string file);
 	virtual bool Parse_XML_FDTDSetup(TiXmlElement* openEMSxml);
@@ -75,6 +76,9 @@ public:
 	void SetTimeStep(double val) {m_TS=val;}
 	void SetTimeStepFactor(double val) {m_TS_fac=val;}
 	void SetMaxTime(double val) {m_maxTime=val;}
+
+	// used by Python binding when running as a shared library
+	void SetLibraryArguments(std::vector<std::string> allOptions);
 
 	void SetNumberOfThreads(int val);
 
@@ -116,6 +120,8 @@ public:
 	void SetVerboseLevel(int level);
 
 protected:
+	void collectCommandLineArguments();
+
 	bool CylinderCoords;
 	std::vector<double> m_CC_MultiGrid;
 

--- a/python/openEMS/openEMS.pxd
+++ b/python/openEMS/openEMS.pxd
@@ -17,6 +17,7 @@
 #
 
 from libcpp.string cimport string
+from libcpp.vector cimport vector
 from libcpp cimport bool
 
 from CSXCAD.CSXCAD cimport _ContinuousStructure, ContinuousStructure
@@ -39,7 +40,7 @@ cdef extern from "openEMS/openems.h":
         void SetTimeStepFactor(double val)
         void SetMaxTime(double val)
 
-        void SetNumberOfThreads(int val)
+        void SetLibraryArguments(vector[string] allOptions) except +
 
         void Set_BC_Type(int idx, int _type)
         int Get_BC_Type(int idx)
@@ -54,13 +55,6 @@ cdef extern from "openEMS/openems.h":
         void SetCustomExcite(string _str, double f0, double fmax)
 
         void SetAbort(bool val)
-
-        void SetVerboseLevel(int level)
-        void DebugMaterial() nogil
-        void DebugPEC()      nogil
-        void DebugOperator() nogil
-        void DebugBox()      nogil
-        void DebugCSX()      nogil
 
         int SetupFDTD() nogil
         void RunFDTD()  nogil

--- a/python/openEMS/openEMS.pyx
+++ b/python/openEMS/openEMS.pyx
@@ -458,8 +458,25 @@ cdef class openEMS:
                     continue
                 grid.AddLine(n, hint[n])
 
-    def Run(self, sim_path, cleanup=False,setup_only=False, debug_material=False, debug_pec=False,
-            debug_operator=False, debug_boxes=False, debug_csx=False, verbose=None, **kw):
+    def _SetLibraryArguments(self, arguments):
+        allOptions = []
+
+        for key, val in arguments.items():
+            key = key.replace("_", "-")
+            key = key.replace("setup-only", "no-simulation")
+
+            # boolean options are implicit
+            if val and (val is not True) and (val is not False):
+                opt = "%s=%s" % (key, val)
+            else:
+                opt = "%s" % key
+
+            allOptions.append(opt.encode("UTF-8"))
+
+        cdef vector[string] allOptionsBuffer = allOptions
+        self.thisptr.SetLibraryArguments(allOptionsBuffer)
+
+    def Run(self, sim_path, cleanup=False, setup_only=False, **kw):
         """ Run(sim_path, cleanup=False, setup_only=False, verbose=None)
 
         Run the openEMS FDTD simulation.
@@ -467,10 +484,27 @@ cdef class openEMS:
         :param sim_path: str -- path to run in and create result data
         :param cleanup: bool -- remove existing sim_path to cleanup old results
         :param setup_only: bool -- only perform FDTD setup, do not run simulation
-        :param verbose: int -- set the openEMS verbosity level 0..3
 
-        Additional keyword parameter:
-        :param numThreads: int -- set the number of threads (default 0 --> max)
+        One can also pass almost all command-line options supported by the main
+        openEMS executable via keyword parameters (replace dashes with
+        underscores). Supported options may vary from versions to versions,
+        see `./openEMS --help`). Examples are:
+
+        * verbose (int) -- set the openEMS verbosity level 0..3
+        * numThreads (int) -- set the number of threads (default 0 --> max)
+        * disable_dumps (bool) -- disable all field dumps for faster simulation
+        * debug_material (bool) - dump material distribution to a vtk file for
+          debugging.
+        * debug_PEC (bool) - dump metal distribution to a vtk file for debugging
+        * debug_operator (bool) - dump operator to vtk file for debugging
+        * debug_boxes (bool) - Dump e.g. probe boxes to vtk file for debugging
+        * debug_CSX (bool) - Write CSX geometry file to debugCSX.xml
+        * dump_statistics (bool) - dump simulation statistics to
+          `openEMS_run_stats.txt` and `openEMS_stats.txt`
+        * showProbeDiscretization (bool) - show probe discretization information
+          for debugging
+        * nativeFieldDumps (bool) - dump all fields using the native field
+          components
         """
         if cleanup and os.path.exists(sim_path):
             shutil.rmtree(sim_path, ignore_errors=True)
@@ -478,25 +512,9 @@ cdef class openEMS:
         if not os.path.exists(sim_path):
             os.mkdir(sim_path)
         os.chdir(sim_path)
-        if verbose is not None:
-            self.thisptr.SetVerboseLevel(verbose)
-        if debug_material:
-            with nogil:
-                self.thisptr.DebugMaterial()
-        if debug_pec:
-            with nogil:
-                self.thisptr.DebugPEC()
-        if debug_operator:
-            with nogil:
-                self.thisptr.DebugOperator()
-        if debug_boxes:
-            with nogil:
-                self.thisptr.DebugBox()
-        if debug_csx:
-            with nogil:
-                self.thisptr.DebugCSX()
-        if 'numThreads' in kw:
-            self.thisptr.SetNumberOfThreads(int(kw['numThreads']))
+
+        self._SetLibraryArguments(kw)
+
         assert os.getcwd() == os.path.realpath(sim_path)
         _openEMS.WelcomeScreen()
         cdef int EC

--- a/tools/global.h
+++ b/tools/global.h
@@ -1,4 +1,5 @@
 /*
+*	Copyright (C) 2024 Yifeng Li <tomli@tomli.me>
 *	Copyright (C) 2010 Sebastian Held <sebastian.held@gmx.de>
 *
 *	This program is free software: you can redistribute it and/or modify
@@ -19,6 +20,7 @@
 #define GLOBAL_H
 
 #include <sstream>
+#include <boost/program_options.hpp>
 #define _USE_MATH_DEFINES
 
 #include "openems_global.h"
@@ -30,12 +32,6 @@ class OPENEMS_EXPORT Global
 {
 public:
 	Global();
-
-	//! Show all possible (global) command line arguments
-	void ShowArguments(std::ostream& ostr, std::string front=std::string());
-
-	//! Parse the given command line arguments
-	bool parseCommandLineArgument( const char *argv );
 
 	bool showProbeDiscretization() const {return m_showProbeDiscretization;}
 
@@ -54,11 +50,68 @@ public:
 	//! Restore the temporarily overwritten verbose level
 	void RestoreVerboseLevel() {m_VerboseLevel=m_SavedVerboseLevel;}
 
+	// openEMS has different modules, and some options may be relevant
+	// only to a single module, such as the upcoming Tiling engine.
+	// Putting all getters and setters into the main openEMS class would
+	// decreases modularity. It's the best if each module can handle their
+	// own options. On the other hand, we really need to know all the options
+	// globally to (1) check whether an option is valid, and (2) provide a
+	// single API to set runtime options when running as a shared library
+	// for Python binding.
+	//
+	// Thus, we use the following 3-step process.
+	//
+	// 1. If a class accepts options, it provides a method optionDesc()
+	// that returns a options_description. During early initialization,
+	// the main program openems.cpp collects them from multiple classes,
+	// then registers them at here by calling appendOptionDesc(). Callback
+	// functions can also be registered via options_description, which
+	// may be used to set the internal state of a class.
+	//
+	// 2. Before starting simulation, if we're running as an executable,
+	// parseCommandLineArguments() is called. If we're running as a shared
+	// library, parseOption() is called (by the user). Callback functions
+	// are also executed at this moment.
+	//
+	// 3. The parsed options is stored as a variables_map in m_options, which
+	// can be accessed globally. Each module only needs to care about its
+	// own options. If a class is only newed after parsing all options
+	// (such as an engine-specific option), callbacks can't be used so the
+	// getOption() method is used instead.
+
+	// Return a list of supported options. If a class accepts options,
+	// it should have its own method.
+	boost::program_options::options_description optionDesc();
+
+	// The optionDesc() of all classes are collected by openems.cpp by
+	// calling appendOptionDesc.
+	void appendOptionDesc(boost::program_options::options_description desc);
+
+	// Parse all options provided as a std::vector of std::strings,
+	// used when running as a shared library. May throw.
+	void parseLibraryArguments(std::vector<std::string> allOptions);
+
+	// Parse all options provided as C string in argv, used when running
+	// as an executable. May throw.
+	void parseCommandLineArguments(int argc, const char* argv[]);
+
+	// Print usage of all known options
+	void showOptionUsage(std::ostream& ostr);
+
+	// Set, get, and clear options, provide access of options to all modules
+	// globally.
+	bool hasOption(std::string option);
+	boost::program_options::variable_value getOption(std::string option);
+	void clearOptions();
+
 protected:
 	bool m_showProbeDiscretization;
 	bool m_nativeFieldDumps;
 	int m_VerboseLevel;
 	int m_SavedVerboseLevel;
+
+	boost::program_options::variables_map m_options;
+	boost::program_options::options_description m_optionDesc;
 };
 
 OPENEMS_EXPORT extern Global g_settings;


### PR DESCRIPTION
## Completely Rewrite Command-Line Argument Parsing

Currently, the openEMS command-line argument parsing has two limitations.

1. If a new module is added into openEMS and that module accepts runtime options, one must change the main openems.cpp to add one new API per option, decreasing code modularity - especially if an option is only used by a single module. This is unsustainable in the long run. The in-development Tiling engine is expected to accept 3 to 4 options.

2. When we're running as a shared library (used by Python binding), if one wants to pass runtime options from Python, one must change the main openems.cpp to add one new API per option. This is again unsustainable. For example, currently there's no way to change the simulation engine via Python because of the lack of APIs.

To overcome these limitations, this commit completely rewrites the command-line argument parsing logic, and a new API SetLibraryArguments() which can be used to set almost all options supported by the main openEMS executable.

The new logic works in the following way:

1. If a class accepts options, it provides a method optionDesc() that returns a options_description. This data structure contains a list of supported options, their text descriptions. Optional callback functions can also be registered, which may be used to set the internal state of a class. During early initialization, the main program openems.cpp collects these options_description from multiple classes, then registers them to g_settings by calling Global::appendOptionDesc(). The combined structure is stored as m_optionDesc. Boost can automatically validate arguments, generate help messages, provide default values, etc.

2. Before starting simulation, if we're running as an executable, parseCommandLineArguments() is called. If we're running as a shared library, parseOption() is called (by the user). Both functions calls Boost's program_options library to parse supplied string options automatically. Registered Callback functions are also executed at this moment, so the variables and states within a class is updated automatically.

3. The parsed options is also globally stored as a variables_map in m_options of g_settings, which can be accessed globally via Global::hasOption() and Global::getOption(). This is useful when a class is only newed after parsing all options (such as an engine-specific option), as callbacks can't be used.

4. A new API SetLibraryArguments() is provided for setting command-line arguments when running as a shared library:

    void SetLibraryArguments(std::vector<std::string> allOptions);

## python: use new SetLibraryArguments() API

In the rewritten command-line argument parsing logic, a new API SetLibraryArguments() is provied, which can be used to set almost all options supported by the main openEMS executable by passing options as strings.

This commit change FDTD.Run() to use the new API. As a result, all command-line options, such as engine types and debugging options, are supported by the Python binding.

## Outcomes

1. New help screen, automatically generated by Boost's program_options library:

```
 ---------------------------------------------------------------------- 
 | openEMS 64bit -- version v0.0.36-17-gd56ff99
 | (C) 2010-2023 Thorsten Liebig <thorsten.liebig@gmx.de>  GPL license
 ---------------------------------------------------------------------- 
	Used external libraries:
		CSXCAD -- Version: v0.6.3-2-gc6a1587
		hdf5   -- Version: 1.14.2
		          compiled against: HDF5 library version: 1.14.2
		tinyxml -- compiled against: 2.6.2
		fparser
		boost  -- compiled against: 1_83
		vtk -- Version: 9.2.6
		       compiled against: 9.2.6

 Usage: openEMS <FDTD_XML_FILE> [<options>...]
 
Options:
  -h [ --help ]                Show this help message and exit
  --disable-dumps              Disable all field dumps for faster simulation
  --debug-material             Dump material distribution to a vtk file for 
                               debugging
  --debug-PEC                  Dump metal distribution to a vtk file for 
                               debugging
  --debug-operator             Dump operator to vtk file for debugging
  --debug-boxes                Dump e.g. probe boxes to vtk file for debugging
  --debug-CSX                  Write CSX geometry file to debugCSX.xml
  --engine arg (=fastest)      Choose engine type 
                               
                                 fastest: fastest available engine (default)
                                 basic: basic FDTD engine
                                 sse: engine using SSE vector extensions
                                 sse-compressed: engine using compressed 
                                                 operator + sse vector 
                                                 extensions
                                 multithreaded: engine using compressed 
                                                operator + sse vector 
                                                extensions + multithreading
                               
  --numThreads arg (=0)        Force use n threads for multithreaded engine 
                               (needs: --engine=multithreaded)
  --no-simulation              only run preprocessing; do not simulate
  --dump-statistics            dump simulation statistics to 
                               'openEMS_run_stats.txt' and 'openEMS_stats.txt'

Additional global arguments:
  --showProbeDiscretization    Show probe discretization information
  --nativeFieldDumps           Dump all fields using the native field 
                               components
  -v [ --verbose ] [=arg(=1)]  Verbose level, select debug level 1 to 3, also 
                               accept -v, -vv, -vvv

```

2. All program options are now supported by Python

e.g. 

```
FDTD.Run(path, engine="basic")
```

produces:

```
openEMS - enabled basic engine                                                                                                                                
 ----------------------------------------------------------------------                                                                                       
 | openEMS 64bit -- version v0.0.36-17-gd56ff99                                                                                                               
 | (C) 2010-2023 Thorsten Liebig <thorsten.liebig@gmx.de>  GPL license                                                                                        
 ----------------------------------------------------------------------                                                                                       
        Used external libraries:                                                                                                                              
                CSXCAD -- Version: v0.6.3-2-gc6a1587                                                                                                          
                hdf5   -- Version: 1.14.2                                                                                                                     
                          compiled against: HDF5 library version: 1.14.2                                                                                      
                tinyxml -- compiled against: 2.6.2                                                                                                            
                fparser                                                                                                                                       
                boost  -- compiled against: 1_83                                                                                                              
                vtk -- Version: 9.2.6                                                                                                                         
                       compiled against: 9.2.6                                                                                                                
                                                                                                                                                              
Create FDTD operator                                                                                 
```

3. It's no longer necessary to change the APIs inside main openEMS class after adding new modules and new options. Only a small change is necessary here:

```
void openEMS::collectCommandLineArguments()
{
	// register our supported options to g_settings
	g_settings.appendOptionDesc(optionDesc());
	g_settings.appendOptionDesc(g_settings.optionDesc());
}
```