### PR TITLE
python/setup.py: drop minimum version requirements, close #165.

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -51,9 +51,9 @@ setup(
   package_data={'openEMS': ['*.pxd']},
   python_requires='>=3.9',
   install_requires=[
-    'cython>=3.0.6',  # Apache License 2.0 (https://github.com/cython/cython/blob/master/LICENSE.txt)
-    'h5py>=3.10.0',   # BSD 3-Clause (https://github.com/h5py/h5py/blob/master/LICENSE)
-    'numpy>=1.26.2',  # BSD 3-Clause (https://github.com/numpy/numpy/blob/main/LICENSE.txt)
+    'cython', # Apache License 2.0 (https://github.com/cython/cython/blob/master/LICENSE.txt)
+    'h5py',   # BSD 3-Clause (https://github.com/h5py/h5py/blob/master/LICENSE)
+    'numpy',  # BSD 3-Clause (https://github.com/numpy/numpy/blob/main/LICENSE.txt)
   ],
   ext_modules = cythonize(extensions, language_level = 3)
  )


### PR DESCRIPTION
On Debian 11, running openEMS via Python produces the following error:

    ImportError: numpy.core.multiarray failed to import

This is a binary compatibility problem that should've never happened. But it did. Why? Because setup.py requires NumPy 1.26, but Debian only has NumPy 1.24. Python finds no system package that can satisfy this requirement so download binaries that from PyPI instead. But now we have NumPy v2 incompatible with the rest of the system, creating the binary compatibility problem. It's exactly why PyPI packages should never be mixed outside a virtualenv. Same problems exist for h5py and cython as well. although there's no compatibility problem per se, at least, not yet.

These version requirements were introduced by in commit 5bc31d0 ("add missing package python dependencies") and e7620dc ("also add cython (everything but setuptools)"), but no justification was given about why these minimum versions were necessary. If I recall correctly, openEMS used to be compatible even with very ancient Python versions.

For now, drop these version requirements entirely. It's a bit sloppy but it's easier than trying to test ancient systems and figuring out the exact minimum versions. If we insist on adding version requirements in the future, it should be at least compatible with Debian's oldstable.