### PR TITLE
lumpedRLC: replace all "uint" to "unsigned int".

### DIFF
--- a/FDTD/extensions/engine_ext_lumpedRLC.cpp
+++ b/FDTD/extensions/engine_ext_lumpedRLC.cpp
@@ -36,15 +36,15 @@ Engine_Ext_LumpedRLC::Engine_Ext_LumpedRLC(Operator_Ext_LumpedRLC* op_ext_RLC) :
 	// Initialize ADE containers for currents and voltages
 	v_Il 		= new FDTD_FLOAT[m_Op_Ext_RLC->RLC_count];
 
-	for (uint posIdx = 0 ; posIdx < m_Op_Ext_RLC->RLC_count ; ++posIdx)
+	for (unsigned int posIdx = 0 ; posIdx < m_Op_Ext_RLC->RLC_count ; ++posIdx)
 		v_Il[posIdx] 	= 0.0;
 
-	for (uint k = 0 ; k < 3 ; k++)
+	for (unsigned int k = 0 ; k < 3 ; k++)
 	{
 		v_Vdn[k] = new FDTD_FLOAT[m_Op_Ext_RLC->RLC_count];
 		v_Jn[k] = new FDTD_FLOAT[m_Op_Ext_RLC->RLC_count];
 
-		for (uint posIdx = 0 ; posIdx < m_Op_Ext_RLC->RLC_count ; ++posIdx)
+		for (unsigned int posIdx = 0 ; posIdx < m_Op_Ext_RLC->RLC_count ; ++posIdx)
 		{
 			v_Jn[k][posIdx] = 0.0;
 			v_Vdn[k][posIdx] = 0.0;;
@@ -60,7 +60,7 @@ Engine_Ext_LumpedRLC::~Engine_Ext_LumpedRLC()
 	{
 		delete[] v_Il;
 
-		for (uint k = 0 ; k < 3 ; k++)
+		for (unsigned int k = 0 ; k < 3 ; k++)
 		{
 			delete[] v_Vdn[k];
 			delete[] v_Jn[k];
@@ -82,7 +82,7 @@ Engine_Ext_LumpedRLC::~Engine_Ext_LumpedRLC()
 
 void Engine_Ext_LumpedRLC::DoPreVoltageUpdates()
 {
-	uint **pos = m_Op_Ext_RLC->v_RLC_pos;
+	unsigned int **pos = m_Op_Ext_RLC->v_RLC_pos;
 	int *dir = m_Op_Ext_RLC->v_RLC_dir;
 
 	// Iterate Vd containers
@@ -93,7 +93,7 @@ void Engine_Ext_LumpedRLC::DoPreVoltageUpdates()
 	v_Vdn[0] = v_temp;
 
 	// In pre-process, only update the parallel inductor current:
-	for (uint pIdx = 0 ; pIdx < m_Op_Ext_RLC->RLC_count ; pIdx++)
+	for (unsigned int pIdx = 0 ; pIdx < m_Op_Ext_RLC->RLC_count ; pIdx++)
 		v_Il[pIdx] += (m_Op_Ext_RLC->v_RLC_i2v[pIdx])*(m_Op_Ext_RLC->v_RLC_ilv[pIdx])*v_Vdn[1][pIdx];
 
 	return;
@@ -101,7 +101,7 @@ void Engine_Ext_LumpedRLC::DoPreVoltageUpdates()
 
 void Engine_Ext_LumpedRLC::Apply2Voltages()
 {
-	uint **pos = m_Op_Ext_RLC->v_RLC_pos;
+	unsigned int **pos = m_Op_Ext_RLC->v_RLC_pos;
 	int *dir = m_Op_Ext_RLC->v_RLC_dir;
 
 	// Iterate J containers
@@ -117,7 +117,7 @@ void Engine_Ext_LumpedRLC::Apply2Voltages()
 	{
 		case Engine::BASIC:
 		{
-			for (uint pIdx = 0 ; pIdx < m_Op_Ext_RLC->RLC_count ; pIdx++)
+			for (unsigned int pIdx = 0 ; pIdx < m_Op_Ext_RLC->RLC_count ; pIdx++)
 				v_Vdn[0][pIdx] = m_Eng->Engine::GetVolt(dir[pIdx],pos[0][pIdx],pos[1][pIdx],pos[2][pIdx]);
 
 			break;
@@ -125,14 +125,14 @@ void Engine_Ext_LumpedRLC::Apply2Voltages()
 		case Engine::SSE:
 		{
 			Engine_sse* eng_sse = (Engine_sse*)m_Eng;
-			for (uint pIdx = 0 ; pIdx < m_Op_Ext_RLC->RLC_count ; pIdx++)
+			for (unsigned int pIdx = 0 ; pIdx < m_Op_Ext_RLC->RLC_count ; pIdx++)
 				v_Vdn[0][pIdx] = eng_sse->Engine_sse::GetVolt(dir[pIdx],pos[0][pIdx],pos[1][pIdx],pos[2][pIdx]);
 
 			break;
 		}
 		default:
 		{
-			for (uint pIdx = 0 ; pIdx < m_Op_Ext_RLC->RLC_count ; pIdx++)
+			for (unsigned int pIdx = 0 ; pIdx < m_Op_Ext_RLC->RLC_count ; pIdx++)
 				v_Vdn[0][pIdx] = m_Eng->GetVolt(dir[pIdx],pos[0][pIdx],pos[1][pIdx],pos[2][pIdx]);;
 
 			break;
@@ -140,7 +140,7 @@ void Engine_Ext_LumpedRLC::Apply2Voltages()
 	}
 
 	// Post process: Calculate node voltage with respect to the lumped RLC auxilliary quantity, J
-	for (uint pIdx = 0 ; pIdx < m_Op_Ext_RLC->RLC_count ; pIdx++)
+	for (unsigned int pIdx = 0 ; pIdx < m_Op_Ext_RLC->RLC_count ; pIdx++)
 	{
 		// Calculate updated node voltage, with series and parallel additions
 		v_Vdn[0][pIdx] = 	(m_Op_Ext_RLC->v_RLC_vvd[pIdx])*(
@@ -166,7 +166,7 @@ void Engine_Ext_LumpedRLC::Apply2Voltages()
 	{
 		case Engine::BASIC:
 		{
-			for (uint pIdx = 0 ; pIdx < m_Op_Ext_RLC->RLC_count ; pIdx++)
+			for (unsigned int pIdx = 0 ; pIdx < m_Op_Ext_RLC->RLC_count ; pIdx++)
 				m_Eng->Engine::SetVolt(dir[pIdx],pos[0][pIdx],pos[1][pIdx],pos[2][pIdx],v_Vdn[0][pIdx]);
 
 			break;
@@ -174,14 +174,14 @@ void Engine_Ext_LumpedRLC::Apply2Voltages()
 		case Engine::SSE:
 		{
 			Engine_sse* eng_sse = (Engine_sse*)m_Eng;
-			for (uint pIdx = 0 ; pIdx < m_Op_Ext_RLC->RLC_count ; pIdx++)
+			for (unsigned int pIdx = 0 ; pIdx < m_Op_Ext_RLC->RLC_count ; pIdx++)
 				eng_sse->Engine_sse::SetVolt(dir[pIdx],pos[0][pIdx],pos[1][pIdx],pos[2][pIdx],v_Vdn[0][pIdx]);
 
 			break;
 		}
 		default:
 		{
-			for (uint pIdx = 0 ; pIdx < m_Op_Ext_RLC->RLC_count ; pIdx++)
+			for (unsigned int pIdx = 0 ; pIdx < m_Op_Ext_RLC->RLC_count ; pIdx++)
 				m_Eng->SetVolt(dir[pIdx],pos[0][pIdx],pos[1][pIdx],pos[2][pIdx],v_Vdn[0][pIdx]);
 
 			break;

--- a/FDTD/extensions/operator_ext_lumpedRLC.cpp
+++ b/FDTD/extensions/operator_ext_lumpedRLC.cpp
@@ -94,7 +94,7 @@ Operator_Ext_LumpedRLC::~Operator_Ext_LumpedRLC()
 		// Additional containers
 		delete[] v_RLC_dir;
 
-		for (uint dIdx = 0 ; dIdx < 3 ; dIdx++)
+		for (unsigned int dIdx = 0 ; dIdx < 3 ; dIdx++)
 			delete[] v_RLC_pos[dIdx];
 
 		delete[] v_RLC_pos;
@@ -117,14 +117,14 @@ bool Operator_Ext_LumpedRLC::BuildExtension()
 					+
 					m_Op->GetExcitationSignal()->GetCutOffFreq();
 
-	uint 	pos[] = {0,0,0};
+	unsigned int 	pos[] = {0,0,0};
 
 	vector<CSProperties*> cs_props;
 
 	int 			dir;
 	CSPropLumpedElement::LEtype lumpedType;
 
-	vector<uint> 	v_pos[3];
+	vector<unsigned int> 	v_pos[3];
 
 	vector<int>		v_dir;
 
@@ -143,7 +143,7 @@ bool Operator_Ext_LumpedRLC::BuildExtension()
 	double R, L, C;
 
 	// clear all vectors to initialize them
-	for (uint dIdx = 0 ; dIdx < 3 ; dIdx++)
+	for (unsigned int dIdx = 0 ; dIdx < 3 ; dIdx++)
 		v_pos[dIdx].clear();
 
 	v_dir.clear();
@@ -385,7 +385,7 @@ bool Operator_Ext_LumpedRLC::BuildExtension()
 							}
 
 							// Store position and direction
-							for (uint dIdx = 0 ; dIdx < 3 ; ++dIdx)
+							for (unsigned int dIdx = 0 ; dIdx < 3 ; ++dIdx)
 								v_pos[dIdx].push_back(pos[dIdx]);
 
 						}
@@ -460,9 +460,9 @@ bool Operator_Ext_LumpedRLC::BuildExtension()
 		v_RLC_b1 = new FDTD_FLOAT[RLC_count];
 		v_RLC_b2 = new FDTD_FLOAT[RLC_count];
 
-		v_RLC_pos = new uint*[3];
-		for (uint dIdx = 0 ; dIdx < 3 ; ++dIdx)
-			v_RLC_pos[dIdx] = new uint[RLC_count];
+		v_RLC_pos = new unsigned int*[3];
+		for (unsigned int dIdx = 0 ; dIdx < 3 ; ++dIdx)
+			v_RLC_pos[dIdx] = new unsigned int[RLC_count];
 
 		// Copy all vectors to arrays
 		COPY_V2A(v_dir, v_RLC_dir);
@@ -478,7 +478,7 @@ bool Operator_Ext_LumpedRLC::BuildExtension()
 		COPY_V2A(v_b1,v_RLC_b1);
 		COPY_V2A(v_b2,v_RLC_b2);
 
-		for (uint dIdx = 0 ; dIdx < 3 ; ++dIdx)
+		for (unsigned int dIdx = 0 ; dIdx < 3 ; ++dIdx)
 			COPY_V2A(v_pos[dIdx],v_RLC_pos[dIdx]);
 	}
 

--- a/FDTD/extensions/operator_ext_lumpedRLC.h
+++ b/FDTD/extensions/operator_ext_lumpedRLC.h
@@ -73,10 +73,10 @@ protected:
 
 	// Additional containers
 	int				*v_RLC_dir;
-	uint			**v_RLC_pos;
+	unsigned int			**v_RLC_pos;
 
 	// Vector length indicator
-	uint			RLC_count;
+	unsigned int			RLC_count;
 
 
 


### PR DESCRIPTION
The original contributor used "uint" in all code, which is a non-standard language extension that doesn't exist in ISO C or ISO C++, and causes build failures on macOS as reported by PR #144. Replace all "uint" with "unsigned int" for standard conformance to maximize portability.