### PR TITLE
Define version only once in CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ ENDIF()
 
 #ADD_DEFINITIONS( -D__SSE2__ )
 
-set(VERSION "v0.0.36")
+set(VERSION "v${LIB_VERSION_STRING}")
 
 # add git revision
 IF(EXISTS ${PROJECT_SOURCE_DIR}/.git )


### PR DESCRIPTION
UPD. I dropped PowerPC-related stuff from here and a fix to headers in favor of other PR, retaining only a trivial CMakeLists improvement.