### PR TITLE
Pythonize/open ems

### DIFF
--- a/python/openEMS/openEMS.pyx
+++ b/python/openEMS/openEMS.pyx
@@ -309,19 +309,16 @@ cdef class openEMS:
                 continue
             raise Exception('Unknown boundary condition')
 
-    def AddLumpedPort(self, port_nr, R, start, stop, p_dir, excite=0, **kw):
-        """ AddLumpedPort(port_nr, R, start, stop, p_dir, excite=0, **kw)
-
-        Add a lumped port with the given values and location.
+    def AddLumpedPort(self, port_nr, R, start, stop, p_dir, excite=0, edges2grid=None, **kw)->ports.LumpedPort:
+        """Add a lumped port with the given values and location.
 
         See Also
         --------
         openEMS.ports.LumpedPort
         """
         if self.__CSX is None:
-            raise Exception('AddLumpedPort: CSX is not set!')
-        port = ports.LumpedPort(self.__CSX, port_nr, R, start, stop, p_dir, excite, **kw)
-        edges2grid = kw.get('edges2grid', None)
+            raise RuntimeError('CSX is not yet set!')
+        port = ports.LumpedPort(CSX=self.__CSX, port_nr=port_nr, R=R, start=start, stop=stop, exc_dir=p_dir, excite=excite, **kw)
         if edges2grid is not None:
             grid = self.__CSX.GetGrid()
             for n in GetMultiDirs(edges2grid):

--- a/python/openEMS/openEMS.pyx
+++ b/python/openEMS/openEMS.pyx
@@ -255,13 +255,13 @@ cdef class openEMS:
         """
         self.thisptr.SetDiracExcite(f_max)
 
-    def SetStepExcite(self, f_max):
-        """ SetStepExcite(f_max)
+    def SetStepExcite(self, f_max:float):
+        """Set a step function as excitation signal.
 
-        Set a step function as excitation signal.
-
-        :param f_max: float -- maximum simulated frequency in Hz.
+        :param f_max: Maximum simulated frequency in Hz.
         """
+        if not isinstance(f_max, (int,float)) or f_max<0:
+            raise ValueError(f'`f_max` must be a number >0, received {f_max}. ')
         self.thisptr.SetStepExcite(f_max)
 
     def SetCustomExcite(self, _str, f0, fmax):

--- a/python/openEMS/openEMS.pyx
+++ b/python/openEMS/openEMS.pyx
@@ -276,22 +276,26 @@ cdef class openEMS:
         """
         self.thisptr.SetCustomExcite(_str, f0, fmax)
 
-    def SetBoundaryCond(self, BC):
-        """ SetBoundaryCond(BC)
+    def SetBoundaryCond(self, x_min:str|int, x_max:str|int, y_min:str|int, y_max:str|int, z_min:str|int, z_max:str|int):
+        """Set the boundary conditions for all six FDTD directions.
 
-        Set the boundary conditions for all six FDTD directions.
+        Options for all the arguments `x_min`, `x_max`, ... are:
+        * 'PEC': Perfect electric conductor.
+        * 'PMC': Perfect magnetic conductor, useful for symmetries.
+        * 'MUR': Simple MUR absorbing boundary conditions.
+        * 'PML_n: PML absorbing boundary conditions, with PML size `n` between 4 and 50.
 
-        Options:
-
-        * 0 or 'PEC' : perfect electric conductor (default)
-        * 1 or 'PMC' : perfect magnetic conductor, useful for symmetries
-        * 2 or 'MUR' : simple MUR absorbing boundary conditions
-        * 3 or 'PML_8' : PML absorbing boundary conditions
-
-        :param BC: (8,) array or list -- see options above
+        Note: Each argument `x_min`, `x_max`, ... can take integer values 0, 1, 2 or 3. This is kept for backwards compatibility but its usage is discouraged.
         """
-        if not len(BC)==6:
-            raise Exception('Invalid boundary condition size!')
+        POSSIBLE_VALUES_FOR_BOUNDARY_CONDITIONS = {'PEC','PMC','MUR'} | {f'PML_{x}' for x in range(4,51)}
+        POSSIBLE_VALUES_FOR_BOUNDARY_CONDITIONS |= {0,1,2,3} # This is for backwards compatibility, but passing numbers should be avoided.
+
+        boundary_conditions = dict(x_min=x_min, x_max=x_max, y_min=y_min, y_max=y_max, z_min=z_min, z_max=z_max)
+        for name,val in boundary_conditions.items():
+            if val not in POSSIBLE_VALUES_FOR_BOUNDARY_CONDITIONS:
+                raise ValueError(f'`{name}` is not one of the allowed boundary conditions, which are "PEC", "PMC", "MUR" or "PML_n" with "n" between 4 and 50. Received {repr(val)}. ')
+
+        BC = [boundary_conditions[name] for name in ['x_min','x_max','y_min','y_max','z_min','z_max']]
         for n in range(len(BC)):
             if type(BC[n])==int:
                 self.thisptr.Set_BC_Type(n, BC[n])

--- a/python/openEMS/openEMS.pyx
+++ b/python/openEMS/openEMS.pyx
@@ -22,6 +22,8 @@ import numpy as np
 cimport openEMS
 from openEMS import ports, nf2ff, automesh
 import warnings
+from typing_extensions import deprecated # The `deprecated` decorator will be available in the `warnings` standard library as of Python 3.13, see [here](https://docs.python.org/3.13/library/warnings.html#warnings.deprecated).
+
 
 from CSXCAD.Utilities import GetMultiDirs
 
@@ -278,6 +280,7 @@ cdef class openEMS:
         """
         self.thisptr.SetCustomExcite(_str, f0, fmax)
 
+    @deprecated('Please use the new method `SetBoundaryConditions`.')
     def SetBoundaryCond(self, BC):
         """ SetBoundaryCond(BC)
 
@@ -292,7 +295,6 @@ cdef class openEMS:
 
         :param BC: (8,) array or list -- see options above
         """
-        warnings.warn('`SetBoundaryCond` will be deprecated in the future, please migrate to the new method `SetBoundaryConditions`. ')
         if not len(BC)==6:
             raise Exception('Invalid boundary condition size!')
         for n in range(len(BC)):

--- a/python/setup.py
+++ b/python/setup.py
@@ -54,6 +54,7 @@ setup(
     'cython>=3.0.6',  # Apache License 2.0 (https://github.com/cython/cython/blob/master/LICENSE.txt)
     'h5py>=3.10.0',   # BSD 3-Clause (https://github.com/h5py/h5py/blob/master/LICENSE)
     'numpy>=1.26.2',  # BSD 3-Clause (https://github.com/numpy/numpy/blob/main/LICENSE.txt)
+    'typing_extensions', # Used for `typing_extensions.deprecated` warning, will not be needed as of Python 3.13 because it will become part of the standard `warnings` library.
   ],
   ext_modules = cythonize(extensions, language_level = 3)
  )


### PR DESCRIPTION
Interface is more robust and user friendly. Did it only for some functions I am using.

## Important
In `openEMS.SetBoundaryCond` I changed the interface, instead of receiving a list with 6 elements, it receives the 6 elements as function arguments. Advantages:
- It is obvious from the source code what is each element.
- Makes it possible to use named arguments with any arbitrary ordering.
- More robust.
The conversion from any code running with the previous interface to the new interface should be straightforward:
```python
ems.SetBoundaryCond(my_BC)
```
becomes
```python
ems.SetBoundaryCond(*my_BC)
```
which should be easy to do with a single find-and-replace `.SetBoundaryCond(`→`.SetBoundaryCond(*`.

All the rest I think should be backwards compatible.