### PR TITLE
Speeding Up FDTD Engine By an Improved Multi-dimensional Arrays Implementation "ArrayLib" with Contiguous Memory

### DIFF
--- a/FDTD/engine.h
+++ b/FDTD/engine.h
@@ -21,6 +21,8 @@
 #include <fstream>
 #include "operator.h"
 
+#include "tools/arraylib/array_nijk.h"
+
 namespace NS_Engine_Multithread
 {
 class thread; // evil hack to access numTS from multithreading context
@@ -52,42 +54,50 @@ public:
 	//this access functions muss be overloaded by any new engine using a different storage model
 	inline virtual FDTD_FLOAT GetVolt(unsigned int n, unsigned int x, unsigned int y, unsigned int z) const
 	{
+		ArrayLib::ArrayNIJK<FDTD_FLOAT>& volt = *volt_ptr;
 		return volt[n][x][y][z];
 	}
 
 	inline virtual FDTD_FLOAT GetVolt(unsigned int n, const unsigned int pos[3]) const
 	{
+		ArrayLib::ArrayNIJK<FDTD_FLOAT>& volt = *volt_ptr;
 		return volt[n][pos[0]][pos[1]][pos[2]];
 	}
 
 	inline virtual FDTD_FLOAT GetCurr(unsigned int n, unsigned int x, unsigned int y, unsigned int z) const
 	{
+		ArrayLib::ArrayNIJK<FDTD_FLOAT>& curr = *curr_ptr;
 		return curr[n][x][y][z];
 	}
 
 	inline virtual FDTD_FLOAT GetCurr(unsigned int n, const unsigned int pos[3]) const
 	{
+		ArrayLib::ArrayNIJK<FDTD_FLOAT>& curr = *curr_ptr;
 		return curr[n][pos[0]][pos[1]][pos[2]];
 	}
 
 	inline virtual void SetVolt(unsigned int n, unsigned int x, unsigned int y, unsigned int z, FDTD_FLOAT value)
 	{
-		volt[n][x][y][z]=value;
+		ArrayLib::ArrayNIJK<FDTD_FLOAT>& volt = *volt_ptr;
+		volt[n][x][y][z] = value;
 	}
 
 	inline virtual void SetVolt(unsigned int n, const unsigned int pos[3], FDTD_FLOAT value)
 	{
-		volt[n][pos[0]][pos[1]][pos[2]]=value;
+		ArrayLib::ArrayNIJK<FDTD_FLOAT>& volt = *volt_ptr;
+		volt[n][pos[0]][pos[1]][pos[2]] = value;
 	}
 
 	inline virtual void SetCurr(unsigned int n, unsigned int x, unsigned int y, unsigned int z, FDTD_FLOAT value)
 	{
-		curr[n][x][y][z]=value;
+		ArrayLib::ArrayNIJK<FDTD_FLOAT>& curr = *curr_ptr;
+		curr[n][x][y][z] = value;
 	}
 
 	inline virtual void SetCurr(unsigned int n, const unsigned int pos[3], FDTD_FLOAT value )
 	{
-		curr[n][pos[0]][pos[1]][pos[2]]=value;
+		ArrayLib::ArrayNIJK<FDTD_FLOAT>& curr = *curr_ptr;
+		curr[n][pos[0]][pos[1]][pos[2]] = value;
 	}
 
 	//! Execute Pre-Voltage extension updates
@@ -122,8 +132,8 @@ protected:
 
 	unsigned int numLines[3];
 
-	FDTD_FLOAT**** volt;
-	FDTD_FLOAT**** curr;
+	ArrayLib::ArrayNIJK<FDTD_FLOAT>* volt_ptr;
+	ArrayLib::ArrayNIJK<FDTD_FLOAT>* curr_ptr;
 	unsigned int numTS;
 
 	virtual void InitExtensions();

--- a/FDTD/engine.h
+++ b/FDTD/engine.h
@@ -65,7 +65,7 @@ public:
 		return curr[n][x][y][z];
 	}
 
-	inline virtual FDTD_FLOAT GetCurr(unsigned int n, const unsigned int pos[3] const
+	inline virtual FDTD_FLOAT GetCurr(unsigned int n, const unsigned int pos[3]) const
 	{
 		return curr[n][pos[0]][pos[1]][pos[2]];
 	}

--- a/FDTD/engine.h
+++ b/FDTD/engine.h
@@ -50,15 +50,45 @@ public:
 	virtual void NextInterval(float curr_speed) {};
 
 	//this access functions muss be overloaded by any new engine using a different storage model
-	inline virtual FDTD_FLOAT GetVolt( unsigned int n, unsigned int x, unsigned int y, unsigned int z )		const { return volt[n][x][y][z]; }
-	inline virtual FDTD_FLOAT GetVolt( unsigned int n, const unsigned int pos[3] )							const { return volt[n][pos[0]][pos[1]][pos[2]]; }
-	inline virtual FDTD_FLOAT GetCurr( unsigned int n, unsigned int x, unsigned int y, unsigned int z )		const { return curr[n][x][y][z]; }
-	inline virtual FDTD_FLOAT GetCurr( unsigned int n, const unsigned int pos[3] )							const { return curr[n][pos[0]][pos[1]][pos[2]]; }
+	inline virtual FDTD_FLOAT GetVolt(unsigned int n, unsigned int x, unsigned int y, unsigned int z) const
+	{
+		return volt[n][x][y][z];
+	}
 
-	inline virtual void SetVolt( unsigned int n, unsigned int x, unsigned int y, unsigned int z, FDTD_FLOAT value)	{ volt[n][x][y][z]=value; }
-	inline virtual void SetVolt( unsigned int n, const unsigned int pos[3], FDTD_FLOAT value )						{ volt[n][pos[0]][pos[1]][pos[2]]=value; }
-	inline virtual void SetCurr( unsigned int n, unsigned int x, unsigned int y, unsigned int z, FDTD_FLOAT value)	{ curr[n][x][y][z]=value; }
-	inline virtual void SetCurr( unsigned int n, const unsigned int pos[3], FDTD_FLOAT value )						{ curr[n][pos[0]][pos[1]][pos[2]]=value; }
+	inline virtual FDTD_FLOAT GetVolt(unsigned int n, const unsigned int pos[3]) const
+	{
+		return volt[n][pos[0]][pos[1]][pos[2]];
+	}
+
+	inline virtual FDTD_FLOAT GetCurr(unsigned int n, unsigned int x, unsigned int y, unsigned int z) const
+	{
+		return curr[n][x][y][z];
+	}
+
+	inline virtual FDTD_FLOAT GetCurr(unsigned int n, const unsigned int pos[3] const
+	{
+		return curr[n][pos[0]][pos[1]][pos[2]];
+	}
+
+	inline virtual void SetVolt(unsigned int n, unsigned int x, unsigned int y, unsigned int z, FDTD_FLOAT value)
+	{
+		volt[n][x][y][z]=value;
+	}
+
+	inline virtual void SetVolt(unsigned int n, const unsigned int pos[3], FDTD_FLOAT value)
+	{
+		volt[n][pos[0]][pos[1]][pos[2]]=value;
+	}
+
+	inline virtual void SetCurr(unsigned int n, unsigned int x, unsigned int y, unsigned int z, FDTD_FLOAT value)
+	{
+		curr[n][x][y][z]=value;
+	}
+
+	inline virtual void SetCurr(unsigned int n, const unsigned int pos[3], FDTD_FLOAT value )
+	{
+		curr[n][pos[0]][pos[1]][pos[2]]=value;
+	}
 
 	//! Execute Pre-Voltage extension updates
 	virtual void DoPreVoltageUpdates();

--- a/FDTD/engine_cylindermultigrid.cpp
+++ b/FDTD/engine_cylindermultigrid.cpp
@@ -134,6 +134,9 @@ bool Engine_CylinderMultiGrid::IterateTS(unsigned int iterTS)
 void Engine_CylinderMultiGrid::InterpolVoltChild2Base(unsigned int rPos)
 {
 	//interpolate voltages from child engine to the base engine...
+	ArrayLib::ArrayNIJK<f4vector>& f4_volt = *f4_volt_ptr;
+	ArrayLib::ArrayNIJK<f4vector>& innerEngine_f4_volt = *m_InnerEngine->f4_volt_ptr;
+
 	unsigned int pos[3];
 	pos[0] = rPos;
 	for (pos[1]=0; pos[1]<numLines[1]; ++pos[1])
@@ -141,16 +144,16 @@ void Engine_CylinderMultiGrid::InterpolVoltChild2Base(unsigned int rPos)
 		for (pos[2]=0; pos[2]<numVectors; ++pos[2])
 		{
 			//r - direction
-			f4_volt[0][pos[0]][pos[1]][pos[2]].v  = Op_CMG->f4_interpol_v_2p[0][pos[1]].v * m_InnerEngine->f4_volt[0][pos[0]][Op_CMG->m_interpol_pos_v_2p[0][pos[1]]][pos[2]].v
-													+ Op_CMG->f4_interpol_v_2pp[0][pos[1]].v * m_InnerEngine->f4_volt[0][pos[0]][Op_CMG->m_interpol_pos_v_2pp[0][pos[1]]][pos[2]].v;
+			f4_volt[0][pos[0]][pos[1]][pos[2]].v  = Op_CMG->f4_interpol_v_2p[0][pos[1]].v * innerEngine_f4_volt[0][pos[0]][Op_CMG->m_interpol_pos_v_2p[0][pos[1]]][pos[2]].v
+													+ Op_CMG->f4_interpol_v_2pp[0][pos[1]].v * innerEngine_f4_volt[0][pos[0]][Op_CMG->m_interpol_pos_v_2pp[0][pos[1]]][pos[2]].v;
 
 			//z - direction
-			f4_volt[2][pos[0]][pos[1]][pos[2]].v  = Op_CMG->f4_interpol_v_2p[0][pos[1]].v * m_InnerEngine->f4_volt[2][pos[0]][Op_CMG->m_interpol_pos_v_2p[0][pos[1]]][pos[2]].v
-													+ Op_CMG->f4_interpol_v_2pp[0][pos[1]].v * m_InnerEngine->f4_volt[2][pos[0]][Op_CMG->m_interpol_pos_v_2pp[0][pos[1]]][pos[2]].v;
+			f4_volt[2][pos[0]][pos[1]][pos[2]].v  = Op_CMG->f4_interpol_v_2p[0][pos[1]].v * innerEngine_f4_volt[2][pos[0]][Op_CMG->m_interpol_pos_v_2p[0][pos[1]]][pos[2]].v
+													+ Op_CMG->f4_interpol_v_2pp[0][pos[1]].v * innerEngine_f4_volt[2][pos[0]][Op_CMG->m_interpol_pos_v_2pp[0][pos[1]]][pos[2]].v;
 
 			//alpha - direction
-			f4_volt[1][pos[0]][pos[1]][pos[2]].v  = Op_CMG->f4_interpol_v_2p[1][pos[1]].v * m_InnerEngine->f4_volt[1][pos[0]][Op_CMG->m_interpol_pos_v_2p[1][pos[1]]][pos[2]].v
-													+ Op_CMG->f4_interpol_v_2pp[1][pos[1]].v * m_InnerEngine->f4_volt[1][pos[0]][Op_CMG->m_interpol_pos_v_2pp[1][pos[1]]][pos[2]].v;
+			f4_volt[1][pos[0]][pos[1]][pos[2]].v  = Op_CMG->f4_interpol_v_2p[1][pos[1]].v * innerEngine_f4_volt[1][pos[0]][Op_CMG->m_interpol_pos_v_2p[1][pos[1]]][pos[2]].v
+													+ Op_CMG->f4_interpol_v_2pp[1][pos[1]].v * innerEngine_f4_volt[1][pos[0]][Op_CMG->m_interpol_pos_v_2pp[1][pos[1]]][pos[2]].v;
 		}
 	}
 }
@@ -158,6 +161,9 @@ void Engine_CylinderMultiGrid::InterpolVoltChild2Base(unsigned int rPos)
 void Engine_CylinderMultiGrid::InterpolCurrChild2Base(unsigned int rPos)
 {
 	//interpolate voltages from child engine to the base engine...
+	ArrayLib::ArrayNIJK<f4vector>& f4_curr = *f4_curr_ptr;
+	ArrayLib::ArrayNIJK<f4vector>& innerEngine_f4_curr = *m_InnerEngine->f4_curr_ptr;
+
 	unsigned int pos[3];
 	pos[0] = rPos;
 	for (pos[1]=0; pos[1]<numLines[1]; ++pos[1])
@@ -165,16 +171,16 @@ void Engine_CylinderMultiGrid::InterpolCurrChild2Base(unsigned int rPos)
 		for (pos[2]=0; pos[2]<numVectors; ++pos[2])
 		{
 			//r - direction
-			f4_curr[0][pos[0]][pos[1]][pos[2]].v  = Op_CMG->f4_interpol_i_2p[0][pos[1]].v * m_InnerEngine->f4_curr[0][pos[0]][Op_CMG->m_interpol_pos_i_2p[0][pos[1]]][pos[2]].v
-													+ Op_CMG->f4_interpol_i_2pp[0][pos[1]].v * m_InnerEngine->f4_curr[0][pos[0]][Op_CMG->m_interpol_pos_i_2pp[0][pos[1]]][pos[2]].v;
+			f4_curr[0][pos[0]][pos[1]][pos[2]].v  = Op_CMG->f4_interpol_i_2p[0][pos[1]].v * innerEngine_f4_curr[0][pos[0]][Op_CMG->m_interpol_pos_i_2p[0][pos[1]]][pos[2]].v
+													+ Op_CMG->f4_interpol_i_2pp[0][pos[1]].v * innerEngine_f4_curr[0][pos[0]][Op_CMG->m_interpol_pos_i_2pp[0][pos[1]]][pos[2]].v;
 
 			//z - direction
-			f4_curr[2][pos[0]][pos[1]][pos[2]].v  = Op_CMG->f4_interpol_i_2p[0][pos[1]].v * m_InnerEngine->f4_curr[2][pos[0]][Op_CMG->m_interpol_pos_i_2p[0][pos[1]]][pos[2]].v
-													+ Op_CMG->f4_interpol_i_2pp[0][pos[1]].v * m_InnerEngine->f4_curr[2][pos[0]][Op_CMG->m_interpol_pos_i_2pp[0][pos[1]]][pos[2]].v;
+			f4_curr[2][pos[0]][pos[1]][pos[2]].v  = Op_CMG->f4_interpol_i_2p[0][pos[1]].v * innerEngine_f4_curr[2][pos[0]][Op_CMG->m_interpol_pos_i_2p[0][pos[1]]][pos[2]].v
+													+ Op_CMG->f4_interpol_i_2pp[0][pos[1]].v * innerEngine_f4_curr[2][pos[0]][Op_CMG->m_interpol_pos_i_2pp[0][pos[1]]][pos[2]].v;
 
 			//alpha - direction
-			f4_curr[1][pos[0]][pos[1]][pos[2]].v  = Op_CMG->f4_interpol_i_2p[1][pos[1]].v * m_InnerEngine->f4_curr[1][pos[0]][Op_CMG->m_interpol_pos_i_2p[1][pos[1]]][pos[2]].v
-													+ Op_CMG->f4_interpol_i_2pp[1][pos[1]].v * m_InnerEngine->f4_curr[1][pos[0]][Op_CMG->m_interpol_pos_i_2pp[1][pos[1]]][pos[2]].v;
+			f4_curr[1][pos[0]][pos[1]][pos[2]].v  = Op_CMG->f4_interpol_i_2p[1][pos[1]].v * innerEngine_f4_curr[1][pos[0]][Op_CMG->m_interpol_pos_i_2p[1][pos[1]]][pos[2]].v
+													+ Op_CMG->f4_interpol_i_2pp[1][pos[1]].v * innerEngine_f4_curr[1][pos[0]][Op_CMG->m_interpol_pos_i_2pp[1][pos[1]]][pos[2]].v;
 		}
 	}
 }

--- a/FDTD/engine_interface_fdtd.cpp
+++ b/FDTD/engine_interface_fdtd.cpp
@@ -136,8 +136,11 @@ double Engine_Interface_FDTD::GetRawDualField(unsigned int n, const unsigned int
 	double delta = m_Op->GetEdgeLength(n,pos,true);
 	if ((type==0) && (delta))
 		return value/delta;
-	if ((type==1) && (m_Op->m_mueR) && (delta))
-		return value*m_Op->m_mueR[n][pos[0]][pos[1]][pos[2]]/delta;
+	if ((type==1) && (m_Op->m_mueR_ptr) && (delta))
+	{
+		ArrayLib::ArrayNIJK<float>& m_mueR = *m_Op->m_mueR_ptr;
+		return value * m_mueR[n][pos[0]][pos[1]][pos[2]] / delta;
+	}
 	return 0.0;
 }
 
