### PR TITLE
Fix VTK Deprecation Warning in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,7 +134,12 @@ message(STATUS "Boost_LIBRARIES: ${Boost_LIBRARIES}")
 INCLUDE_DIRECTORIES (${Boost_INCLUDE_DIRS})
 
 # vtk
-find_package(VTK COMPONENTS vtkIOXML vtkIOGeometry vtkIOLegacy vtkIOPLY NO_MODULE REQUIRED)
+find_package(VTK REQUIRED NO_MODULE)
+if (${VTK_VERSION} VERSION_GREATER "9")
+    find_package(VTK REQUIRED COMPONENTS IOXML IOGeometry IOLegacy IOPLY NO_MODULE REQUIRED)
+else()
+    find_package(VTK REQUIRED COMPONENTS vtkIOXML vtkIOGeometry vtkIOLegacy vtkIOPLY NO_MODULE REQUIRED)
+endif()
 
 message(STATUS "Found package VTK. Using version " ${VTK_VERSION})
 set( vtk_LIBS ${VTK_LIBRARIES} )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,13 +139,13 @@ if (${VTK_VERSION} VERSION_GREATER "9")
     find_package(VTK REQUIRED COMPONENTS IOXML IOGeometry IOLegacy IOPLY NO_MODULE REQUIRED)
 else()
     find_package(VTK REQUIRED COMPONENTS vtkIOXML vtkIOGeometry vtkIOLegacy vtkIOPLY NO_MODULE REQUIRED)
+    include(${VTK_USE_FILE})
 endif()
 
 message(STATUS "Found package VTK. Using version " ${VTK_VERSION})
 set( vtk_LIBS ${VTK_LIBRARIES} )
 message(STATUS "vtk libraries " ${vtk_LIBS})
 
-include(${VTK_USE_FILE})
 INCLUDE_DIRECTORIES (${VTK_INCLUDE_DIR})
 
 # independent tool


### PR DESCRIPTION
This PR contains two changes.

## CMakeLists.txt: avoid deprecated names in VTK 9+.

In VTK 9+, components vtkIOXML, vtkIOGeometry, vtkIOLegacy, vtkIOPLY, etc, have been renamed to IOXML, IOGeometry, IOLegacy, IOPLY, etc. So use the new name if VTK 9+ is detected.

## CMakeLists.txt: don't call VTK_USE_FILE for 9.0+

The `VTK_USE_FILE` is no longer used starting with 8.90.
