### PR TITLE
CMakeLists.txt: fix VTK regression again.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,7 +134,7 @@ message(STATUS "Boost_LIBRARIES: ${Boost_LIBRARIES}")
 INCLUDE_DIRECTORIES (${Boost_INCLUDE_DIRS})
 
 # vtk
-find_package(VTK)
+find_package(VTK COMPONENTS CommonCore QUIET)
 if (${VTK_VERSION} VERSION_GREATER "9")
     find_package(VTK REQUIRED COMPONENTS IOXML IOGeometry IOLegacy IOPLY NO_MODULE REQUIRED)
 else()


### PR DESCRIPTION
It turns out that `find_package(VTK)` without any component has some side-effects that interacts with Boost, causing nf2ff build failures. This problem doesn't seem to show up if openEMS is built separately, but will appear if the entire project is built together.

To fix the problem, instead we use:

    find_package(VTK COMPONENTS CommonCore QUIET)

If VTK 9 is installed, CommonCore can be found and VTK 9's branch is executed. It's marked as QUIET so this failure doesn't generate fatal error messages on the screen. If VTK 8 is installed (or no VTK is installed), VTK 8's branch is executed, so its behavior on old systems should be exactly the same.