### PR TITLE
Added checks for `port_nr` so it does not repeat

### DIFF
--- a/python/openEMS/openEMS.pxd
+++ b/python/openEMS/openEMS.pxd
@@ -71,3 +71,4 @@ cdef extern from "openEMS/openems.h":
 cdef class openEMS:
     cdef  _openEMS *thisptr
     cdef readonly ContinuousStructure __CSX      # hold a C++ instance which we're wrapping
+    cdef dict ports

--- a/python/openEMS/openEMS.pyx
+++ b/python/openEMS/openEMS.pyx
@@ -71,6 +71,8 @@ cdef class openEMS:
     def __cinit__(self, *args, **kw):
         self.thisptr = new _openEMS()
         self.__CSX = None
+        self.ports = dict()
+        """A dictionary of the form `{port_nr: port}` that is automatically filled by the methods dedicated to adding ports. `port_nr` is an integer."""
 
         if 'NrTS' in kw:
             self.SetNumberOfTimeSteps(kw['NrTS'])
@@ -300,19 +302,26 @@ cdef class openEMS:
                 continue
             raise Exception('Unknown boundary condition')
 
-    def AddLumpedPort(self, port_nr, R, start, stop, p_dir, excite=0, **kw):
-        """ AddLumpedPort(port_nr, R, start, stop, p_dir, excite=0, **kw)
+    def _validate_port_nr(self, port_nr):
+        if not isinstance(port_nr, int):
+            raise TypeError(f'`port_nr` must be an int, received object of type {type(port_nr)}. ')
+        if port_nr < 0:
+            raise ValueError(f'`port_nr` must be >= 0, received {port_nr}. ')
+        if port_nr in self.ports:
+            raise ValueError(f'Port number `port_nr` {port_nr} already present. ')
 
-        Add a lumped port with the given values and location.
+    def AddLumpedPort(self, port_nr, R, start, stop, p_dir, excite=0, edges2grid=None, **kw)->ports.LumpedPort:
+        """Add a lumped port with the given values and location.
 
         See Also
         --------
         openEMS.ports.LumpedPort
         """
         if self.__CSX is None:
-            raise Exception('AddLumpedPort: CSX is not set!')
-        port = ports.LumpedPort(self.__CSX, port_nr, R, start, stop, p_dir, excite, **kw)
-        edges2grid = kw.get('edges2grid', None)
+            raise RuntimeError('CSX is not yet set!')
+        self._validate_port_nr(port_nr)
+        port = ports.LumpedPort(CSX=self.__CSX, port_nr=port_nr, R=R, start=start, stop=stop, exc_dir=p_dir, excite=excite, **kw)
+        self.ports[port_nr] = port
         if edges2grid is not None:
             grid = self.__CSX.GetGrid()
             for n in GetMultiDirs(edges2grid):
@@ -332,7 +341,10 @@ cdef class openEMS:
         """
         if self.__CSX is None:
             raise Exception('AddWaveGuidePort: CSX is not set!')
-        return ports.WaveguidePort(self.__CSX, port_nr, start, stop, p_dir, E_func, H_func, kc, excite, **kw)
+        self._validate_port_nr(port_nr)
+        port = ports.WaveguidePort(self.__CSX, port_nr, start, stop, p_dir, E_func, H_func, kc, excite, **kw)
+        self.ports[port_nr] = port
+        return port
 
     def AddRectWaveGuidePort(self, port_nr, start, stop, p_dir, a, b, mode_name, excite=0, **kw):
         """ AddRectWaveGuidePort(port_nr, start, stop, p_dir, a, b, mode_name, excite=0, **kw)
@@ -345,7 +357,10 @@ cdef class openEMS:
         """
         if self.__CSX is None:
             raise Exception('AddRectWaveGuidePort: CSX is not set!')
-        return ports.RectWGPort(self.__CSX, port_nr, start, stop, p_dir, a, b, mode_name, excite, **kw)
+        self._validate_port_nr(port_nr)
+        port = ports.RectWGPort(self.__CSX, port_nr, start, stop, p_dir, a, b, mode_name, excite, **kw)
+        self.ports[port_nr] = port
+        return port
 
     def AddMSLPort(self, port_nr, metal_prop, start, stop, prop_dir, exc_dir, excite=0, **kw):
         """ AddMSLPort(port_nr, metal_prop, start, stop, prop_dir, exc_dir, excite=0, **kw)
@@ -358,7 +373,10 @@ cdef class openEMS:
         """
         if self.__CSX is None:
             raise Exception('AddMSLPort: CSX is not set!')
-        return ports.MSLPort(self.__CSX, port_nr, metal_prop, start, stop, prop_dir, exc_dir, excite, **kw)
+        self._validate_port_nr(port_nr)
+        port = ports.MSLPort(self.__CSX, port_nr, metal_prop, start, stop, prop_dir, exc_dir, excite, **kw)
+        self.ports[port_nr] = port
+        return port
 
     def CreateNF2FFBox(self, name='nf2ff', start=None, stop=None, **kw):
         """ CreateNF2FFBox(name='nf2ff', start=None, stop=None, **kw)


### PR DESCRIPTION
This PR comes after my question in issue #155 . I don't see any reason for repeating the `port_nr` when calling multiple times to `Add___Port` methods. If it accidentally repeats, it fails completely silently. This PR comes to fix that. Additionally, it adds the `ports` dictionary that automatically stores the ports and makes it public to the user.

For the future: I would change `port_nr` to `port_name:str`. Gives much more clarity, and the output files could have this name instead of numbers. Whoever wants to keep using numbers, can do e.g. `port_name='1'`. Not sure if this requires changes in the C++ part to be implemented, hope not.