### PR TITLE
tools/global.cpp: assign default verbose value.

### DIFF
--- a/python/openEMS/openEMS.pyx
+++ b/python/openEMS/openEMS.pyx
@@ -461,16 +461,29 @@ cdef class openEMS:
 
     def _SetLibraryArguments(self, arguments):
         allOptions = []
+        integerOptions = ["verbose", "numthreads"]
 
         for key, val in arguments.items():
             key = key.replace("_", "-")
             key = key.replace("setup-only", "no-simulation")
 
-            # boolean options are implicit
-            if val and (val is not True) and (val is not False):
-                opt = "%s=%s" % (key, val)
-            else:
+            # Using 1/0 instead of True/False is tolerated, but only
+            # if the option is not an integer (which is ambiguous)
+            if key.lower() not in integerOptions:
+                if val == 1:
+                    val = True
+                elif val == 0:
+                    val = False
+
+            if val is True:
+                # "True" boolean options are implicit
                 opt = "%s" % key
+            elif val is False:
+                # "False" boolean options are ignored
+                opt = ""
+            elif (val is not True) and (val is not False):
+                # integer and string options are explicit
+                opt = "%s=%s" % (key, val)
 
             allOptions.append(opt.encode("UTF-8"))
 

--- a/tools/global.cpp
+++ b/tools/global.cpp
@@ -66,13 +66,18 @@ Global::optionDesc()
 		)
 		(
 			"verbose,v",
-			po::value<unsigned int>()->implicit_value(1)->notifier(
+			po::value<unsigned int>()->default_value(0)->implicit_value(1)->
+			notifier(
 				[&](unsigned int val)
 				{
-					if (val == 0) return;
+					// Don't apply settings if the default value 0 is unchanged,
+					// Apply settings and print messages if we have a non-default value
+					// or if the non-default value is changed back to default in another
+					// call (when running as a shared library).
+					if (val == 0 && m_VerboseLevel == 0) return;
+
 					m_VerboseLevel = val;
 					cout << "openEMS - verbose level " << m_VerboseLevel << endl;
-
 				}
 			),
             "Verbose level, select debug level 1 to 3, "

--- a/tools/global.cpp
+++ b/tools/global.cpp
@@ -80,8 +80,8 @@ Global::optionDesc()
 					cout << "openEMS - verbose level " << m_VerboseLevel << endl;
 				}
 			),
-            "Verbose level, select debug level 1 to 3, "
-		    "also accept -v, -vv, -vvv"
+			"Verbose level, select debug level 1 to 3, "
+			"also accept -v, -vv, -vvv"
 		);
 	return optdesc;
 }


### PR DESCRIPTION
After commit 3c4e802638d4 ("Completely Rewrite Command-Line Argument Parsing"), the "verbose" option was assigned an implicit value (i.e. the value used for "-v" without an explicit number), but not a default value (i.e. the value used if no "-v" is given). This commit assigns a default value of 0 for logical consistency, and to allow the help message to show the default verbose value correctly.