@@ -260,10 +263,14 @@ double Engine_Interface_FDTD::GetRawField(unsigned int n, const unsigned int* po
 	double delta = m_Op->GetEdgeLength(n,pos);
 	if ((type==0) && (delta))
 		return value/delta;
-	if ((type==1) && (m_Op->m_kappa) && (delta))
-		return value*m_Op->m_kappa[n][pos[0]][pos[1]][pos[2]]/delta;
-	if ((type==3) && (m_Op->m_epsR) && (delta))
-		return value*m_Op->m_epsR[n][pos[0]][pos[1]][pos[2]]/delta;
+	if ((type==1) && (m_Op->m_kappa_ptr) && (delta)) {
+		ArrayLib::ArrayNIJK<float>& kappa = *m_Op->m_kappa_ptr;
+		return value * kappa[n][pos[0]][pos[1]][pos[2]] / delta;
+	}
+	if ((type==3) && (m_Op->m_epsR_ptr) && (delta)) {
+		ArrayLib::ArrayNIJK<float>& epsR = *m_Op->m_epsR_ptr;
+		return value * epsR[n][pos[0]][pos[1]][pos[2]] / delta;
+	}
 	if (type==2) //calc rot(H)
 	{
 		int nP = (n+1)%3;

--- a/FDTD/engine_interface_sse_fdtd.cpp
+++ b/FDTD/engine_interface_sse_fdtd.cpp
@@ -54,13 +54,16 @@ double Engine_Interface_SSE_FDTD::CalcFastEnergy() const
 		{
 			for (pos[2]=0; pos[2]<m_Op_SSE->numVectors; ++pos[2])
 			{
-				E_energy.v += m_Eng_SSE->Engine_sse::f4_volt[0][pos[0]][pos[1]][pos[2]].v * m_Eng_SSE->Engine_sse::f4_volt[0][pos[0]][pos[1]][pos[2]].v;
-				E_energy.v += m_Eng_SSE->Engine_sse::f4_volt[1][pos[0]][pos[1]][pos[2]].v * m_Eng_SSE->Engine_sse::f4_volt[1][pos[0]][pos[1]][pos[2]].v;
-				E_energy.v += m_Eng_SSE->Engine_sse::f4_volt[2][pos[0]][pos[1]][pos[2]].v * m_Eng_SSE->Engine_sse::f4_volt[2][pos[0]][pos[1]][pos[2]].v;
+				ArrayLib::ArrayNIJK<f4vector>& f4_volt = *m_Eng_SSE->Engine_sse::f4_volt_ptr;
+				ArrayLib::ArrayNIJK<f4vector>& f4_curr = *m_Eng_SSE->Engine_sse::f4_curr_ptr;
 
-				H_energy.v += m_Eng_SSE->Engine_sse::f4_curr[0][pos[0]][pos[1]][pos[2]].v * m_Eng_SSE->Engine_sse::f4_curr[0][pos[0]][pos[1]][pos[2]].v;
-				H_energy.v += m_Eng_SSE->Engine_sse::f4_curr[1][pos[0]][pos[1]][pos[2]].v * m_Eng_SSE->Engine_sse::f4_curr[1][pos[0]][pos[1]][pos[2]].v;
-				H_energy.v += m_Eng_SSE->Engine_sse::f4_curr[2][pos[0]][pos[1]][pos[2]].v * m_Eng_SSE->Engine_sse::f4_curr[2][pos[0]][pos[1]][pos[2]].v;
+				E_energy.v += f4_volt[0][pos[0]][pos[1]][pos[2]].v * f4_volt[0][pos[0]][pos[1]][pos[2]].v;
+				E_energy.v += f4_volt[1][pos[0]][pos[1]][pos[2]].v * f4_volt[1][pos[0]][pos[1]][pos[2]].v;
+				E_energy.v += f4_volt[2][pos[0]][pos[1]][pos[2]].v * f4_volt[2][pos[0]][pos[1]][pos[2]].v;
+
+				H_energy.v += f4_curr[0][pos[0]][pos[1]][pos[2]].v * f4_curr[0][pos[0]][pos[1]][pos[2]].v;
+				H_energy.v += f4_curr[1][pos[0]][pos[1]][pos[2]].v * f4_curr[1][pos[0]][pos[1]][pos[2]].v;
+				H_energy.v += f4_curr[2][pos[0]][pos[1]][pos[2]].v * f4_curr[2][pos[0]][pos[1]][pos[2]].v;
 			}
 		}
 	}

--- a/FDTD/engine_sse.cpp
+++ b/FDTD/engine_sse.cpp
@@ -32,8 +32,8 @@ Engine_sse::Engine_sse(const Operator_sse* op) : Engine(op)
 {
 	m_type = SSE;
 	Op = op;
-	f4_volt = 0;
-	f4_curr = 0;
+	f4_volt_ptr = NULL;
+	f4_curr_ptr = NULL;
 	numVectors =  ceil((double)numLines[2]/4.0);
 
 	// speed up the calculation of denormal floating point values (flush-to-zero)
@@ -56,21 +56,30 @@ void Engine_sse::Init()
 	delete curr_ptr;
 	curr_ptr = NULL;
 
-	f4_volt = Create_N_3DArray_v4sf(numLines);
-	f4_curr = Create_N_3DArray_v4sf(numLines);
+	f4_volt_ptr = new ArrayLib::ArrayNIJK<f4vector>(
+		"f4_volt", {numLines[0], numLines[1], numVectors}
+	);
+	f4_curr_ptr = new ArrayLib::ArrayNIJK<f4vector>(
+		"f4_curr", {numLines[0], numLines[1], numVectors}
+	);
 }
 
 void Engine_sse::Reset()
 {
 	Engine::Reset();
-	Delete_N_3DArray_v4sf(f4_volt,numLines);
-	f4_volt = 0;
-	Delete_N_3DArray_v4sf(f4_curr,numLines);
-	f4_curr = 0;
+	delete f4_volt_ptr;
+	f4_volt_ptr = NULL;
+	delete f4_curr_ptr;
+	f4_curr_ptr = NULL;
 }
 
 void Engine_sse::UpdateVoltages(unsigned int startX, unsigned int numX)
 {
+	ArrayLib::ArrayNIJK<f4vector>& f4_volt = *f4_volt_ptr;
+	ArrayLib::ArrayNIJK<f4vector>& f4_curr = *f4_curr_ptr;
+	ArrayLib::ArrayNIJK<f4vector>& f4_vv = *Op->f4_vv_ptr;
+	ArrayLib::ArrayNIJK<f4vector>& f4_vi = *Op->f4_vi_ptr;
+
 	unsigned int pos[3];
 	bool shift[2];
 	f4vector temp;
@@ -86,9 +95,9 @@ void Engine_sse::UpdateVoltages(unsigned int startX, unsigned int numX)
 			{
 				// x-polarization
 				f4_volt[0][pos[0]][pos[1]][pos[2]].v *=
-				    Op->f4_vv[0][pos[0]][pos[1]][pos[2]].v;
+				    f4_vv[0][pos[0]][pos[1]][pos[2]].v;
 				f4_volt[0][pos[0]][pos[1]][pos[2]].v +=
-				    Op->f4_vi[0][pos[0]][pos[1]][pos[2]].v * (
+				    f4_vi[0][pos[0]][pos[1]][pos[2]].v * (
 				        f4_curr[2][pos[0]][pos[1]         ][pos[2]].v -
 				        f4_curr[2][pos[0]][pos[1]-shift[1]][pos[2]].v -
 				        f4_curr[1][pos[0]][pos[1]         ][pos[2]].v +
@@ -97,9 +106,9 @@ void Engine_sse::UpdateVoltages(unsigned int startX, unsigned int numX)
 
 				// y-polarization
 				f4_volt[1][pos[0]][pos[1]][pos[2]].v *=
-				    Op->f4_vv[1][pos[0]][pos[1]][pos[2]].v;
+				    f4_vv[1][pos[0]][pos[1]][pos[2]].v;
 				f4_volt[1][pos[0]][pos[1]][pos[2]].v +=
-				    Op->f4_vi[1][pos[0]][pos[1]][pos[2]].v * (
+				    f4_vi[1][pos[0]][pos[1]][pos[2]].v * (
 				        f4_curr[0][pos[0]         ][pos[1]][pos[2]  ].v -
 				        f4_curr[0][pos[0]         ][pos[1]][pos[2]-1].v -
 				        f4_curr[2][pos[0]         ][pos[1]][pos[2]  ].v +
@@ -108,9 +117,9 @@ void Engine_sse::UpdateVoltages(unsigned int startX, unsigned int numX)
 
 				// z-polarization
 				f4_volt[2][pos[0]][pos[1]][pos[2]].v *=
-				    Op->f4_vv[2][pos[0]][pos[1]][pos[2]].v;
+				    f4_vv[2][pos[0]][pos[1]][pos[2]].v;
 				f4_volt[2][pos[0]][pos[1]][pos[2]].v +=
-				    Op->f4_vi[2][pos[0]][pos[1]][pos[2]].v * (
+				    f4_vi[2][pos[0]][pos[1]][pos[2]].v * (
 				        f4_curr[1][pos[0]         ][pos[1]         ][pos[2]].v -
 				        f4_curr[1][pos[0]-shift[0]][pos[1]         ][pos[2]].v -
 				        f4_curr[0][pos[0]         ][pos[1]         ][pos[2]].v +
@@ -125,9 +134,9 @@ void Engine_sse::UpdateVoltages(unsigned int startX, unsigned int numX)
 			temp.f[2] = f4_curr[1][pos[0]][pos[1]][numVectors-1].f[1];
 			temp.f[3] = f4_curr[1][pos[0]][pos[1]][numVectors-1].f[2];
 			f4_volt[0][pos[0]][pos[1]][0].v *=
-			    Op->f4_vv[0][pos[0]][pos[1]][0].v;
+			    f4_vv[0][pos[0]][pos[1]][0].v;
 			f4_volt[0][pos[0]][pos[1]][0].v +=
-			    Op->f4_vi[0][pos[0]][pos[1]][0].v * (
+			    f4_vi[0][pos[0]][pos[1]][0].v * (
 			        f4_curr[2][pos[0]][pos[1]         ][0].v -
 			        f4_curr[2][pos[0]][pos[1]-shift[1]][0].v -
 			        f4_curr[1][pos[0]][pos[1]         ][0].v +
@@ -140,9 +149,9 @@ void Engine_sse::UpdateVoltages(unsigned int startX, unsigned int numX)
 			temp.f[2] = f4_curr[0][pos[0]][pos[1]][numVectors-1].f[1];
 			temp.f[3] = f4_curr[0][pos[0]][pos[1]][numVectors-1].f[2];
 			f4_volt[1][pos[0]][pos[1]][0].v *=
-			    Op->f4_vv[1][pos[0]][pos[1]][0].v;
+			    f4_vv[1][pos[0]][pos[1]][0].v;
 			f4_volt[1][pos[0]][pos[1]][0].v +=
-			    Op->f4_vi[1][pos[0]][pos[1]][0].v * (
+			    f4_vi[1][pos[0]][pos[1]][0].v * (
 			        f4_curr[0][pos[0]         ][pos[1]][0].v -
 			        temp.v -
 			        f4_curr[2][pos[0]         ][pos[1]][0].v +
@@ -151,9 +160,9 @@ void Engine_sse::UpdateVoltages(unsigned int startX, unsigned int numX)
 
 			// z-polarization
 			f4_volt[2][pos[0]][pos[1]][0].v *=
-			    Op->f4_vv[2][pos[0]][pos[1]][0].v;
+			    f4_vv[2][pos[0]][pos[1]][0].v;
 			f4_volt[2][pos[0]][pos[1]][0].v +=
-			    Op->f4_vi[2][pos[0]][pos[1]][0].v * (
+			    f4_vi[2][pos[0]][pos[1]][0].v * (
 			        f4_curr[1][pos[0]         ][pos[1]         ][0].v -
 			        f4_curr[1][pos[0]-shift[0]][pos[1]         ][0].v -
 			        f4_curr[0][pos[0]         ][pos[1]         ][0].v +
@@ -166,6 +175,11 @@ void Engine_sse::UpdateVoltages(unsigned int startX, unsigned int numX)
 
 void Engine_sse::UpdateCurrents(unsigned int startX, unsigned int numX)
 {
+	ArrayLib::ArrayNIJK<f4vector>& f4_curr = *f4_curr_ptr;
+	ArrayLib::ArrayNIJK<f4vector>& f4_volt = *f4_volt_ptr;
+	ArrayLib::ArrayNIJK<f4vector>& f4_ii = *Op->f4_ii_ptr;
+	ArrayLib::ArrayNIJK<f4vector>& f4_iv = *Op->f4_iv_ptr;
+
 	unsigned int pos[5];
 	f4vector temp;
 
@@ -178,9 +192,9 @@ void Engine_sse::UpdateCurrents(unsigned int startX, unsigned int numX)
 			{
 				// x-pol
 				f4_curr[0][pos[0]][pos[1]][pos[2]].v *=
-				    Op->f4_ii[0][pos[0]][pos[1]][pos[2]].v;
+				    f4_ii[0][pos[0]][pos[1]][pos[2]].v;
 				f4_curr[0][pos[0]][pos[1]][pos[2]].v +=
-				    Op->f4_iv[0][pos[0]][pos[1]][pos[2]].v * (
+				    f4_iv[0][pos[0]][pos[1]][pos[2]].v * (
 				        f4_volt[2][pos[0]][pos[1]  ][pos[2]  ].v -
 				        f4_volt[2][pos[0]][pos[1]+1][pos[2]  ].v -
 				        f4_volt[1][pos[0]][pos[1]  ][pos[2]  ].v +
@@ -189,9 +203,9 @@ void Engine_sse::UpdateCurrents(unsigned int startX, unsigned int numX)
 
 				// y-pol
 				f4_curr[1][pos[0]][pos[1]][pos[2]].v *=
-				    Op->f4_ii[1][pos[0]][pos[1]][pos[2]].v;
+				    f4_ii[1][pos[0]][pos[1]][pos[2]].v;
 				f4_curr[1][pos[0]][pos[1]][pos[2]].v +=
-				    Op->f4_iv[1][pos[0]][pos[1]][pos[2]].v * (
+				    f4_iv[1][pos[0]][pos[1]][pos[2]].v * (
 				        f4_volt[0][pos[0]  ][pos[1]][pos[2]  ].v -
 				        f4_volt[0][pos[0]  ][pos[1]][pos[2]+1].v -
 				        f4_volt[2][pos[0]  ][pos[1]][pos[2]  ].v +
@@ -200,9 +214,9 @@ void Engine_sse::UpdateCurrents(unsigned int startX, unsigned int numX)
 
 				// z-pol
 				f4_curr[2][pos[0]][pos[1]][pos[2]].v *=
-				    Op->f4_ii[2][pos[0]][pos[1]][pos[2]].v;
+				    f4_ii[2][pos[0]][pos[1]][pos[2]].v;
 				f4_curr[2][pos[0]][pos[1]][pos[2]].v +=
-				    Op->f4_iv[2][pos[0]][pos[1]][pos[2]].v * (
+				    f4_iv[2][pos[0]][pos[1]][pos[2]].v * (
 				        f4_volt[1][pos[0]  ][pos[1]  ][pos[2]].v -
 				        f4_volt[1][pos[0]+1][pos[1]  ][pos[2]].v -
 				        f4_volt[0][pos[0]  ][pos[1]  ][pos[2]].v +
@@ -217,9 +231,9 @@ void Engine_sse::UpdateCurrents(unsigned int startX, unsigned int numX)
 			temp.f[2] = f4_volt[1][pos[0]][pos[1]][0].f[3];
 			temp.f[3] = 0;
 			f4_curr[0][pos[0]][pos[1]][numVectors-1].v *=
-			    Op->f4_ii[0][pos[0]][pos[1]][numVectors-1].v;
+			    f4_ii[0][pos[0]][pos[1]][numVectors-1].v;
 			f4_curr[0][pos[0]][pos[1]][numVectors-1].v +=
-			    Op->f4_iv[0][pos[0]][pos[1]][numVectors-1].v * (
+			    f4_iv[0][pos[0]][pos[1]][numVectors-1].v * (
 			        f4_volt[2][pos[0]][pos[1]  ][numVectors-1].v -
 			        f4_volt[2][pos[0]][pos[1]+1][numVectors-1].v -
 			        f4_volt[1][pos[0]][pos[1]  ][numVectors-1].v +
@@ -232,9 +246,9 @@ void Engine_sse::UpdateCurrents(unsigned int startX, unsigned int numX)
 			temp.f[2] = f4_volt[0][pos[0]][pos[1]][0].f[3];
 			temp.f[3] = 0;
 			f4_curr[1][pos[0]][pos[1]][numVectors-1].v *=
-			    Op->f4_ii[1][pos[0]][pos[1]][numVectors-1].v;
+			    f4_ii[1][pos[0]][pos[1]][numVectors-1].v;
 			f4_curr[1][pos[0]][pos[1]][numVectors-1].v +=
-			    Op->f4_iv[1][pos[0]][pos[1]][numVectors-1].v * (
+			    f4_iv[1][pos[0]][pos[1]][numVectors-1].v * (
 			        f4_volt[0][pos[0]  ][pos[1]][numVectors-1].v -
 			        temp.v -
 			        f4_volt[2][pos[0]  ][pos[1]][numVectors-1].v +
@@ -243,9 +257,9 @@ void Engine_sse::UpdateCurrents(unsigned int startX, unsigned int numX)
 
 			// z-pol
 			f4_curr[2][pos[0]][pos[1]][numVectors-1].v *=
-			    Op->f4_ii[2][pos[0]][pos[1]][numVectors-1].v;
+			    f4_ii[2][pos[0]][pos[1]][numVectors-1].v;
 			f4_curr[2][pos[0]][pos[1]][numVectors-1].v +=
-			    Op->f4_iv[2][pos[0]][pos[1]][numVectors-1].v * (
+			    f4_iv[2][pos[0]][pos[1]][numVectors-1].v * (
 			        f4_volt[1][pos[0]  ][pos[1]  ][numVectors-1].v -
 			        f4_volt[1][pos[0]+1][pos[1]  ][numVectors-1].v -
 			        f4_volt[0][pos[0]  ][pos[1]  ][numVectors-1].v +

--- a/FDTD/engine_sse.cpp
+++ b/FDTD/engine_sse.cpp
@@ -49,10 +49,12 @@ void Engine_sse::Init()
 {
 	Engine::Init();
 
-	Delete_N_3DArray(volt,numLines);
-	volt=NULL; // not used
-	Delete_N_3DArray(curr,numLines);
-	curr=NULL; // not used
+	// This engine uses its own SIMD arrays to represent E&M fields, so
+	// free the arrays from the base class.
+	delete volt_ptr;
+	volt_ptr = NULL;
+	delete curr_ptr;
+	curr_ptr = NULL;
 
 	f4_volt = Create_N_3DArray_v4sf(numLines);
 	f4_curr = Create_N_3DArray_v4sf(numLines);

--- a/FDTD/engine_sse.h
+++ b/FDTD/engine_sse.h
@@ -33,15 +33,45 @@ public:
 	virtual unsigned int GetNumberOfTimesteps() {return numTS;};
 
 	//this access functions muss be overloaded by any new engine using a different storage model
-	inline virtual FDTD_FLOAT GetVolt( unsigned int n, unsigned int x, unsigned int y, unsigned int z )	const { return f4_volt[n][x][y][z%numVectors].f[z/numVectors]; }
-	inline virtual FDTD_FLOAT GetVolt( unsigned int n, const unsigned int pos[3] )						const { return f4_volt[n][pos[0]][pos[1]][pos[2]%numVectors].f[pos[2]/numVectors]; }
-	inline virtual FDTD_FLOAT GetCurr( unsigned int n, unsigned int x, unsigned int y, unsigned int z )	const { return f4_curr[n][x][y][z%numVectors].f[z/numVectors]; }
-	inline virtual FDTD_FLOAT GetCurr( unsigned int n, const unsigned int pos[3] )						const { return f4_curr[n][pos[0]][pos[1]][pos[2]%numVectors].f[pos[2]/numVectors]; }
+	inline virtual FDTD_FLOAT GetVolt(unsigned int n, unsigned int x, unsigned int y, unsigned int z) const
+	{
+		return f4_volt[n][x][y][z%numVectors].f[z/numVectors];
+	}
 
-	inline virtual void SetVolt( unsigned int n, unsigned int x, unsigned int y, unsigned int z, FDTD_FLOAT value)	{ f4_volt[n][x][y][z%numVectors].f[z/numVectors]=value; }
-	inline virtual void SetVolt( unsigned int n, const unsigned int pos[3], FDTD_FLOAT value )						{ f4_volt[n][pos[0]][pos[1]][pos[2]%numVectors].f[pos[2]/numVectors]=value; }
-	inline virtual void SetCurr( unsigned int n, unsigned int x, unsigned int y, unsigned int z, FDTD_FLOAT value)	{ f4_curr[n][x][y][z%numVectors].f[z/numVectors]=value; }
-	inline virtual void SetCurr( unsigned int n, const unsigned int pos[3], FDTD_FLOAT value )						{ f4_curr[n][pos[0]][pos[1]][pos[2]%numVectors].f[pos[2]/numVectors]=value; }
+	inline virtual FDTD_FLOAT GetVolt(unsigned int n, const unsigned int pos[3]) const
+	{
+		return f4_volt[n][pos[0]][pos[1]][pos[2]%numVectors].f[pos[2]/numVectors];
+	}
+
+	inline virtual FDTD_FLOAT GetCurr(unsigned int n, unsigned int x, unsigned int y, unsigned int z) const
+	{
+		return f4_curr[n][x][y][z%numVectors].f[z/numVectors];
+	}
+
+	inline virtual FDTD_FLOAT GetCurr(unsigned int n, const unsigned int pos[3]) const
+	{
+		return f4_curr[n][pos[0]][pos[1]][pos[2]%numVectors].f[pos[2]/numVectors];
+	}
+
+	inline virtual void SetVolt(unsigned int n, unsigned int x, unsigned int y, unsigned int z, FDTD_FLOAT value)
+	{
+		f4_volt[n][x][y][z%numVectors].f[z/numVectors]=value;
+	}
+
+	inline virtual void SetVolt(unsigned int n, const unsigned int pos[3], FDTD_FLOAT value)
+	{
+		f4_volt[n][pos[0]][pos[1]][pos[2]%numVectors].f[pos[2]/numVectors]=value;
+	}
+
+	inline virtual void SetCurr(unsigned int n, unsigned int x, unsigned int y, unsigned int z, FDTD_FLOAT value)
+	{
+		f4_curr[n][x][y][z%numVectors].f[z/numVectors]=value;
+	}
+
+	inline virtual void SetCurr(unsigned int n, const unsigned int pos[3], FDTD_FLOAT value)
+	{
+		f4_curr[n][pos[0]][pos[1]][pos[2]%numVectors].f[pos[2]/numVectors]=value;
+	}
 
 protected:
 	Engine_sse(const Operator_sse* op);

--- a/FDTD/engine_sse.h
+++ b/FDTD/engine_sse.h
@@ -21,6 +21,8 @@
 #include "engine.h"
 #include "operator_sse.h"
 
+#include "tools/arraylib/array_nijk.h"
+
 class Engine_sse : public Engine
 {
 public:
@@ -35,41 +37,49 @@ public:
 	//this access functions muss be overloaded by any new engine using a different storage model
 	inline virtual FDTD_FLOAT GetVolt(unsigned int n, unsigned int x, unsigned int y, unsigned int z) const
 	{
+		ArrayLib::ArrayNIJK<f4vector>& f4_volt = *f4_volt_ptr;
 		return f4_volt[n][x][y][z%numVectors].f[z/numVectors];
 	}
 
 	inline virtual FDTD_FLOAT GetVolt(unsigned int n, const unsigned int pos[3]) const
 	{
+		ArrayLib::ArrayNIJK<f4vector>& f4_volt = *f4_volt_ptr;
 		return f4_volt[n][pos[0]][pos[1]][pos[2]%numVectors].f[pos[2]/numVectors];
 	}
 
 	inline virtual FDTD_FLOAT GetCurr(unsigned int n, unsigned int x, unsigned int y, unsigned int z) const
 	{
+		ArrayLib::ArrayNIJK<f4vector>& f4_curr = *f4_curr_ptr;
 		return f4_curr[n][x][y][z%numVectors].f[z/numVectors];
 	}
 
 	inline virtual FDTD_FLOAT GetCurr(unsigned int n, const unsigned int pos[3]) const
 	{
+		ArrayLib::ArrayNIJK<f4vector>& f4_curr = *f4_curr_ptr;
 		return f4_curr[n][pos[0]][pos[1]][pos[2]%numVectors].f[pos[2]/numVectors];
 	}
 
 	inline virtual void SetVolt(unsigned int n, unsigned int x, unsigned int y, unsigned int z, FDTD_FLOAT value)
 	{
+		ArrayLib::ArrayNIJK<f4vector>& f4_volt = *f4_volt_ptr;
 		f4_volt[n][x][y][z%numVectors].f[z/numVectors]=value;
 	}
 
 	inline virtual void SetVolt(unsigned int n, const unsigned int pos[3], FDTD_FLOAT value)
 	{
+		ArrayLib::ArrayNIJK<f4vector>& f4_volt = *f4_volt_ptr;
 		f4_volt[n][pos[0]][pos[1]][pos[2]%numVectors].f[pos[2]/numVectors]=value;
 	}
 
 	inline virtual void SetCurr(unsigned int n, unsigned int x, unsigned int y, unsigned int z, FDTD_FLOAT value)
 	{
+		ArrayLib::ArrayNIJK<f4vector>& f4_curr = *f4_curr_ptr;
 		f4_curr[n][x][y][z%numVectors].f[z/numVectors]=value;
 	}
 
 	inline virtual void SetCurr(unsigned int n, const unsigned int pos[3], FDTD_FLOAT value)
 	{
+		ArrayLib::ArrayNIJK<f4vector>& f4_curr = *f4_curr_ptr;
 		f4_curr[n][pos[0]][pos[1]][pos[2]%numVectors].f[pos[2]/numVectors]=value;
 	}
 
@@ -83,8 +93,8 @@ protected:
 	unsigned int numVectors;
 
 public: //public access to the sse arrays for efficient extensions access... use careful...
-	f4vector**** f4_volt;
-	f4vector**** f4_curr;
+	ArrayLib::ArrayNIJK<f4vector>* f4_volt_ptr;
+	ArrayLib::ArrayNIJK<f4vector>* f4_curr_ptr;
 };
 
 #endif // ENGINE_SSE_H

--- a/FDTD/engine_sse_compressed.cpp
+++ b/FDTD/engine_sse_compressed.cpp
@@ -47,6 +47,9 @@ Engine_SSE_Compressed::~Engine_SSE_Compressed()
 
 void Engine_SSE_Compressed::UpdateVoltages(unsigned int startX, unsigned int numX)
 {
+	ArrayLib::ArrayNIJK<f4vector>& f4_volt = *f4_volt_ptr;
+	ArrayLib::ArrayNIJK<f4vector>& f4_curr = *f4_curr_ptr;
+
 	unsigned int pos[3];
 	bool shift[2];
 	f4vector temp;
@@ -157,6 +160,9 @@ void Engine_SSE_Compressed::UpdateVoltages(unsigned int startX, unsigned int num
 
 void Engine_SSE_Compressed::UpdateCurrents(unsigned int startX, unsigned int numX)
 {
+	ArrayLib::ArrayNIJK<f4vector>& f4_curr = *f4_curr_ptr;
+	ArrayLib::ArrayNIJK<f4vector>& f4_volt = *f4_volt_ptr;
+
 	unsigned int pos[3];
 	f4vector temp;
 

--- a/FDTD/extensions/engine_ext_cylindermultigrid.cpp
+++ b/FDTD/extensions/engine_ext_cylindermultigrid.cpp
@@ -106,15 +106,18 @@ void Engine_Ext_CylinderMultiGrid::SyncVoltages()
 		pos1_half = pos[1]/2;
 		for (pos[2]=0; pos[2]<m_Eng_MG->numVectors; ++pos[2])
 		{
+			ArrayLib::ArrayNIJK<f4vector>& mgEng_f4_volt = *m_Eng_MG->f4_volt_ptr;
+			ArrayLib::ArrayNIJK<f4vector>& innerEng_f4_volt = *m_InnerEng->f4_volt_ptr;
+
 			//r - direczion
-			m_InnerEng->f4_volt[0][pos[0]][pos1_half][pos[2]].v = v_null.v;
+			innerEng_f4_volt[0][pos[0]][pos1_half][pos[2]].v = v_null.v;
 
 			//z - direction
-			m_InnerEng->f4_volt[2][pos[0]][pos1_half][pos[2]].v = m_Eng_MG->f4_volt[2][pos[0]][pos[1]][pos[2]].v;
+			innerEng_f4_volt[2][pos[0]][pos1_half][pos[2]].v = mgEng_f4_volt[2][pos[0]][pos[1]][pos[2]].v;
 
 			//alpha - direction
-			m_InnerEng->f4_volt[1][pos[0]][pos1_half][pos[2]].v  = m_Eng_MG->f4_volt[1][pos[0]][pos[1]][pos[2]].v;
-			m_InnerEng->f4_volt[1][pos[0]][pos1_half][pos[2]].v += m_Eng_MG->f4_volt[1][pos[0]][pos[1]+1][pos[2]].v;
+			innerEng_f4_volt[1][pos[0]][pos1_half][pos[2]].v  = mgEng_f4_volt[1][pos[0]][pos[1]][pos[2]].v;
+			innerEng_f4_volt[1][pos[0]][pos1_half][pos[2]].v += mgEng_f4_volt[1][pos[0]][pos[1]+1][pos[2]].v;
 		}
 	}
 }

--- a/FDTD/extensions/engine_ext_mur_abc.cpp
+++ b/FDTD/extensions/engine_ext_mur_abc.cpp
@@ -23,7 +23,12 @@
 #include "tools/useful.h"
 #include "operator_ext_excitation.h"
 
-Engine_Ext_Mur_ABC::Engine_Ext_Mur_ABC(Operator_Ext_Mur_ABC* op_ext) : Engine_Extension(op_ext)
+Engine_Ext_Mur_ABC::Engine_Ext_Mur_ABC(Operator_Ext_Mur_ABC* op_ext) :
+	Engine_Extension(op_ext),
+	m_Mur_Coeff_nyP (op_ext->m_Mur_Coeff_nyP),
+	m_Mur_Coeff_nyPP(op_ext->m_Mur_Coeff_nyPP),
+	m_volt_nyP ("volt_nyP",  op_ext->m_numLines),
+	m_volt_nyPP("volt_nyPP", op_ext->m_numLines)
 {
 	m_Op_mur = op_ext;
 	m_numLines[0] = m_Op_mur->m_numLines[0];
@@ -33,12 +38,6 @@ Engine_Ext_Mur_ABC::Engine_Ext_Mur_ABC(Operator_Ext_Mur_ABC* op_ext) : Engine_Ex
 	m_nyPP = m_Op_mur->m_nyPP;
 	m_LineNr = m_Op_mur->m_LineNr;
 	m_LineNr_Shift = m_Op_mur->m_LineNr_Shift;
-
-	m_Mur_Coeff_nyP = m_Op_mur->m_Mur_Coeff_nyP;
-	m_Mur_Coeff_nyPP = m_Op_mur->m_Mur_Coeff_nyPP;
-
-	m_volt_nyP = Create2DArray<FDTD_FLOAT>(m_numLines);
-	m_volt_nyPP = Create2DArray<FDTD_FLOAT>(m_numLines);
 
 	//find if some excitation is on this mur-abc and find the max length of this excite, so that the abc can start after the excitation is done...
 	int maxDelay=-1;
@@ -63,10 +62,6 @@ Engine_Ext_Mur_ABC::Engine_Ext_Mur_ABC(Operator_Ext_Mur_ABC* op_ext) : Engine_Ex
 
 Engine_Ext_Mur_ABC::~Engine_Ext_Mur_ABC()
 {
-	Delete2DArray(m_volt_nyP,m_numLines);
-	m_volt_nyP = NULL;
-	Delete2DArray(m_volt_nyPP,m_numLines);
-	m_volt_nyPP = NULL;
 }
 
 

--- a/FDTD/extensions/engine_ext_mur_abc.h
+++ b/FDTD/extensions/engine_ext_mur_abc.h
@@ -22,6 +22,7 @@
 #include "FDTD/engine.h"
 #include "FDTD/operator.h"
 #include "engine_extension_dispatcher.h"
+#include "tools/arraylib/array_ij.h"
 
 class Operator_Ext_Mur_ABC;
 
@@ -64,10 +65,10 @@ protected:
 	vector<unsigned int> m_start;
 	vector<unsigned int> m_numX;
 
-	FDTD_FLOAT** m_Mur_Coeff_nyP;
-	FDTD_FLOAT** m_Mur_Coeff_nyPP;
-	FDTD_FLOAT** m_volt_nyP; //n+1 direction
-	FDTD_FLOAT** m_volt_nyPP; //n+2 direction
+	ArrayLib::ArrayIJ<FDTD_FLOAT>& m_Mur_Coeff_nyP;
+	ArrayLib::ArrayIJ<FDTD_FLOAT>& m_Mur_Coeff_nyPP;
+	ArrayLib::ArrayIJ<FDTD_FLOAT> m_volt_nyP; //n+1 direction
+	ArrayLib::ArrayIJ<FDTD_FLOAT> m_volt_nyPP; //n+2 direction
 };
 
 #endif // ENGINE_EXT_MUR_ABC_H

--- a/FDTD/extensions/engine_ext_upml.cpp
+++ b/FDTD/extensions/engine_ext_upml.cpp
@@ -29,18 +29,14 @@ Engine_Ext_UPML::Engine_Ext_UPML(Operator_Ext_UPML* op_ext) : Engine_Extension(o
 	//this ABC extension should be executed first!
 	m_Priority = ENG_EXT_PRIO_UPML;
 
-	volt_flux = Create_N_3DArray<FDTD_FLOAT>(m_Op_UPML->m_numLines);
-	curr_flux = Create_N_3DArray<FDTD_FLOAT>(m_Op_UPML->m_numLines);
+	volt_flux.Init("volt_flux", m_Op_UPML->m_numLines);
+	curr_flux.Init("curr_flux", m_Op_UPML->m_numLines);
 
 	SetNumberOfThreads(1);
 }
 
 Engine_Ext_UPML::~Engine_Ext_UPML()
 {
-	Delete_N_3DArray<FDTD_FLOAT>(volt_flux,m_Op_UPML->m_numLines);
-	volt_flux=NULL;
-	Delete_N_3DArray<FDTD_FLOAT>(curr_flux,m_Op_UPML->m_numLines);
-	curr_flux=NULL;
 }
 
 void Engine_Ext_UPML::SetNumberOfThreads(int nrThread)

--- a/FDTD/extensions/engine_ext_upml.h
+++ b/FDTD/extensions/engine_ext_upml.h
@@ -61,8 +61,8 @@ protected:
 	vector<unsigned int> m_start;
 	vector<unsigned int> m_numX;
 
-	FDTD_FLOAT**** volt_flux;
-	FDTD_FLOAT**** curr_flux;
+	ArrayLib::ArrayNIJK<FDTD_FLOAT> volt_flux;
+	ArrayLib::ArrayNIJK<FDTD_FLOAT> curr_flux;
 };
 
 #endif // ENGINE_EXT_UPML_H

--- a/FDTD/extensions/operator_ext_mur_abc.cpp
+++ b/FDTD/extensions/operator_ext_mur_abc.cpp
@@ -29,10 +29,6 @@ Operator_Ext_Mur_ABC::Operator_Ext_Mur_ABC(Operator* op) : Operator_Extension(op
 
 Operator_Ext_Mur_ABC::~Operator_Ext_Mur_ABC()
 {
-	Delete2DArray(m_Mur_Coeff_nyP,m_numLines);
-	m_Mur_Coeff_nyP = NULL;
-	Delete2DArray(m_Mur_Coeff_nyPP,m_numLines);
-	m_Mur_Coeff_nyPP = NULL;
 }
 
 Operator_Ext_Mur_ABC::Operator_Ext_Mur_ABC(Operator* op, Operator_Ext_Mur_ABC* op_ext) : Operator_Extension(op, op_ext)
@@ -78,9 +74,6 @@ void Operator_Ext_Mur_ABC::Initialize()
 
 	m_v_phase = 0.0;
 
-	m_Mur_Coeff_nyP = NULL;
-	m_Mur_Coeff_nyPP = NULL;
-
 	m_numLines[0]=0;
 	m_numLines[1]=0;
 }
@@ -89,9 +82,6 @@ void Operator_Ext_Mur_ABC::SetDirection(int ny, bool top_ny)
 {
 	if ((ny<0) || (ny>2))
 		return;
-
-	Delete2DArray(m_Mur_Coeff_nyP,m_numLines);
-	Delete2DArray(m_Mur_Coeff_nyPP,m_numLines);
 
 	m_ny = ny;
 	m_top = top_ny;
@@ -111,9 +101,8 @@ void Operator_Ext_Mur_ABC::SetDirection(int ny, bool top_ny)
 	m_numLines[0] = m_Op->GetNumberOfLines(m_nyP,true);
 	m_numLines[1] = m_Op->GetNumberOfLines(m_nyPP,true);
 
-	m_Mur_Coeff_nyP = Create2DArray<FDTD_FLOAT>(m_numLines);
-	m_Mur_Coeff_nyPP = Create2DArray<FDTD_FLOAT>(m_numLines);
-
+	m_Mur_Coeff_nyP.Init("Mur_Coeff_nyP", m_numLines);
+	m_Mur_Coeff_nyPP.Init("Mur_Coeff_nyPP", m_numLines);
 }
 
 bool Operator_Ext_Mur_ABC::BuildExtension()

--- a/FDTD/extensions/operator_ext_mur_abc.h
+++ b/FDTD/extensions/operator_ext_mur_abc.h
@@ -20,6 +20,7 @@
 
 #include "FDTD/operator.h"
 #include "operator_extension.h"
+#include "tools/arraylib/array_ij.h"
 
 class Operator_Ext_Mur_ABC : public Operator_Extension
 {
@@ -61,8 +62,8 @@ protected:
 
 	unsigned int m_numLines[2];
 
-	FDTD_FLOAT** m_Mur_Coeff_nyP;
-	FDTD_FLOAT** m_Mur_Coeff_nyPP;
+	ArrayLib::ArrayIJ<FDTD_FLOAT> m_Mur_Coeff_nyP;
+	ArrayLib::ArrayIJ<FDTD_FLOAT> m_Mur_Coeff_nyPP;
 };
 
 #endif // OPERATOR_EXT_MUR_ABC_H

--- a/FDTD/extensions/operator_ext_upml.cpp
+++ b/FDTD/extensions/operator_ext_upml.cpp
@@ -40,13 +40,6 @@ Operator_Ext_UPML::Operator_Ext_UPML(Operator* op) : Operator_Extension(op)
 		m_StartPos[n]=0;
 		m_numLines[n]=0;
 	}
-
-	vv = NULL;
-	vvfo = NULL;
-	vvfn = NULL;
-	ii = NULL;
-	iifo = NULL;
-	iifn = NULL;
 }
 
 Operator_Ext_UPML::~Operator_Ext_UPML()
@@ -257,18 +250,6 @@ bool Operator_Ext_UPML::Create_UPML(Operator* op, const int ui_BC[6], const unsi
 
 void Operator_Ext_UPML::DeleteOp()
 {
-	Delete_N_3DArray<FDTD_FLOAT>(vv,m_numLines);
-	vv = NULL;
-	Delete_N_3DArray<FDTD_FLOAT>(vvfo,m_numLines);
-	vvfo = NULL;
-	Delete_N_3DArray<FDTD_FLOAT>(vvfn,m_numLines);
-	vvfn = NULL;
-	Delete_N_3DArray<FDTD_FLOAT>(ii,m_numLines);
-	ii = NULL;
-	Delete_N_3DArray<FDTD_FLOAT>(iifo,m_numLines);
-	iifo = NULL;
-	Delete_N_3DArray<FDTD_FLOAT>(iifn,m_numLines);
-	iifn = NULL;
 }
 
 
@@ -372,13 +353,12 @@ bool Operator_Ext_UPML::BuildExtension()
 	if (m_Op==NULL)
 		return false;
 
-	DeleteOp();
-	vv = Create_N_3DArray<FDTD_FLOAT>(m_numLines);
-	vvfo = Create_N_3DArray<FDTD_FLOAT>(m_numLines);
-	vvfn = Create_N_3DArray<FDTD_FLOAT>(m_numLines);
-	ii = Create_N_3DArray<FDTD_FLOAT>(m_numLines);
-	iifo = Create_N_3DArray<FDTD_FLOAT>(m_numLines);
-	iifn = Create_N_3DArray<FDTD_FLOAT>(m_numLines);
+	vv.Init("vv", m_numLines);
+	vvfo.Init("vvfo", m_numLines);
+	vvfn.Init("vvfn", m_numLines);
+	ii.Init("ii", m_numLines);
+	iifo.Init("iifo", m_numLines);
+	iifn.Init("iifn", m_numLines);
 
 	unsigned int pos[3];
 	unsigned int loc_pos[3];

--- a/FDTD/extensions/operator_ext_upml.h
+++ b/FDTD/extensions/operator_ext_upml.h
@@ -21,6 +21,8 @@
 #include "FDTD/operator.h"
 #include "operator_extension.h"
 
+#include "tools/arraylib/array_nijk.h"
+
 class FunctionParser;
 
 //! Operator extension implementation an uniaxial perfectly matched layer (upml)
@@ -95,12 +97,12 @@ protected:
 	virtual FDTD_FLOAT& GetIIFO(int ny, unsigned int pos[3]) {return iifo[ny][pos[0]][pos[1]][pos[2]];}
 	virtual FDTD_FLOAT& GetIIFN(int ny, unsigned int pos[3]) {return iifn[ny][pos[0]][pos[1]][pos[2]];}
 
-	FDTD_FLOAT**** vv;   //calc new voltage from old voltage
-	FDTD_FLOAT**** vvfo; //calc new voltage from old voltage flux
-	FDTD_FLOAT**** vvfn; //calc new voltage from new voltage flux
-	FDTD_FLOAT**** ii;   //calc new current from old current
-	FDTD_FLOAT**** iifo; //calc new current from old current flux
-	FDTD_FLOAT**** iifn; //calc new current from new current flux
+	ArrayLib::ArrayNIJK<FDTD_FLOAT> vv;   //calc new voltage from old voltage
+	ArrayLib::ArrayNIJK<FDTD_FLOAT> vvfo; //calc new voltage from old voltage flux
+	ArrayLib::ArrayNIJK<FDTD_FLOAT> vvfn; //calc new voltage from new voltage flux
+	ArrayLib::ArrayNIJK<FDTD_FLOAT> ii;   //calc new current from old current
+	ArrayLib::ArrayNIJK<FDTD_FLOAT> iifo; //calc new current from old current flux
+	ArrayLib::ArrayNIJK<FDTD_FLOAT> iifn; //calc new current from new current flux
 };
 
 #endif // OPERATOR_EXT_UPML_H

--- a/FDTD/operator.cpp
+++ b/FDTD/operator.cpp
@@ -79,10 +79,10 @@ void Operator::Init()
 	iv=NULL;
 	ii=NULL;
 
-	m_epsR=NULL;
-	m_kappa=NULL;
-	m_mueR=NULL;
-	m_sigma=NULL;
+	m_epsR_ptr = NULL;
+	m_kappa_ptr = NULL;
+	m_mueR_ptr = NULL;
+	m_sigma_ptr = NULL;
 
 	MainOp=NULL;
 
@@ -117,14 +117,14 @@ void Operator::Delete()
 		delete[] EC_R[n];EC_R[n]=0;
 	}
 
-	Delete_N_3DArray(m_epsR,numLines);
-	m_epsR=0;
-	Delete_N_3DArray(m_kappa,numLines);
-	m_kappa=0;
-	Delete_N_3DArray(m_mueR,numLines);
-	m_mueR=0;
-	Delete_N_3DArray(m_sigma,numLines);
-	m_sigma=0;
+	delete m_epsR_ptr;
+	m_epsR_ptr = NULL;
+	delete m_kappa_ptr;
+	m_kappa_ptr = NULL;
+	delete m_mueR_ptr;
+	m_mueR_ptr = NULL;
+	delete m_sigma_ptr;
+	m_sigma_ptr = NULL;
 }
 
 void Operator::Reset()
@@ -742,10 +742,10 @@ void Operator::DumpMaterial2File(string filename)
 
 	cout << "Operator: Dumping material information to vtk file: " << filename << " ..."  << flush;
 
-	FDTD_FLOAT**** epsilon = Create_N_3DArray<FDTD_FLOAT>(numLines);
-	FDTD_FLOAT**** mue     = Create_N_3DArray<FDTD_FLOAT>(numLines);
-	FDTD_FLOAT**** kappa   = Create_N_3DArray<FDTD_FLOAT>(numLines);
-	FDTD_FLOAT**** sigma   = Create_N_3DArray<FDTD_FLOAT>(numLines);
+	ArrayLib::ArrayNIJK<FDTD_FLOAT> epsilon("epsilonR", numLines);
+	ArrayLib::ArrayNIJK<FDTD_FLOAT> mue("mueR", numLines);
+	ArrayLib::ArrayNIJK<FDTD_FLOAT> kappa("kappa", numLines);
+	ArrayLib::ArrayNIJK<FDTD_FLOAT> sigma("sigma", numLines);
 
 	unsigned int pos[3];
 	for (pos[0]=0; pos[0]<numLines[0]; ++pos[0])
@@ -775,13 +775,9 @@ void Operator::DumpMaterial2File(string filename)
 	vtk_Writer->SetNativeDump(true);
 
 	vtk_Writer->AddVectorField("epsilon",epsilon);
-	Delete_N_3DArray(epsilon,numLines);
 	vtk_Writer->AddVectorField("mue",mue);
-	Delete_N_3DArray(mue,numLines);
 	vtk_Writer->AddVectorField("kappa",kappa);
-	Delete_N_3DArray(kappa,numLines);
 	vtk_Writer->AddVectorField("sigma",sigma);
-	Delete_N_3DArray(sigma,numLines);
 
 	if (vtk_Writer->Write()==false)
 		cerr << "Operator::DumpMaterial2File: Error: Can't write file... skipping!" << endl;
@@ -853,61 +849,57 @@ void Operator::InitDataStorage()
 	{
 		if (g_settings.GetVerboseLevel()>0)
 			cerr << "Operator::InitDataStorage(): Storing epsR material data..." << endl;
-		Delete_N_3DArray(m_epsR,numLines);
-		m_epsR = Create_N_3DArray<float>(numLines);
+		m_epsR_ptr = new ArrayLib::ArrayNIJK<float>("m_epsR", numLines);
 	}
 	if (m_StoreMaterial[1])
 	{
 		if (g_settings.GetVerboseLevel()>0)
 			cerr << "Operator::InitDataStorage(): Storing kappa material data..." << endl;
-		Delete_N_3DArray(m_kappa,numLines);
-		m_kappa = Create_N_3DArray<float>(numLines);
+		m_kappa_ptr = new ArrayLib::ArrayNIJK<float>("m_kappa", numLines);
 	}
 	if (m_StoreMaterial[2])
 	{
 		if (g_settings.GetVerboseLevel()>0)
 			cerr << "Operator::InitDataStorage(): Storing muR material data..." << endl;
-		Delete_N_3DArray(m_mueR,numLines);
-		m_mueR = Create_N_3DArray<float>(numLines);
+		m_mueR_ptr = new ArrayLib::ArrayNIJK<float>("m_mueR", numLines);
 	}
 	if (m_StoreMaterial[3])
 	{
 		if (g_settings.GetVerboseLevel()>0)
 			cerr << "Operator::InitDataStorage(): Storing sigma material data..." << endl;
-		Delete_N_3DArray(m_sigma,numLines);
-		m_sigma = Create_N_3DArray<float>(numLines);
+		m_sigma_ptr = new ArrayLib::ArrayNIJK<float>("m_sigma", numLines);
 	}
 }
 
 void Operator::CleanupMaterialStorage()
 {
-	if (!m_StoreMaterial[0] && m_epsR)
+	if (!m_StoreMaterial[0] && m_epsR_ptr)
 	{
 		if (g_settings.GetVerboseLevel()>0)
 			cerr << "Operator::CleanupMaterialStorage(): Delete epsR material data..." << endl;
-		Delete_N_3DArray(m_epsR,numLines);
-		m_epsR = NULL;
+		delete m_epsR_ptr;
+		m_epsR_ptr = NULL;
 	}
-	if (!m_StoreMaterial[1] && m_kappa)
+	if (!m_StoreMaterial[1] && m_kappa_ptr)
 	{
 		if (g_settings.GetVerboseLevel()>0)
 			cerr << "Operator::CleanupMaterialStorage(): Delete kappa material data..." << endl;
-		Delete_N_3DArray(m_kappa,numLines);
-		m_kappa = NULL;
+		delete m_kappa_ptr;
+		m_kappa_ptr = NULL;
 	}
-	if (!m_StoreMaterial[2] && m_mueR)
+	if (!m_StoreMaterial[2] && m_mueR_ptr)
 	{
 		if (g_settings.GetVerboseLevel()>0)
 			cerr << "Operator::CleanupMaterialStorage(): Delete mueR material data..." << endl;
-		Delete_N_3DArray(m_mueR,numLines);
-		m_mueR = NULL;
+		delete m_mueR_ptr;
+		m_mueR_ptr = NULL;
 	}
-	if (!m_StoreMaterial[3] && m_sigma)
+	if (!m_StoreMaterial[3] && m_sigma_ptr)
 	{
 		if (g_settings.GetVerboseLevel()>0)
 			cerr << "Operator::CleanupMaterialStorage(): Delete sigma material data..." << endl;
-		Delete_N_3DArray(m_sigma,numLines);
-		m_sigma = NULL;
+		delete m_sigma_ptr;
+		m_sigma_ptr = NULL;
 	}
 }
 
@@ -916,21 +908,37 @@ double Operator::GetDiscMaterial(int type, int n, const unsigned int pos[3]) con
 	switch (type)
 	{
 	case 0:
-		if (m_epsR==0)
+		if (m_epsR_ptr == NULL)
 			return 0;
-		return m_epsR[n][pos[0]][pos[1]][pos[2]];
+		else
+		{
+			ArrayLib::ArrayNIJK<float>& m_epsR = *m_epsR_ptr;
+			return m_epsR[n][pos[0]][pos[1]][pos[2]];
+		}
 	case 1:
-		if (m_kappa==0)
+		if (m_kappa_ptr == NULL)
 			return 0;
-		return m_kappa[n][pos[0]][pos[1]][pos[2]];
+		else
+		{
+			ArrayLib::ArrayNIJK<float>& m_kappa = *m_kappa_ptr;
+			return m_kappa[n][pos[0]][pos[1]][pos[2]];
+		}
 	case 2:
-		if (m_mueR==0)
+		if (m_mueR_ptr == NULL)
 			return 0;
-		return m_mueR[n][pos[0]][pos[1]][pos[2]];
+		else
+		{
+			ArrayLib::ArrayNIJK<float>& m_mueR = *m_mueR_ptr;
+			return m_mueR[n][pos[0]][pos[1]][pos[2]];
+		}
 	case 3:
-		if (m_sigma==0)
+		if (m_sigma_ptr == NULL)
 			return 0;
-		return m_sigma[n][pos[0]][pos[1]][pos[2]];
+		else
+		{
+			ArrayLib::ArrayNIJK<float>& m_sigma = *m_sigma_ptr;
+			return m_sigma[n][pos[0]][pos[1]][pos[2]];
+		}
 	}
 	return 0;
 }
@@ -1178,14 +1186,26 @@ bool Operator::Calc_ECPos(int ny, const unsigned int* pos, double* EC, vector<CS
 	double EffMat[4];
 	Calc_EffMatPos(ny,pos,EffMat, vPrims);
 
-	if (m_epsR)
+	if (m_epsR_ptr)
+	{
+		ArrayLib::ArrayNIJK<float>& m_epsR = *m_epsR_ptr;
 		m_epsR[ny][pos[0]][pos[1]][pos[2]] =  EffMat[0];
-	if (m_kappa)
+	}
+	if (m_kappa_ptr)
+	{
+		ArrayLib::ArrayNIJK<float>& m_kappa = *m_kappa_ptr;
 		m_kappa[ny][pos[0]][pos[1]][pos[2]] =  EffMat[1];
-	if (m_mueR)
+	}
+	if (m_mueR_ptr)
+	{
+		ArrayLib::ArrayNIJK<float>& m_mueR = *m_mueR_ptr;
 		m_mueR[ny][pos[0]][pos[1]][pos[2]] =  EffMat[2];
-	if (m_sigma)
+	}
+	if (m_sigma_ptr)
+	{
+		ArrayLib::ArrayNIJK<float>& m_sigma = *m_sigma_ptr;
 		m_sigma[ny][pos[0]][pos[1]][pos[2]] =  EffMat[3];
+	}
 
 	double delta = GetEdgeLength(ny,pos);
 	double area  = GetEdgeArea(ny,pos);

--- a/FDTD/operator.cpp
+++ b/FDTD/operator.cpp
@@ -568,30 +568,29 @@ void Operator::DumpOperator2File(string filename)
 
 	if (Op_Ext_Exc)
 	{
-		FDTD_FLOAT**** exc = NULL;
 		if (Op_Ext_Exc->Volt_Count>0)
 		{
-			exc = Create_N_3DArray<FDTD_FLOAT>(numLines);
+			ArrayLib::ArrayNIJK<FDTD_FLOAT> exc("exc", numLines);
+
 			for (unsigned int n=0; n<  Op_Ext_Exc->Volt_Count; ++n)
 				exc[  Op_Ext_Exc->Volt_dir[n]][  Op_Ext_Exc->Volt_index[0][n]][  Op_Ext_Exc->Volt_index[1][n]][  Op_Ext_Exc->Volt_index[2][n]] =   Op_Ext_Exc->Volt_amp[n];
 			vtk_Writer->AddVectorField("exc_volt",exc);
-			Delete_N_3DArray(exc,numLines);
 		}
 
 		if (  Op_Ext_Exc->Curr_Count>0)
 		{
-			exc = Create_N_3DArray<FDTD_FLOAT>(numLines);
+			ArrayLib::ArrayNIJK<FDTD_FLOAT> exc("exc", numLines);
+
 			for (unsigned int n=0; n<  Op_Ext_Exc->Curr_Count; ++n)
 				exc[  Op_Ext_Exc->Curr_dir[n]][  Op_Ext_Exc->Curr_index[0][n]][  Op_Ext_Exc->Curr_index[1][n]][  Op_Ext_Exc->Curr_index[2][n]] =   Op_Ext_Exc->Curr_amp[n];
 			vtk_Writer->AddVectorField("exc_curr",exc);
-			Delete_N_3DArray(exc,numLines);
 		}
 	}
 
-	FDTD_FLOAT**** vv_temp = Create_N_3DArray<FDTD_FLOAT>(numLines);
-	FDTD_FLOAT**** vi_temp = Create_N_3DArray<FDTD_FLOAT>(numLines);
-	FDTD_FLOAT**** iv_temp = Create_N_3DArray<FDTD_FLOAT>(numLines);
-	FDTD_FLOAT**** ii_temp = Create_N_3DArray<FDTD_FLOAT>(numLines);
+	ArrayLib::ArrayNIJK<FDTD_FLOAT> vv_temp("vv", numLines);
+	ArrayLib::ArrayNIJK<FDTD_FLOAT> vi_temp("vi", numLines);
+	ArrayLib::ArrayNIJK<FDTD_FLOAT> iv_temp("iv", numLines);
+	ArrayLib::ArrayNIJK<FDTD_FLOAT> ii_temp("ii", numLines);
 
 	unsigned int pos[3], n;
 	for (n=0; n<3; n++)
@@ -607,13 +606,9 @@ void Operator::DumpOperator2File(string filename)
 
 
 	vtk_Writer->AddVectorField("vv",vv_temp);
-	Delete_N_3DArray(vv_temp,numLines);
 	vtk_Writer->AddVectorField("vi",vi_temp);
-	Delete_N_3DArray(vi_temp,numLines);
 	vtk_Writer->AddVectorField("iv",iv_temp);
-	Delete_N_3DArray(iv_temp,numLines);
 	vtk_Writer->AddVectorField("ii",ii_temp);
-	Delete_N_3DArray(ii_temp,numLines);
 
 	if (vtk_Writer->Write()==false)
 		cerr << "Operator::DumpOperator2File: Error: Can't write file... skipping!" << endl;

--- a/FDTD/operator.cpp
+++ b/FDTD/operator.cpp
@@ -74,10 +74,10 @@ void Operator::Init()
 
 	Operator_Base::Init();
 
-	vv=NULL;
-	vi=NULL;
-	iv=NULL;
-	ii=NULL;
+	vv_ptr = NULL;
+	vi_ptr = NULL;
+	iv_ptr = NULL;
+	ii_ptr = NULL;
 
 	m_epsR_ptr = NULL;
 	m_kappa_ptr = NULL;
@@ -103,11 +103,15 @@ void Operator::Delete()
 {
 	CSX = NULL;
 
-	Delete_N_3DArray(vv,numLines);
-	Delete_N_3DArray(vi,numLines);
-	Delete_N_3DArray(iv,numLines);
-	Delete_N_3DArray(ii,numLines);
-	vv=vi=iv=ii=0;
+	delete vv_ptr;
+	delete vi_ptr;
+	delete iv_ptr;
+	delete ii_ptr;
+	vv_ptr = NULL;
+	vi_ptr = NULL;
+	iv_ptr = NULL;
+	ii_ptr = NULL;
+
 	delete MainOp; MainOp=0;
 	for (int n=0; n<3; ++n)
 	{
@@ -833,14 +837,14 @@ bool Operator::SetGeometryCSX(ContinuousStructure* geo)
 
 void Operator::InitOperator()
 {
-	Delete_N_3DArray(vv,numLines);
-	Delete_N_3DArray(vi,numLines);
-	Delete_N_3DArray(iv,numLines);
-	Delete_N_3DArray(ii,numLines);
-	vv = Create_N_3DArray<FDTD_FLOAT>(numLines);
-	vi = Create_N_3DArray<FDTD_FLOAT>(numLines);
-	iv = Create_N_3DArray<FDTD_FLOAT>(numLines);
-	ii = Create_N_3DArray<FDTD_FLOAT>(numLines);
+	delete vv_ptr;
+	delete vi_ptr;
+	delete iv_ptr;
+	delete ii_ptr;
+	vv_ptr = new ArrayLib::ArrayNIJK<FDTD_FLOAT>("vv", numLines);
+	vi_ptr = new ArrayLib::ArrayNIJK<FDTD_FLOAT>("vi", numLines);
+	iv_ptr = new ArrayLib::ArrayNIJK<FDTD_FLOAT>("iv", numLines);
+	ii_ptr = new ArrayLib::ArrayNIJK<FDTD_FLOAT>("ii", numLines);
 }
 
 void Operator::InitDataStorage()

--- a/FDTD/operator.h
+++ b/FDTD/operator.h
@@ -23,6 +23,8 @@
 #include "excitation.h"
 #include "Common/operator_base.h"
 
+#include "tools/arraylib/array_nijk.h"
+
 class Operator_Extension;
 class Operator_Ext_Excitation;
 class Engine;
@@ -294,10 +296,10 @@ protected:
 	int m_BC_Size[6];
 
 	//store material properties for post-processing
-	float**** m_epsR;
-	float**** m_kappa;
-	float**** m_mueR;
-	float**** m_sigma;
+	ArrayLib::ArrayNIJK<float>* m_epsR_ptr;
+	ArrayLib::ArrayNIJK<float>* m_kappa_ptr;
+	ArrayLib::ArrayNIJK<float>* m_mueR_ptr;
+	ArrayLib::ArrayNIJK<float>* m_sigma_ptr;
 
 	//EC elements, internal only!
 	virtual void Init_EC();

--- a/FDTD/operator.h
+++ b/FDTD/operator.h
@@ -60,22 +60,61 @@ public:
 	virtual int CalcECOperator( DebugFlags debugFlags = None );
 
 	// the next four functions need to be reimplemented in a derived class
-	inline virtual FDTD_FLOAT GetVV( unsigned int n, unsigned int x, unsigned int y, unsigned int z ) const { return vv[n][x][y][z]; }
-	inline virtual FDTD_FLOAT GetVI( unsigned int n, unsigned int x, unsigned int y, unsigned int z ) const { return vi[n][x][y][z]; }
-	inline virtual FDTD_FLOAT GetII( unsigned int n, unsigned int x, unsigned int y, unsigned int z ) const { return ii[n][x][y][z]; }
-	inline virtual FDTD_FLOAT GetIV( unsigned int n, unsigned int x, unsigned int y, unsigned int z ) const { return iv[n][x][y][z]; }
+	inline virtual FDTD_FLOAT GetVV(unsigned int n, unsigned int x, unsigned int y, unsigned int z) const
+	{
+		return vv[n][x][y][z];
+	}
+
+	inline virtual FDTD_FLOAT GetVI(unsigned int n, unsigned int x, unsigned int y, unsigned int z) const
+	{
+		return vi[n][x][y][z];
+	}
+
+	inline virtual FDTD_FLOAT GetII(unsigned int n, unsigned int x, unsigned int y, unsigned int z) const
+	{
+		return ii[n][x][y][z];
+	}
+	inline virtual FDTD_FLOAT GetIV(unsigned int n, unsigned int x, unsigned int y, unsigned int z) const
+	{
+		return iv[n][x][y][z];
+	}
 
 	// convenient access functions
-	inline virtual FDTD_FLOAT GetVV( unsigned int n, unsigned int pos[3] ) const { return GetVV(n,pos[0],pos[1],pos[2]); }
-	inline virtual FDTD_FLOAT GetVI( unsigned int n, unsigned int pos[3] ) const { return GetVI(n,pos[0],pos[1],pos[2]); }
-	inline virtual FDTD_FLOAT GetII( unsigned int n, unsigned int pos[3] ) const { return GetII(n,pos[0],pos[1],pos[2]); }
-	inline virtual FDTD_FLOAT GetIV( unsigned int n, unsigned int pos[3] ) const { return GetIV(n,pos[0],pos[1],pos[2]); }
+	inline virtual FDTD_FLOAT GetVV( unsigned int n, unsigned int pos[3] ) const
+	{
+		return GetVV(n, pos[0], pos[1], pos[2]);
+	}
+
+	inline virtual FDTD_FLOAT GetVI( unsigned int n, unsigned int pos[3] ) const
+	{
+		return GetVI(n, pos[0], pos[1], pos[2]);
+	}
+	inline virtual FDTD_FLOAT GetII( unsigned int n, unsigned int pos[3] ) const
+	{
+		return GetII(n, pos[0], pos[1], pos[2]);
+	}
+	inline virtual FDTD_FLOAT GetIV( unsigned int n, unsigned int pos[3] ) const
+	{
+		return GetIV(n, pos[0], pos[1], pos[2]);
+	}
 
 	// the next four functions need to be reimplemented in a derived class
-	inline virtual void SetVV( unsigned int n, unsigned int x, unsigned int y, unsigned int z, FDTD_FLOAT value ) { vv[n][x][y][z] = value; }
-	inline virtual void SetVI( unsigned int n, unsigned int x, unsigned int y, unsigned int z, FDTD_FLOAT value ) { vi[n][x][y][z] = value; }
-	inline virtual void SetII( unsigned int n, unsigned int x, unsigned int y, unsigned int z, FDTD_FLOAT value ) { ii[n][x][y][z] = value; }
-	inline virtual void SetIV( unsigned int n, unsigned int x, unsigned int y, unsigned int z, FDTD_FLOAT value ) { iv[n][x][y][z] = value; }
+	inline virtual void SetVV(unsigned int n, unsigned int x, unsigned int y, unsigned int z, FDTD_FLOAT value)
+	{
+		vv[n][x][y][z] = value;
+	}
+	inline virtual void SetVI(unsigned int n, unsigned int x, unsigned int y, unsigned int z, FDTD_FLOAT value)
+	{
+		vi[n][x][y][z] = value;
+	}
+	inline virtual void SetII(unsigned int n, unsigned int x, unsigned int y, unsigned int z, FDTD_FLOAT value)
+	{
+		ii[n][x][y][z] = value;
+	}
+	inline virtual void SetIV(unsigned int n, unsigned int x, unsigned int y, unsigned int z, FDTD_FLOAT value)
+	{
+		iv[n][x][y][z] = value;
+	}
 
 	virtual void ApplyElectricBC(bool* dirs); //applied by default to all boundaries
 	virtual void ApplyMagneticBC(bool* dirs);

--- a/FDTD/operator.h
+++ b/FDTD/operator.h
@@ -64,20 +64,24 @@ public:
 	// the next four functions need to be reimplemented in a derived class
 	inline virtual FDTD_FLOAT GetVV(unsigned int n, unsigned int x, unsigned int y, unsigned int z) const
 	{
+		ArrayLib::ArrayNIJK<FDTD_FLOAT>& vv = *vv_ptr;
 		return vv[n][x][y][z];
 	}
 
 	inline virtual FDTD_FLOAT GetVI(unsigned int n, unsigned int x, unsigned int y, unsigned int z) const
 	{
+		ArrayLib::ArrayNIJK<FDTD_FLOAT>& vi = *vi_ptr;
 		return vi[n][x][y][z];
 	}
 
 	inline virtual FDTD_FLOAT GetII(unsigned int n, unsigned int x, unsigned int y, unsigned int z) const
 	{
+		ArrayLib::ArrayNIJK<FDTD_FLOAT>& ii = *ii_ptr;
 		return ii[n][x][y][z];
 	}
 	inline virtual FDTD_FLOAT GetIV(unsigned int n, unsigned int x, unsigned int y, unsigned int z) const
 	{
+		ArrayLib::ArrayNIJK<FDTD_FLOAT>& iv = *iv_ptr;
 		return iv[n][x][y][z];
 	}
 
@@ -103,18 +107,22 @@ public:
 	// the next four functions need to be reimplemented in a derived class
 	inline virtual void SetVV(unsigned int n, unsigned int x, unsigned int y, unsigned int z, FDTD_FLOAT value)
 	{
+		ArrayLib::ArrayNIJK<FDTD_FLOAT>& vv = *vv_ptr;
 		vv[n][x][y][z] = value;
 	}
 	inline virtual void SetVI(unsigned int n, unsigned int x, unsigned int y, unsigned int z, FDTD_FLOAT value)
 	{
+		ArrayLib::ArrayNIJK<FDTD_FLOAT>& vi = *vi_ptr;
 		vi[n][x][y][z] = value;
 	}
 	inline virtual void SetII(unsigned int n, unsigned int x, unsigned int y, unsigned int z, FDTD_FLOAT value)
 	{
+		ArrayLib::ArrayNIJK<FDTD_FLOAT>& ii = *ii_ptr;
 		ii[n][x][y][z] = value;
 	}
 	inline virtual void SetIV(unsigned int n, unsigned int x, unsigned int y, unsigned int z, FDTD_FLOAT value)
 	{
+		ArrayLib::ArrayNIJK<FDTD_FLOAT>& iv = *iv_ptr;
 		iv[n][x][y][z] = value;
 	}
 
@@ -323,10 +331,10 @@ protected:
 	// engine/post-proc needs access
 public:
 	//EC operator
-	FDTD_FLOAT**** vv; //calc new voltage from old voltage
-	FDTD_FLOAT**** vi; //calc new voltage from old current
-	FDTD_FLOAT**** ii; //calc new current from old current
-	FDTD_FLOAT**** iv; //calc new current from old voltage
+	ArrayLib::ArrayNIJK<FDTD_FLOAT>* vv_ptr; //calc new voltage from old voltage
+	ArrayLib::ArrayNIJK<FDTD_FLOAT>* vi_ptr; //calc new voltage from old current
+	ArrayLib::ArrayNIJK<FDTD_FLOAT>* ii_ptr; //calc new current from old current
+	ArrayLib::ArrayNIJK<FDTD_FLOAT>* iv_ptr; //calc new current from old voltage
 };
 
 inline Operator::DebugFlags operator|( Operator::DebugFlags a, Operator::DebugFlags b ) { return static_cast<Operator::DebugFlags>(static_cast<int>(a) | static_cast<int>(b)); }

--- a/FDTD/operator_cylindermultigrid.cpp
+++ b/FDTD/operator_cylindermultigrid.cpp
@@ -224,14 +224,26 @@ void Operator_CylinderMultiGrid::FillMissingDataStorage()
 				{
 					Calc_EffMatPos(ny,pos,EffMat,vPrims);
 
-					if (m_epsR)
+					if (m_epsR_ptr)
+					{
+						ArrayLib::ArrayNIJK<float>& m_epsR = *m_epsR_ptr;
 						m_epsR[ny][pos[0]][pos[1]][pos[2]] =  EffMat[0];
-					if (m_kappa)
+					}
+					if (m_kappa_ptr)
+					{
+						ArrayLib::ArrayNIJK<float>& m_kappa = *m_kappa_ptr;
 						m_kappa[ny][pos[0]][pos[1]][pos[2]] =  EffMat[1];
-					if (m_mueR)
+					}
+					if (m_mueR_ptr)
+					{
+						ArrayLib::ArrayNIJK<float>& m_mueR = *m_mueR_ptr;
 						m_mueR[ny][pos[0]][pos[1]][pos[2]] =  EffMat[2];
-					if (m_sigma)
+					}
+					if (m_sigma_ptr)
+					{
+						ArrayLib::ArrayNIJK<float>& m_sigma = *m_sigma_ptr;
 						m_sigma[ny][pos[0]][pos[1]][pos[2]] =  EffMat[3];
+					}
 				}
 			}
 		}

--- a/FDTD/operator_sse.cpp
+++ b/FDTD/operator_sse.cpp
@@ -30,10 +30,10 @@ Operator_sse* Operator_sse::New()
 
 Operator_sse::Operator_sse() : Operator()
 {
-	f4_vv = 0;
-	f4_vi = 0;
-	f4_iv = 0;
-	f4_ii = 0;
+	f4_vv_ptr = NULL;
+	f4_vi_ptr = NULL;
+	f4_iv_ptr = NULL;
+	f4_ii_ptr = NULL;
 }
 
 Operator_sse::~Operator_sse()
@@ -51,22 +51,22 @@ Engine* Operator_sse::CreateEngine()
 void Operator_sse::Init()
 {
 	Operator::Init();
-	f4_vv = 0;
-	f4_vi = 0;
-	f4_iv = 0;
-	f4_ii = 0;
+	f4_vv_ptr = NULL;
+	f4_vi_ptr = NULL;
+	f4_iv_ptr = NULL;
+	f4_ii_ptr = NULL;
 }
 
 void Operator_sse::Delete()
 {
-	Delete_N_3DArray_v4sf(f4_vv,numLines);
-	Delete_N_3DArray_v4sf(f4_vi,numLines);
-	Delete_N_3DArray_v4sf(f4_iv,numLines);
-	Delete_N_3DArray_v4sf(f4_ii,numLines);
-	f4_vv = 0;
-	f4_vi = 0;
-	f4_iv = 0;
-	f4_ii = 0;
+	delete f4_vv_ptr;
+	delete f4_vi_ptr;
+	delete f4_iv_ptr;
+	delete f4_ii_ptr;
+	f4_vv_ptr = NULL;
+	f4_vi_ptr = NULL;
+	f4_iv_ptr = NULL;
+	f4_ii_ptr = NULL;
 }
 
 void Operator_sse::Reset()
@@ -78,14 +78,23 @@ void Operator_sse::Reset()
 
 void Operator_sse::InitOperator()
 {
-	Delete_N_3DArray_v4sf(f4_vv,numLines);
-	Delete_N_3DArray_v4sf(f4_vi,numLines);
-	Delete_N_3DArray_v4sf(f4_iv,numLines);
-	Delete_N_3DArray_v4sf(f4_ii,numLines);
-	f4_vv = Create_N_3DArray_v4sf(numLines);
-	f4_vi = Create_N_3DArray_v4sf(numLines);
-	f4_iv = Create_N_3DArray_v4sf(numLines);
-	f4_ii = Create_N_3DArray_v4sf(numLines);
+	delete f4_vv_ptr;
+	delete f4_vi_ptr;
+	delete f4_iv_ptr;
+	delete f4_ii_ptr;
 
 	numVectors =  ceil((double)numLines[2]/4.0);
+
+	f4_vv_ptr = new ArrayLib::ArrayNIJK<f4vector>(
+		"f4_vv", {numLines[0], numLines[1], numVectors}
+	);
+	f4_vi_ptr = new ArrayLib::ArrayNIJK<f4vector>(
+		"f4_vi", {numLines[0], numLines[1], numVectors}
+	);
+	f4_iv_ptr = new ArrayLib::ArrayNIJK<f4vector>(
+		"f4_iv", {numLines[0], numLines[1], numVectors}
+	);
+	f4_ii_ptr = new ArrayLib::ArrayNIJK<f4vector>(
+		"f4_ii", {numLines[0], numLines[1], numVectors}
+	);
 }

--- a/FDTD/operator_sse.h
+++ b/FDTD/operator_sse.h
@@ -33,41 +33,49 @@ public:
 
 	inline virtual FDTD_FLOAT GetVV(unsigned int n, unsigned int x, unsigned int y, unsigned int z) const
 	{
+		ArrayLib::ArrayNIJK<f4vector>& f4_vv = *f4_vv_ptr;
 		return f4_vv[n][x][y][z%numVectors].f[z/numVectors];
 	}
 
 	inline virtual FDTD_FLOAT GetVI(unsigned int n, unsigned int x, unsigned int y, unsigned int z) const
 	{
+		ArrayLib::ArrayNIJK<f4vector>& f4_vi = *f4_vi_ptr;
 		return f4_vi[n][x][y][z%numVectors].f[z/numVectors];
 	}
 
 	inline virtual FDTD_FLOAT GetII(unsigned int n, unsigned int x, unsigned int y, unsigned int z) const
 	{
+		ArrayLib::ArrayNIJK<f4vector>& f4_ii = *f4_ii_ptr;
 		return f4_ii[n][x][y][z%numVectors].f[z/numVectors];
 	}
 
 	inline virtual FDTD_FLOAT GetIV(unsigned int n, unsigned int x, unsigned int y, unsigned int z) const
 	{
+		ArrayLib::ArrayNIJK<f4vector>& f4_iv = *f4_iv_ptr;
 		return f4_iv[n][x][y][z%numVectors].f[z/numVectors];
 	}
 
 	inline virtual void SetVV(unsigned int n, unsigned int x, unsigned int y, unsigned int z, FDTD_FLOAT value)
 	{
+		ArrayLib::ArrayNIJK<f4vector>& f4_vv = *f4_vv_ptr;
 		f4_vv[n][x][y][z%numVectors].f[z/numVectors] = value;
 	}
 
 	inline virtual void SetVI(unsigned int n, unsigned int x, unsigned int y, unsigned int z, FDTD_FLOAT value)
 	{
+		ArrayLib::ArrayNIJK<f4vector>& f4_vi = *f4_vi_ptr;
 		f4_vi[n][x][y][z%numVectors].f[z/numVectors] = value;
 	}
 
 	inline virtual void SetII(unsigned int n, unsigned int x, unsigned int y, unsigned int z, FDTD_FLOAT value)
 	{
+		ArrayLib::ArrayNIJK<f4vector>& f4_ii = *f4_ii_ptr;
 		f4_ii[n][x][y][z%numVectors].f[z/numVectors] = value;
 	}
 
 	inline virtual void SetIV(unsigned int n, unsigned int x, unsigned int y, unsigned int z, FDTD_FLOAT value)
 	{
+		ArrayLib::ArrayNIJK<f4vector>& f4_iv = *f4_iv_ptr;
 		f4_iv[n][x][y][z%numVectors].f[z/numVectors] = value;
 	}
 
@@ -84,10 +92,10 @@ protected:
 
 	// engine/post-proc needs access
 public:
-	f4vector**** f4_vv; //calc new voltage from old voltage
-	f4vector**** f4_vi; //calc new voltage from old current
-	f4vector**** f4_iv; //calc new current from old current
-	f4vector**** f4_ii; //calc new current from old voltage
+	ArrayLib::ArrayNIJK<f4vector>* f4_vv_ptr; //calc new voltage from old voltage
+	ArrayLib::ArrayNIJK<f4vector>* f4_vi_ptr; //calc new voltage from old current
+	ArrayLib::ArrayNIJK<f4vector>* f4_iv_ptr; //calc new current from old current
+	ArrayLib::ArrayNIJK<f4vector>* f4_ii_ptr; //calc new current from old voltage
 };
 
 #endif // OPERATOR_SSE_H

--- a/FDTD/operator_sse.h
+++ b/FDTD/operator_sse.h
@@ -31,15 +31,45 @@ public:
 
 	virtual Engine* CreateEngine();
 
-	inline virtual FDTD_FLOAT GetVV( unsigned int n, unsigned int x, unsigned int y, unsigned int z ) const { return f4_vv[n][x][y][z%numVectors].f[z/numVectors]; }
-	inline virtual FDTD_FLOAT GetVI( unsigned int n, unsigned int x, unsigned int y, unsigned int z ) const { return f4_vi[n][x][y][z%numVectors].f[z/numVectors]; }
-	inline virtual FDTD_FLOAT GetII( unsigned int n, unsigned int x, unsigned int y, unsigned int z ) const { return f4_ii[n][x][y][z%numVectors].f[z/numVectors]; }
-	inline virtual FDTD_FLOAT GetIV( unsigned int n, unsigned int x, unsigned int y, unsigned int z ) const { return f4_iv[n][x][y][z%numVectors].f[z/numVectors]; }
+	inline virtual FDTD_FLOAT GetVV(unsigned int n, unsigned int x, unsigned int y, unsigned int z) const
+	{
+		return f4_vv[n][x][y][z%numVectors].f[z/numVectors];
+	}
 
-	inline virtual void SetVV( unsigned int n, unsigned int x, unsigned int y, unsigned int z, FDTD_FLOAT value ) { f4_vv[n][x][y][z%numVectors].f[z/numVectors] = value; }
-	inline virtual void SetVI( unsigned int n, unsigned int x, unsigned int y, unsigned int z, FDTD_FLOAT value ) { f4_vi[n][x][y][z%numVectors].f[z/numVectors] = value; }
-	inline virtual void SetII( unsigned int n, unsigned int x, unsigned int y, unsigned int z, FDTD_FLOAT value ) { f4_ii[n][x][y][z%numVectors].f[z/numVectors] = value; }
-	inline virtual void SetIV( unsigned int n, unsigned int x, unsigned int y, unsigned int z, FDTD_FLOAT value ) { f4_iv[n][x][y][z%numVectors].f[z/numVectors] = value; }
+	inline virtual FDTD_FLOAT GetVI(unsigned int n, unsigned int x, unsigned int y, unsigned int z) const
+	{
+		return f4_vi[n][x][y][z%numVectors].f[z/numVectors];
+	}
+
+	inline virtual FDTD_FLOAT GetII(unsigned int n, unsigned int x, unsigned int y, unsigned int z) const
+	{
+		return f4_ii[n][x][y][z%numVectors].f[z/numVectors];
+	}
+
+	inline virtual FDTD_FLOAT GetIV(unsigned int n, unsigned int x, unsigned int y, unsigned int z) const
+	{
+		return f4_iv[n][x][y][z%numVectors].f[z/numVectors];
+	}
+
+	inline virtual void SetVV(unsigned int n, unsigned int x, unsigned int y, unsigned int z, FDTD_FLOAT value)
+	{
+		f4_vv[n][x][y][z%numVectors].f[z/numVectors] = value;
+	}
+
+	inline virtual void SetVI(unsigned int n, unsigned int x, unsigned int y, unsigned int z, FDTD_FLOAT value)
+	{
+		f4_vi[n][x][y][z%numVectors].f[z/numVectors] = value;
+	}
+
+	inline virtual void SetII(unsigned int n, unsigned int x, unsigned int y, unsigned int z, FDTD_FLOAT value)
+	{
+		f4_ii[n][x][y][z%numVectors].f[z/numVectors] = value;
+	}
+
+	inline virtual void SetIV(unsigned int n, unsigned int x, unsigned int y, unsigned int z, FDTD_FLOAT value)
+	{
+		f4_iv[n][x][y][z%numVectors].f[z/numVectors] = value;
+	}
 
 protected:
 	//! use New() for creating a new Operator

--- a/FDTD/operator_sse_compressed.cpp
+++ b/FDTD/operator_sse_compressed.cpp
@@ -33,7 +33,6 @@ Operator_SSE_Compressed* Operator_SSE_Compressed::New()
 
 Operator_SSE_Compressed::Operator_SSE_Compressed() : Operator_sse()
 {
-	m_Op_index = NULL;
 	m_Use_Compression = false;	
 }
 
@@ -65,17 +64,10 @@ void Operator_SSE_Compressed::Init()
 {
 	Operator_sse::Init();
 	m_Use_Compression = false;
-	m_Op_index = NULL;
 }
 
 void Operator_SSE_Compressed::Delete()
 {
-	if (m_Op_index)
-	{
-		Delete3DArray<unsigned int>( m_Op_index, numLines );
-		m_Op_index = 0;
-	}
-
 	m_Use_Compression = false;
 	for (int n=0; n<3; n++)
 	{
@@ -105,7 +97,7 @@ void Operator_SSE_Compressed::InitOperator()
 	}
 
 	Operator_sse::InitOperator();
-	m_Op_index = Create3DArray<unsigned int>( numLines );
+	m_Op_index.Init("Op_index", numLines);
 }
 
 void Operator_SSE_Compressed::ShowStat() const

--- a/FDTD/operator_sse_compressed.cpp
+++ b/FDTD/operator_sse_compressed.cpp
@@ -122,6 +122,11 @@ bool Operator_SSE_Compressed::CompressOperator()
 	if (g_settings.GetVerboseLevel()>0)
 		cout << "Compressing the FDTD operator... this may take a while..." << endl;
 
+	ArrayLib::ArrayNIJK<f4vector>& f4_vv = *f4_vv_ptr;
+	ArrayLib::ArrayNIJK<f4vector>& f4_vi = *f4_vi_ptr;
+	ArrayLib::ArrayNIJK<f4vector>& f4_iv = *f4_iv_ptr;
+	ArrayLib::ArrayNIJK<f4vector>& f4_ii = *f4_ii_ptr;
+
 	map<SSE_coeff,unsigned int> lookUpMap;
 
 	unsigned int pos[3];
@@ -163,14 +168,14 @@ bool Operator_SSE_Compressed::CompressOperator()
 		}
 	}
 
-	Delete_N_3DArray_v4sf(f4_vv,numLines);
-	Delete_N_3DArray_v4sf(f4_vi,numLines);
-	Delete_N_3DArray_v4sf(f4_iv,numLines);
-	Delete_N_3DArray_v4sf(f4_ii,numLines);
-	f4_vv = 0;
-	f4_vi = 0;
-	f4_iv = 0;
-	f4_ii = 0;
+	delete f4_vv_ptr;
+	delete f4_vi_ptr;
+	delete f4_iv_ptr;
+	delete f4_ii_ptr;
+	f4_vv_ptr = NULL;
+	f4_vi_ptr = NULL;
+	f4_iv_ptr = NULL;
+	f4_ii_ptr = NULL;
 
 	return true;
 }

--- a/FDTD/operator_sse_compressed.h
+++ b/FDTD/operator_sse_compressed.h
@@ -20,6 +20,7 @@
 
 #include "operator_sse.h"
 #include "tools/aligned_allocator.h"
+#include "tools/arraylib/array_ijk.h"
 
 class SSE_coeff
 {
@@ -73,7 +74,7 @@ protected:
 
 	// engine needs access
 public:
-	unsigned int*** m_Op_index;
+	ArrayLib::ArrayIJK<unsigned int> m_Op_index;
 	vector<f4vector,aligned_allocator<f4vector> > f4_vv_Compressed[3]; //!< coefficient: calc new voltage from old voltage
 	vector<f4vector,aligned_allocator<f4vector> > f4_vi_Compressed[3]; //!< coefficient: calc new voltage from old current
 	vector<f4vector,aligned_allocator<f4vector> > f4_iv_Compressed[3]; //!< coefficient: calc new current from old voltage

--- a/tools/arraylib/README.md
+++ b/tools/arraylib/README.md
@@ -1,0 +1,200 @@
+ArrayLib - Simple Multi-Dimensional Array Library with C-like Syntax
+=====================================================================
+
+Motivation
+-------------
+
+Originally, multi-dimensional arrays in the simulation engine were
+allocated as multi-level C pointers. For example, the following code
+allocates and accesses a 3D array:
+
+    // allocate 3D arrays as pointers of pointers
+    T*** array=NULL;
+    array = new T**[SIZE_I]
+    for (size_t i = 0; i < SIZE_I; i++)
+    {
+    	array[i] = new T*[SIZE_J]
+    	for (size_t j = 0; j < SIZE_J; j++)
+    	{
+            array[i][j] = new T[SIZE_K];
+            for (size_t k = 0; k < SIZE_K; k++)
+    		{
+                // access array via C-style syntax
+    			array[i][j][k] = 0;
+    		}
+    	}
+    }
+
+The advantage is that all multi-dimensional arrays can be accessed
+like a C-style array. But with several downsides:
+
+1. A single array requires multiple `malloc()` or `new` allocation.
+2. The allocated memory is not contiguous, reducing memory locality
+and performance, especially when the final dimension is small.
+
+According to the best practice today (e.g. `std::mdspan`), these raw
+pointers should be converted to wrapped arrays classes with their
+internal indexing code, and they should be accessed using the following
+syntax:
+
+    array(i, j, k) = 0;
+    array[i, j, k] = 0; // C++23
+
+But this requires massive change of all existing array indexing code
+throughout the codebase, which is error-prone and difficult to review.
+
+ArrayLib is a simple library written with the goal of providing a simple
+implementation of multi-dimensional array, but preserved the C-like access
+syntax using C++ template metaprogramming to minimize the code change in
+the simulation engine.
+
+Supported Types
+--------------------
+
+1. ArrayIJ - 2D array.
+2. ArrayIJK - 3D array.
+3. ArrayNIJK - 3D array (N = 3 only), IJK is the coordinate of a 3D
+vector in space, N (0, 1, 2) selects the X/Y/Z value from the vector.
+
+To avoid ambiguity, IJK is always used to describe coordinates in
+space, not X/Y/Z.
+
+Usage 1: new/delete
+--------------------
+
+ArrayLib can be used in several ways, the first method closely mirrors
+the C-style code using raw pointers, allowing direct migration from
+legacy code.
+
+    ArrayLib::ArrayIJK<float>* arr_ptr = new ArrayLib::ArrayIJK("name", {10, 20, 30});
+
+    // arr_ptr[0][1][2] is wrong, because we need to call the operator[]
+    // of ArrayIJK, rather than accessing an array of pointers of type
+    // `ArrayIJK*`.
+    (*arr_ptr)[0][1][2] = 3;
+
+    // But one can use C++ reference rather than pointers to access it
+    // in a readable way, add a line of boilerplate, but more readable
+    ArrayLib::ArrayIJK<float>& arr = *arr_ptr;
+    arr[0][1][2] = 3;
+
+    delete arr_ptr;
+
+The first method is advantageous in the sense that all existing pointers
+with inconsistent lifetimes can be converted to ArrayLib directly as
+drop-in replacement. The disadvantage is that the C-style syntax is only
+emulated we're accessing a C++ reference, not a C pointer. Yet C++ reference
+can't be NULL, so when arrays with inconsistent lifetimes are used in
+classes, C-style pointers (with confusing syntax) must be kept as member
+variables, not references (with natural syntax).
+
+To write readable code, whenever an array is accessed by a member function,
+we must dereference a pointer to create a C++ reference first. Overall, this
+is the smoothest migration path, so this style is widely used in engine classes.
+
+Usage 2: As Local Member Variable w/ RAII
+------------------------------------------
+
+ArrayLib arrays can be used as local variables by declaring them directly
+(with name and size). These arrays are automatically freed by C++'s
+RAII mechanics when they go out of scope.
+
+    void process()
+    {
+        ArrayLib::ArrayIJK<float> arr("name", {10, 20, 30});
+        array[0][1][2] = 0;
+        // deleted automatically by RAII
+    }
+
+This allows one to access arrays using the natural syntax, and without manual
+memory management, 
+
+Usage 3: As Class Member Variable w/ RAII
+-----------------------------------------
+
+Similarly, ArrayLib arrays can also be used as class member variables
+in conformance to the C++ RAII idiom. Class member variables are
+recommended for arrays with runtime-determined size.
+
+    class Engine
+    {
+        // automatically deleteled by RAII
+        ArrayLib::ArrayIJK<float> arr1("static size", {10, 20, 30});
+        ArrayLib::ArrayIJK<float> arr2;
+        
+        Engine(size_t i, size_t j, size_t k) :
+            arr2("initialize in constructor", {i, j, k})
+        {
+            // use natural C-style syntax for acess
+            arr1[1][2][3] = 0;
+            arr2[4][5][6] = 1;
+        }
+    }
+
+Ideally, this should be the recommended usage for ArrayLib arrays in
+C++ classes.
+
+Unfortunately, because the existing codebase does not use the C++ RAII
+idiom, and arrays mostly have inconsistent lifetimes (e.g. sometimes,
+array sizes can't be determined in the constructor, but instead is
+determined in the middle of the class's lifetime from an external
+source), it's not possible to translate all existing array usages to
+this idiom.
+
+Usage 4: As Class Member Variable w/ Two-Phase Initialization
+--------------------------------------------------------------
+
+As a compromise to the lifetime problem, two-phase Initialization is
+also supported. This can be done by creating an array object (not
+reference or pointers) as a class member variable without specifying
+its name and size. The result is a placeholder array in an invalid
+state, which can be later initialized.
+
+    class Engine
+    {
+        // automatically deleteled by RAII, size unknown
+        ArrayLib::ArrayIJK<float> arr1;
+        
+        Engine(size_t i, size_t j, size_t k);
+        {
+            // two-phase initialization before use
+            arr1.Init("name", {i, j, k});
+
+            // use natural C-style syntax for acess
+            arr1[1][2][3] = 0;
+        }
+    }
+
+Although it's potentially unsafe, but one can still enjoy automatic
+release of memory upon class destruction by C++'s RAII.
+
+ArrayLib Arrays Can't be Passed by Value
+--------------------------------------------
+
+ArrayLib objects are simple wrappers to heap-allocated memory, with few extra
+features in comparison to raw C pointers. In fact, they're designed to serve as
+drop-in replacement of raw pointers, which is prevalent in the existing codebase
+(we expect to refactor the codebase progressively). Thus, they're not meant to
+be high-level C++ containers. ArrayLib objects must be always passed as pointers
+or references, pass-by-value and copy-assignment are not supported. These
+operators are marked as deleted, attempting to do so would create a compile-time
+error. They make little sense for the low-level numerical simulation kernel in
+its current form.
+
+    ArrayLib::ArrayIJK<float> data("name", size);
+
+    // pass-by-reference, recommended when possible
+    void process_ref(ArrayLib::ArrayIJK<float>& arr);
+    process_ref(data);
+
+    // pass-by-pointer, use only when necessary
+    void process_ptr(ArrayLib::ArrayIJK<float>* arr_ptr);
+    process_ptr(&data);
+
+    // pass-by-value, WRONG!
+    void process_value(ArrayLib::ArrayIJK<float> arr);
+    process_value(data)
+
+Furthermore, practically speaking, in a simulation, large arrays to represent
+electromagnetic fields and material properties are allocated and passed around
+as pointers. Attempting to pass an array by value is always a bug.

--- a/tools/arraylib/array_ij.h
+++ b/tools/arraylib/array_ij.h
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2024 Yifeng Li <tomli@tomli.me>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef ARRAYLIB_ARRAY_IJ_H
+#define ARRAYLIB_ARRAY_IJ_H
+
+#include <cstddef>
+#include <cstdint>
+#include <iostream>
+#include <array>
+
+#include "impl/array_base.h"
+
+namespace ArrayLib
+{
+	template <typename T, typename IndexType=uint32_t>
+	class ArrayIJ;
+};
+
+template <typename T, typename IndexType>
+class ArrayLib::ArrayIJ :
+	public ArrayBase<ArrayIJ<T, IndexType>, T, 2, IndexType>
+{
+private:
+	IndexType m_stride;
+
+public:
+	using Base = ArrayBase<ArrayIJ<T, IndexType>, T, 2, IndexType>;
+	using Base::operator();
+
+	// 2-phase initialization: user declares a dummy array object first,
+	// and calls Init() later. Ugly but needed because openEMS's FDTD
+	// engine itself uses the 2-phase initialization pattern, we can't
+	// determine simulation domain size in the constructor.
+	ArrayIJ() {}
+
+	void Init(std::string name, std::array<IndexType, 2> extent)
+	{
+		if (this->m_ptr != NULL)
+			Base::AllocatorType::free(this->m_ptr, this->m_size);
+
+		this->m_name = name;
+		this->m_size = extent[0] * extent[1];
+		this->m_bytes = sizeof(T) * this->m_size;
+		this->m_ptr = Base::AllocatorType::alloc(this->m_size);
+
+		this->m_extent = extent;
+		this->m_stride = extent[1];
+	}
+
+	void Init(std::string name, IndexType extent[2])
+	{
+		Init(name, {extent[0], extent[1]});
+	}
+
+	// standard RAII initialization
+	ArrayIJ(std::string name, std::array<IndexType, 2> extent)
+	{
+		Init(name, extent);
+	}
+
+	ArrayIJ(std::string name, IndexType extent[2])
+	{
+		Init(name, {extent[0], extent[1]});
+	}
+
+	IndexType linearIndex(std::array<IndexType, 2> tupleIndex) const
+	{
+		return m_stride * tupleIndex[0] + tupleIndex[1];
+	}
+
+	T& operator() (IndexType i, IndexType j) const
+	{
+		return this->m_ptr[linearIndex({i, j})];
+	}
+
+	~ArrayIJ()
+	{
+		Base::AllocatorType::free(this->m_ptr, this->m_size);
+	}
+};
+
+#endif // ARRAYLIB_ARRAY_IJ_H

--- a/tools/arraylib/array_ijk.h
+++ b/tools/arraylib/array_ijk.h
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2024 Yifeng Li <tomli@tomli.me>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef ARRAYLIB_ARRAY_IJK_H
+#define ARRAYLIB_ARRAY_IJK_H
+
+#include <cstddef>
+#include <cstdint>
+#include <iostream>
+#include <array>
+
+#include "impl/array_base.h"
+
+namespace ArrayLib
+{
+	template <typename T, typename IndexType=uint32_t>
+	class ArrayIJK;
+};
+
+template <typename T, typename IndexType>
+class ArrayLib::ArrayIJK :
+	public ArrayBase<ArrayIJK<T, IndexType>, T, 3, IndexType>
+{
+private:
+	std::array<IndexType, 3> m_stride;
+
+public:
+	using Base = ArrayBase<ArrayIJK<T, IndexType>, T, 3, IndexType>;
+	using Base::operator();
+
+	// 2-phase initialization: user declares a dummy array object first,
+	// and calls Init() later. Ugly but needed because openEMS's FDTD
+	// engine itself uses the 2-phase initialization pattern, we can't
+	// determine simulation domain size in the constructor.
+	ArrayIJK() {}
+
+	void Init(std::string name, std::array<IndexType, 3> extent)
+	{
+		if (this->m_ptr != NULL)
+			Base::AllocatorType::free(this->m_ptr, this->m_size);
+
+		this->m_name = name;
+		this->m_size = extent[0] * extent[1] * extent[2];
+		this->m_bytes = sizeof(T) * this->m_size;
+		this->m_ptr = Base::AllocatorType::alloc(this->m_size);
+
+		this->m_extent = extent;
+		this->m_stride[0] = extent[1] * extent[2];
+		this->m_stride[1] = extent[2];
+	}
+
+	void Init(std::string name, IndexType extent[3])
+	{
+		Init(name, {extent[0], extent[1], extent[2]});
+	}
+
+	// standard RAII initialization
+	ArrayIJK(std::string name, std::array<IndexType, 3> extent)
+	{
+		Init(name, extent);
+	}
+
+	ArrayIJK(std::string name, IndexType extent[3])
+	{
+		Init(name, {extent[0], extent[1], extent[2]});
+	}
+
+	IndexType linearIndex(std::array<IndexType, 3> tupleIndex) const
+	{
+		return m_stride[0] * tupleIndex[0] +
+		       m_stride[1] * tupleIndex[1] +
+		                     tupleIndex[2];
+	}
+
+	T& operator() (IndexType i, IndexType j, IndexType k) const
+	{
+		return this->m_ptr[linearIndex({i, j, k})];
+	}
+
+	~ArrayIJK()
+	{
+		Base::AllocatorType::free(this->m_ptr, this->m_size);
+	}
+};
+
+#endif // ARRAYLIB_ARRAY_IJK_H

--- a/tools/arraylib/array_nijk.h
+++ b/tools/arraylib/array_nijk.h
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2024 Yifeng Li <tomli@tomli.me>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef ARRAYLIB_ARRAY_NIJK_H
+#define ARRAYLIB_ARRAY_NIJK_H
+
+#include <cstddef>
+#include <cstdint>
+#include <iostream>
+#include <array>
+
+#include "impl/array_base.h"
+
+namespace ArrayLib
+{
+	template <typename T, typename IndexType=uint32_t, size_t extentN=3>
+	class ArrayNIJK;
+};
+
+template <typename T, typename IndexType, size_t extentN>
+class ArrayLib::ArrayNIJK :
+	public ArrayBase<ArrayNIJK<T, IndexType>, T, 4, IndexType>
+{
+private:
+	std::array<IndexType, 2> m_stride;
+
+public:
+	using Base = ArrayBase<ArrayNIJK<T, IndexType>, T, 4, IndexType>;
+	using Base::operator();
+
+	// 2-phase initialization: user declares a dummy array object first,
+	// and calls Init() later. Ugly but needed because openEMS's FDTD
+	// engine itself uses the 2-phase initialization pattern, we can't
+	// determine simulation domain size in the constructor.
+	ArrayNIJK() {}
+
+	void Init(std::string name, std::array<IndexType, 3> extent)
+	{
+		if (this->m_ptr != NULL)
+			Base::AllocatorType::free(this->m_ptr, this->m_size);
+
+		this->m_name = name;
+		this->m_size = extent[0] * extent[1] * extent[2] * extentN;
+		this->m_bytes = sizeof(T) * this->m_size;
+		this->m_ptr = Base::AllocatorType::alloc(this->m_size);
+
+		this->m_extent = {extentN, extent[0], extent[1], extent[2]};
+		this->m_stride[0] = extent[1] * extent[2] * extentN;
+		this->m_stride[1] = extent[2] * extentN;
+	}
+
+	void Init(std::string name, IndexType extent[3])
+	{
+		Init(name, {extent[0], extent[1], extent[2]});
+	}
+
+	// standard RAII initialization
+	ArrayNIJK(std::string name, std::array<IndexType, 3> extent)
+	{
+		Init(name, extent);
+	}
+
+	ArrayNIJK(std::string name, IndexType extent[3])
+	{
+		Init(name, {extent[0], extent[1], extent[2]});
+	}
+
+	// Access syntax is (n, i, j, k) but its memory layout is (i, j, k, n),
+	// in which n is the stride-1 dimension. In openEMS, performance is
+	// 20% higher.
+	IndexType linearIndex(std::array<IndexType, 4> tupleIndex) const
+	{
+		return tupleIndex[1] * m_stride[0] + \
+		       tupleIndex[2] * m_stride[1] +
+			   tupleIndex[3] * extentN +
+			   tupleIndex[0];
+	}
+
+	T& operator() (IndexType n, IndexType i, IndexType j, IndexType k) const
+	{
+		return this->m_ptr[linearIndex({n, i, j, k})];
+	}
+
+	~ArrayNIJK()
+	{
+		Base::AllocatorType::free(this->m_ptr, this->m_size);
+	}
+};
+
+#endif // ARRAYLIB_ARRAY_NIJK_H

--- a/tools/arraylib/impl/allocator.h
+++ b/tools/arraylib/impl/allocator.h
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2024 Yifeng Li <tomli@tomli.me>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef ARRAYLIB_ALLOCATOR_H
+#define ARRAYLIB_ALLOCATOR_H
+
+#include <cstddef>
+#include <cmath>
+
+namespace ArrayLib
+{
+	template <typename T>
+	class SimpleAllocator;
+
+	template <typename T>
+	class AlignedAllocator;
+};
+
+template <typename T>
+class ArrayLib::SimpleAllocator
+{
+public:
+	static T* alloc(size_t numelem)
+	{
+		T* ptr = new T[numelem]();
+	}
+
+	static void free(T* ptr, size_t numelem)
+	{
+		delete[] ptr;
+	}
+};
+
+#ifdef WIN32
+#include <malloc.h>
+#endif
+
+template <typename T>
+class ArrayLib::AlignedAllocator
+{
+public:
+	static T* alloc(size_t numelem)
+	{
+		size_t alignment;
+		// User-defined SIMD variables can be larger than the built-in C
+		// types, so they need custom alignments to their own size.
+		if (sizeof(T) <= sizeof(void*))
+			// POSIX says alignment >= sizeof(void*)
+			alignment = sizeof(void *);
+		else
+			// POSIX says alignment must be a power of 2
+			alignment = 1 << (size_t) ceil(log2(sizeof(T)));
+
+		T* buf;
+#ifdef WIN32
+		buf = _mm_malloc(numelem * sizeof(T), alignment);
+		if (buf == NULL)
+		{
+			std::cerr << "Failed to allocate aligned memory" << std::endl;
+			throw std::bad_alloc();
+		}
+#else
+		int retval = posix_memalign((void**) &buf, alignment, numelem * sizeof(T));
+		if (retval != 0)
+		{
+			std::cerr << "Failed to allocate aligned memory" << std::endl;
+			throw std::bad_alloc();
+		}
+#endif
+		memset(buf, 0, numelem * sizeof(T));
+		for (size_t i = 0; i < numelem; i++)
+			new (buf + i) T();
+
+		return buf;
+	}
+
+	static void free(T* ptr, size_t numelem)
+	{
+		if (ptr)
+		{
+			for (size_t i = 0; i < numelem; i++)
+				(&ptr[i])->~T();
+#ifdef WIN32
+			_mm_free(ptr);
+#else
+			std::free(ptr);
+#endif
+		}
+
+	}
+};
+
+#endif // ARRAYLIB_ALLOCATOR_H

--- a/tools/arraylib/impl/array_base.h
+++ b/tools/arraylib/impl/array_base.h
@@ -1,0 +1,126 @@
+/*
+ * Copyright (C) 2024 Yifeng Li <tomli@tomli.me>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef ARRAYLIB_ARRAY_BASE_H
+#define ARRAYLIB_ARRAY_BASE_H
+
+#include <string>
+
+#include "subscript.h"
+#include "allocator.h"
+
+// ArrayBase is a base class of which 2D, 3D and 4D arrays are derived from.
+// this reduces code duplication and allows minimum code in derived classes.
+//
+// Each derived class should implement:
+//
+// * call base constructor
+// * m_ptr, m_size, and m_bytes (by assignment in derived constructor)
+// * IndexType linearIndex(std::array<IndexType, dim> tupleIndex) const
+// * T& operator() (IndexType i, IndexType j, IndexType k)
+// * using Base::operator(); (so both base and derived operator() are visible)
+
+namespace ArrayLib
+{
+	template <
+		typename Derived,
+		typename T,
+		size_t rank,
+		typename Index,
+		typename Allocator=AlignedAllocator<T>
+	>
+	class ArrayBase;
+};
+
+template <
+	typename Derived,
+	typename T,
+	size_t rank,
+	typename Index,
+	typename Allocator
+>
+class ArrayLib::ArrayBase
+{
+private:
+	using ArrayBaseType = ArrayBase<
+		Derived, T, rank, Index, Allocator
+	>;
+
+protected:
+	using AllocatorType = Allocator;
+
+	std::string m_name;
+	std::array<Index, rank> m_extent;
+	Index m_size, m_bytes;
+
+	T* __restrict m_ptr = NULL;
+
+	// 2-phase initialization
+	ArrayBase() {}
+
+public:
+	using IndexType = Index;
+	using ValueType = T;
+
+	// Access array via arr({i, j, k}) syntax with one array of indices.
+	// Each derived class should also implement operator(i, j, k), which
+	// is the recommended syntax.
+	T&
+	operator() (std::array<IndexType, rank> tupleIndex) const
+	{
+		auto derived = static_cast<const Derived*>(this);
+		return m_ptr[derived->linearIndex(tupleIndex)];
+	}
+
+	// Access array via arr[i][j][k] syntax with one index per operator[]
+	// implemented by a Subscript class, which uses template metaprogramming
+	// to either recursively return another Subscript, or return an actual
+	// reference T&. Performance of nested operator[] should be the same as
+	// as flat operator() (identical assembly code generation even on MSVC).
+	//
+	// Not recommended in new code anyway, only for legacy code compatibility.
+	Subscript<const ArrayBaseType, rank, 1>
+	operator[] (IndexType firstTupleIdx) const
+	{
+		auto subscriptAccessor = Subscript<const ArrayBaseType, rank, 0>(*this);
+		return subscriptAccessor[firstTupleIdx];
+	}
+
+	// This array must always be passed via reference, not value, because
+	// it's prohibitively expensive for GiB-sized simulation data. If the
+	// rule is ignored, different copies would hold the same underlying
+	// pointer. When RAII frees a single array within a scope, it affects
+	// the entire program.
+	ArrayBase (const ArrayBase&) = delete;
+	ArrayBase& operator= (const ArrayBase&) = delete;
+
+	std::string                 name()              const { return m_name;     }
+	std::array<IndexType, rank> extent()            const { return m_extent;   }
+	IndexType                   extent(IndexType n) const { return m_extent[n];}
+
+	// return the number of array elements
+	IndexType                   size()              const { return m_size;     }
+
+	// return occupied memory
+	IndexType                   bytes()             const { return m_bytes;    }
+
+	// return raw pointer to underlying data
+	T*                          data()              const { return m_ptr;      }
+	T&                          data(IndexType n)   const { return m_ptr[n];   }
+};
+
+#endif // ARRAYLIB_ARRAY_BASE_H

--- a/tools/arraylib/impl/subscript.h
+++ b/tools/arraylib/impl/subscript.h
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2024 Yifeng Li <tomli@tomli.me>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef ARRAYLIB_SUBSCRIPT_H
+#define ARRAYLIB_SUBSCRIPT_H
+
+#include <cstddef>
+#include <array>
+#include <stdexcept>
+
+// Subscript is a wrapper class that enables access an ArrayType& via
+// arr[i][j][k] syntax, with one index per operator[]. This is implemented
+// via template metaprogramming to either recursively return another
+// Subscript, or return an actual reference T& when recursion reaches
+// the base case.
+//
+// Performance of nested operator[] should be the same as as flat operator()
+// (the last time I've check, with identical assembly code generation even
+// on MSVC).
+namespace ArrayLib
+{
+	template <typename ArrayType, size_t maxDim, size_t dim>
+	class Subscript;
+};
+
+template <typename ArrayType, size_t maxDim, size_t dim>
+class ArrayLib::Subscript
+{
+public:
+	Subscript(ArrayType& array) : m_array(array) {}
+
+	Subscript(
+		const ArrayType& array,
+		std::array<typename ArrayType::IndexType, maxDim> sub
+	) :
+		m_array(array),
+		m_sub(sub)
+	{
+	}
+
+	template <typename ArrayType_=ArrayType> // dummy param for enable_if
+	typename std::enable_if<
+		/* enable when */ dim + 1 < maxDim,
+		/* return type */ Subscript<ArrayType_, maxDim, dim + 1>
+	>::type
+	operator[] (size_t nextTupleIdx)
+	{
+		m_sub[dim] = nextTupleIdx;
+		return Subscript<ArrayType, maxDim, dim + 1>(m_array, m_sub);
+	}
+
+	template <typename ArrayType_=ArrayType> // dummy param for enable_if
+	typename std::enable_if<
+		/* enable when */ dim + 1 == maxDim,
+		/* return type */ typename ArrayType_::ValueType&
+	>::type
+	operator[] (size_t finalTupleIdx)
+	{
+		m_sub[dim] = finalTupleIdx;
+		return m_array(m_sub);
+	}
+
+	// catch common misuses
+	void operator=(typename ArrayType::ValueType val)
+	{
+		(void) val;
+
+		// equivalent to static_assert(false) with friendly error messages
+		static_assert(
+			maxDim == dim, // evaluates to false
+			"Too few [] operators are given to a multi-dimensional array. "
+			"Indexing a pointer without dereference can cause the same error."
+			" (e.g. ptr[x][y][z] should be (*ptr)[x][y][z])"
+		);
+	}
+
+	operator typename ArrayType::ValueType() const
+	{
+		// equivalent to static_assert(false) with friendly error messages
+		static_assert(
+			maxDim == dim, // evaluates to false
+			"Too few [] operators are given to a multi-dimensional array. "
+			"Indexing a pointer without dereference can cause the same error "
+			" (e.g. ptr[x][y][z] should be (*ptr)[x][y][z])"
+		);
+		throw std::logic_error("bad template usage");
+	}
+
+private:
+	const ArrayType& m_array;
+	std::array<typename ArrayType::IndexType, maxDim> m_sub;
+};
+
+#endif // ARRAYLIB_SUBSCRIPT_H

--- a/tools/vtk_file_writer.cpp
+++ b/tools/vtk_file_writer.cpp
@@ -239,6 +239,37 @@ void VTK_File_Writer::AddVectorField(string fieldname, float const* const* const
 	array->Delete();
 }
 
+void VTK_File_Writer::AddVectorField(string fieldname, ArrayLib::ArrayNIJK<float>& field)
+{
+	vtkFloatArray* array = vtkFloatArray::New();
+	array->SetNumberOfComponents(3);
+	array->SetNumberOfTuples(m_MeshLines[0].size()*m_MeshLines[1].size()*m_MeshLines[2].size());
+	array->SetName(fieldname.c_str());
+	int id=0;
+	float out[3];
+	for (unsigned int k=0;k<m_MeshLines[2].size();++k)
+	{
+		for (unsigned int j=0;j<m_MeshLines[1].size();++j)
+		{
+			float cos_a = cos(m_MeshLines[1].at(j)); //needed only for m_MeshType==1 (cylindrical mesh)
+			float sin_a = sin(m_MeshLines[1].at(j)); //needed only for m_MeshType==1 (cylindrical mesh)
+			for (unsigned int i=0;i<m_MeshLines[0].size();++i)
+			{
+				if ((m_MeshType==0) || (m_NativeDump))
+					array->SetTuple3(id++,field[0][i][j][k],field[1][i][j][k],field[2][i][j][k]);
+				else
+				{
+					out[0] = field[0][i][j][k] * cos_a - field[1][i][j][k] * sin_a;
+					out[1] = field[0][i][j][k] * sin_a + field[1][i][j][k] * cos_a;
+					out[2] = field[2][i][j][k];
+					array->SetTuple3(id++,out[0],out[1],out[2]);
+				}
+			}
+		}
+	}
+	m_GridData->GetPointData()->AddArray(array);
+	array->Delete();
+}
 
 int VTK_File_Writer::GetNumberOfFields() const
 {

--- a/tools/vtk_file_writer.h
+++ b/tools/vtk_file_writer.h
@@ -25,6 +25,8 @@
 #include <vector>
 #include <complex>
 
+#include "tools/arraylib/array_nijk.h"
+
 class vtkDataSet;
 
 class VTK_File_Writer
@@ -53,6 +55,7 @@ public:
 	virtual void AddScalarField(std::string fieldname, float const* const* const* field);
 	virtual void AddVectorField(std::string fieldname, double const* const* const* const* field);
 	virtual void AddVectorField(std::string fieldname, float const* const* const* const* field);
+	virtual void AddVectorField(std::string fieldname, ArrayLib::ArrayNIJK<float>& field);
 
 	virtual int GetNumberOfFields() const;
 	virtual void ClearAllFields();


### PR DESCRIPTION
# TL;DR

## Motivation

This is a resubmitted version of PR #117, reworked for the third time. The difference is that, this time, a small C++ class named `ArrayLib` is implemented, and the openEMS's FDTD engine is converted to use the new ArrayLib code.

In ArrayLib, by using C++ template metaprogramming, the existing array indexing syntax `arr[n][i][j][k]` can be kept without changing them to `arr(n, i, j, k)`. This way, we achieve two goals:

1. Clear up the path for the upcoming Tiling engine, which is also based on the new array implementation.
2. It minimizes the changes to the existing engine code. This is useful because the upcoming Tiling engine code is experimental, so we want to keep the old one for reference.

Please consider merging this change as soon as it's appropriately to do so, so that the next phase of development can start. The best is yet to come.

## Result

### Correctness

All built-in Python examples were executed and the simulation results are exactly the same. Furthermore, field dumps of a third-party `pyems` simulation called `gcpw.py` has been executed for hours, the field dumps were compared with the unmodifed openEMS code, and all floating-point numbers are bit-identical.

Note that openEMS automatically terminates simulation if energy is lower than the end criteria, but the exact timestep of termination depends on simulation speed, thus the same simulation is not reproducible by default - This is not a bug in the PR. To replicate the simulation result, it's necessary to (1) Set a impossible end criteria such as 1e-9, so a simulation is not stopped early. (2) manually specify the `NrTS` in a simulation, so that the same simulation would always stop at the same timestep.

## Performance

Performance is improved by 5%-30% in medium and large-size simulations. The most extreme improvement (30%) is seen in long and narrow structure. This is expected because the old array code performs the worst if the last stride is non-contiguous, which is exactly what the new code is meant to fix. For small simulation there can be a performance degradation of 4%-5% or so, but given their small sizes there slowdowns are negligible.

Since the results are rather similar to the benchmarks shown in the old PR, only the benchmark results on one machine is shown here:

![Zen 2 Benchmark](https://github.com/user-attachments/assets/a4b1681c-b33d-43b3-8f34-42d8f8ff6f6c)

---

ArrayLib - Simple Multi-Dimensional Array Library with C-like Syntax
=====================================================================

Motivation
-------------

Originally, multi-dimensional arrays in the simulation engine were allocated as multi-level C pointers. For example, the following code allocates and accesses a 3D array:

    // allocate 3D arrays as pointers of pointers
    T*** array=NULL;
    array = new T**[SIZE_I]
    for (size_t i = 0; i < SIZE_I; i++)
    {
    	array[i] = new T*[SIZE_J]
    	for (size_t j = 0; j < SIZE_J; j++)
    	{
            array[i][j] = new T[SIZE_K];
            for (size_t k = 0; k < SIZE_K; k++)
    		{
                // access array via C-style syntax
    			array[i][j][k] = 0;
    		}
    	}
    }

The advantage is that all multi-dimensional arrays can be accessed like a C-style array. But with several downsides:

1. A single array requires multiple `malloc()` or `new` allocation.
2. The allocated memory is not contiguous, reducing memory locality and performance, especially when the final dimension is small.

According to the best practice today (e.g. `std::mdspan`), these raw pointers should be converted to wrapped arrays classes with their internal indexing code, and they should be accessed using the following syntax:

    array(i, j, k) = 0;
    array[i, j, k] = 0; // C++23

But this requires massive change of all existing array indexing code throughout the codebase, which is error-prone and difficult to review.

ArrayLib is a simple library written with the goal of providing a simple implementation of multi-dimensional array, but preserved the C-like access syntax using C++ template metaprogramming to minimize the code change in the simulation engine.

Supported Types
--------------------

1. ArrayIJ - 2D array.
2. ArrayIJK - 3D array.
3. ArrayNIJK - 3D array (N = 3 only), IJK is the coordinate of a 3D vector in space, N (0, 1, 2) selects the X/Y/Z value from the vector.

To avoid ambiguity, IJK is always used to describe coordinates in space, not X/Y/Z.

Usage 1: new/delete
--------------------

ArrayLib can be used in several ways, the first method closely mirrors the C-style code using raw pointers, allowing direct migration from legacy code.

    ArrayLib::ArrayIJK<float>* arr_ptr = new ArrayLib::ArrayIJK("name", {10, 20, 30});

    // arr_ptr[0][1][2] is wrong, because we need to call the operator[]
    // of ArrayIJK, rather than accessing an array of pointers of type
    // `ArrayIJK*`.
    (*arr_ptr)[0][1][2] = 3;

    // But one can use C++ reference rather than pointers to access it
    // in a readable way, add a line of boilerplate, but more readable
    ArrayLib::ArrayIJK<float>& arr = *arr_ptr;
    arr[0][1][2] = 3;

    delete arr_ptr;

The first method is advantageous in the sense that all existing pointers with inconsistent lifetimes can be converted to ArrayLib directly as drop-in replacement. The disadvantage is that the C-style syntax is only emulated we're accessing a C++ reference, not a C pointer. Yet C++ reference can't be NULL, so when arrays with inconsistent lifetimes are used in classes, C-style pointers (with confusing syntax) must be kept as member variables, not references (with natural syntax).

To write readable code, whenever an array is accessed by a member function, we must dereference a pointer to create a C++ reference first. Overall, this is the smoothest migration path, so this style is widely used in engine classes.

Usage 2: As Local Member Variable w/ RAII
------------------------------------------

ArrayLib arrays can be used as local variables by declaring them directly (with name and size). These arrays are automatically freed by C++'s RAII mechanics when they go out of scope.

    void process()
    {
        ArrayLib::ArrayIJK<float> arr("name", {10, 20, 30});
        array[0][1][2] = 0;
        // deleted automatically by RAII
    }

This allows one to access arrays using the natural syntax, and without manual memory management.

Usage 3: As Class Member Variable w/ RAII
-----------------------------------------

Similarly, ArrayLib arrays can also be used as class member variables in conformance to the C++ RAII idiom. Class member variables are recommended for arrays with runtime-determined size.

    class Engine
    {
        // automatically deleteled by RAII
        ArrayLib::ArrayIJK<float> arr1("static size", {10, 20, 30});
        ArrayLib::ArrayIJK<float> arr2;
        
        Engine(size_t i, size_t j, size_t k) :
            arr2("initialize in constructor", {i, j, k})
        {
            // use natural C-style syntax for acess
            arr1[1][2][3] = 0;
            arr2[4][5][6] = 1;
        }
    }

Ideally, this should be the recommended usage for ArrayLib arrays in C++ classes.

Unfortunately, because the existing codebase does not use the C++ RAII idiom, and arrays mostly have inconsistent lifetimes (e.g. sometimes, array sizes can't be determined in the constructor, but instead is determined in the middle of the class's lifetime from an external source), it's not possible to translate all existing array usages to this idiom.

Usage 4: As Class Member Variable w/ Two-Phase Initialization
--------------------------------------------------------------

As a compromise to the lifetime problem, two-phase Initialization is also supported. This can be done by creating an array object (not reference or pointers) as a class member variable without specifying its name and size. The result is a placeholder array in an invalid state, which can be later initialized.

    class Engine
    {
        // automatically deleteled by RAII, size unknown
        ArrayLib::ArrayIJK<float> arr1;
        
        Engine(size_t i, size_t j, size_t k);
        {
            // two-phase initialization before use
            arr1.Init("name", {i, j, k});

            // use natural C-style syntax for acess
            arr1[1][2][3] = 0;
        }
    }

Although it's potentially unsafe, but one can still enjoy automatic release of memory upon class destruction by C++'s RAII.

ArrayLib Arrays Can't be Passed by Value
--------------------------------------------

ArrayLib objects are simple wrappers to heap-allocated memory, with few extra features in comparison to raw C pointers. In fact, they're designed to serve as drop-in replacement of raw pointers, which is prevalent in the existing codebase (we expect to refactor the codebase progressively). Thus, they're not meant to be high-level C++ containers. ArrayLib objects must be always passed as pointers or references, pass-by-value and copy-assignment are not supported. These operators are marked as deleted, attempting to do so would create a compile-time error. They make little sense for the low-level numerical simulation kernel in its current form.

    ArrayLib::ArrayIJK<float> data("name", size);

    // pass-by-reference, recommended when possible
    void process_ref(ArrayLib::ArrayIJK<float>& arr);
    process_ref(data);

    // pass-by-pointer, use only when necessary
    void process_ptr(ArrayLib::ArrayIJK<float>* arr_ptr);
    process_ptr(&data);

    // pass-by-value, WRONG!
    void process_value(ArrayLib::ArrayIJK<float> arr);
    process_value(data)

Furthermore, practically speaking, in a simulation, large arrays to represent electromagnetic fields and material properties are allocated and passed around as pointers. Attempting to pass an array by value is always a bug.