### PR TITLE
Adding localized Mur\SA-Mur absorbers for waveguide ports and custom waveguide modes

### DIFF
--- a/Common/processmodematch.cpp
+++ b/Common/processmodematch.cpp
@@ -28,6 +28,9 @@ ProcessModeMatch::ProcessModeMatch(Engine_Interface_Base* eng_if) : ProcessInteg
 	{
 		m_ModeParser[n] = new CSFunctionParser();
 		m_ModeDist[n] = NULL;
+
+		m_MWeights[n].clear();
+		m_MCoors[n].clear();
 	}
 	delete[] m_Results;
 	m_Results = new double[2];
@@ -117,16 +120,20 @@ void ProcessModeMatch::InitProcess()
 	m_numLines[0] = stop[nP] - start[nP] + 1;
 	m_numLines[1] = stop[nPP] - start[nPP] + 1;
 
-	for (int n=0; n<2; ++n)
+	// Check that this isn't a custom mode, before running this test
+	if (m_MWeights[0].size() == 0)
 	{
-		int ny = (m_ny+n+1)%3;
-		int res = m_ModeParser[n]->Parse(m_ModeFunction[ny], "x,y,z,rho,a,r,t");
-		if (res >= 0)
+		for (int n=0; n<2; ++n)
 		{
-			cerr << "ProcessModeMatch::InitProcess(): Warning, an error occurred parsing the mode matching function (see below) ..." << endl;
-			cerr << m_ModeFunction[ny] << "\n" << string(res, ' ') << "^\n" << m_ModeParser[n]->ErrorMsg() << "\n";
-			SetEnable(false);
-			Reset();
+			int ny = (m_ny+n+1)%3;
+			int res = m_ModeParser[n]->Parse(m_ModeFunction[ny], "x,y,z,rho,a,r,t");
+			if (res >= 0)
+			{
+				cerr << "ProcessModeMatch::InitProcess(): Warning, an error occurred parsing the mode matching function (see below) ..." << endl;
+				cerr << m_ModeFunction[ny] << "\n" << string(res, ' ') << "^\n" << m_ModeParser[n]->ErrorMsg() << "\n";
+				SetEnable(false);
+				Reset();
+			}
 		}
 	}
 
@@ -144,11 +151,20 @@ void ProcessModeMatch::InitProcess()
 	discLine[m_ny] = Op->GetDiscLine(m_ny,pos[m_ny],dualMesh);
 	double norm = 0;
 	double area = 0;
-	for (unsigned int posP = 0; posP<m_numLines[0]; ++posP)
+
+	// Remove 1 from the number of lines if this is a magentic field. It samples 1 cell too many
+	if (dualMesh)
+	{
+		m_numLines[0]--;
+		m_numLines[1]--;
+	}
+
+	for (unsigned int posP = 0; posP < m_numLines[0]; ++posP)
 	{
 		pos[nP] = start[nP] + posP;
 		discLine[nP] = Op->GetDiscLine(nP,pos[nP],dualMesh);
-		for (unsigned int posPP = 0; posPP<m_numLines[1]; ++posPP)
+
+		for (unsigned int posPP = 0; posPP < m_numLines[1]; ++posPP)
 		{
 			pos[nPP] = start[nPP] + posPP;
 			discLine[nPP] = Op->GetDiscLine(nPP,pos[nPP],dualMesh);
@@ -171,13 +187,39 @@ void ProcessModeMatch::InitProcess()
 				var[6] = asin(1)-atan(var[2]/var[3]); //theta (t)
 			}
 			area = Op->GetNodeArea(m_ny,pos,dualMesh);
-			for (int n=0; n<2; ++n)
+
+			// First pass: extract m_ModeDist values
+			// Check if there are manual weights
+			if (m_MWeights[0].size())
 			{
-				m_ModeDist[n][posP][posPP] = m_ModeParser[n]->Eval(var); //calc mode template
-				if ((std::isnan(m_ModeDist[n][posP][posPP])) || (std::isinf(m_ModeDist[n][posP][posPP])))
-					m_ModeDist[n][posP][posPP] = 0.0;
-				norm += pow(m_ModeDist[n][posP][posPP],2) * area;
+				uint weightIdx = GetClosestManualWeightIdx(discLine);
+
+				//double modeVect[3] = {0.0,0.0,0.0};
+
+				for (int n = 0 ; n < 2; ++n)
+				{
+					int ny = (m_ny+n+1)%3;
+					m_ModeDist[n][posP][posPP] = m_MWeights[ny].at(weightIdx);
+					//modeVect[ny] = m_MWeights[ny].at(weightIdx);
+
+				}
 			}
+
+
+
+			else
+				for (int n = 0; n < 2; ++n)
+				{
+					m_ModeDist[n][posP][posPP] = m_ModeParser[n]->Eval(var); //calc mode template
+					if ((std::isnan(m_ModeDist[n][posP][posPP])) || (std::isinf(m_ModeDist[n][posP][posPP])))
+						m_ModeDist[n][posP][posPP] = 0.0;
+
+				}
+
+			// Second pass, for normalization
+			for (int n=0; n<2; ++n)
+				norm += pow(m_ModeDist[n][posP][posPP],2) * area;
+
 //			cerr << discLine[0] << " " << discLine[1] << " : " << m_ModeDist[0][posP][posPP] << " , " << m_ModeDist[1][posP][posPP] << endl;
 		}
 	}
@@ -213,6 +255,51 @@ void ProcessModeMatch::SetModeFunction(int ny, string function)
 {
 	if ((ny<0) || (ny>2)) return;
 	m_ModeFunction[ny] = function;
+}
+
+void ProcessModeMatch::SetManualWeights(uint dir, const std::vector<float> & v)
+{
+	m_MWeights[dir].clear();
+	m_MWeights[dir].assign(v.begin(),v.end());
+}
+
+void ProcessModeMatch::SetManualCoors(uint dir, const std::vector<float> & v)
+{
+	m_MCoors[dir].clear();
+	m_MCoors[dir].assign(v.begin(),v.end());
+}
+
+void ProcessModeMatch::ClearManualWeights()
+{
+	for(uint dirIdx = 0 ; dirIdx < 3 ; dirIdx++)
+	{
+		m_MWeights[dirIdx].clear();
+		m_MCoors[dirIdx].clear();
+	}
+}
+
+uint ProcessModeMatch::GetClosestManualWeightIdx(const double* coords)
+{
+	// Check if manual weights are set. If so, look for coordinate there
+	float minDr = std::numeric_limits<float>::infinity();	// Container for minimal found dr
+	float dr; 												// Container for distance between requested coordiante and stored coordinate
+	uint minIdx;
+	// Check all the coordinates within this excitation to see which is the closest.
+	for (uint coorIdx = 0 ; coorIdx < m_MWeights[0].size() ; coorIdx++)
+	{
+		dr = sqrtf(	powf(coords[0] - m_MCoors[0].at(coorIdx),2.0f) +
+					powf(coords[1] - m_MCoors[1].at(coorIdx),2.0f) +
+					powf(coords[2] - m_MCoors[2].at(coorIdx),2.0f));
+
+		if (dr < minDr)
+		{
+			minDr = dr;
+			minIdx = coorIdx;
+		}
+
+	}
+
+	return minIdx;
 }
 
 void ProcessModeMatch::SetFieldType(int type)

--- a/Common/processmodematch.h
+++ b/Common/processmodematch.h
@@ -48,11 +48,23 @@ public:
 	virtual int GetNumberOfIntegrals() const {return 2;}
 	virtual double* CalcMultipleIntegrals();
 
+	void SetManualWeights(uint dir, const std::vector<float> & v);
+	void SetManualCoors(uint dir, const std::vector<float> & v);
+	std::vector<float> GetManualWeights(uint dir) {return m_MWeights[dir];}
+	std::vector<float> GetManualCoors(uint dir) {return m_MCoors[dir];}
+
+	void ClearManualWeights();
+
+	uint GetClosestManualWeightIdx(const double* coords);
+
 protected:
 	//normal direction of the mode plane
 	int m_ny;
 
 	int m_ModeFieldType;
+
+	std::vector<float>	m_MWeights[3];	// Manual weights for mode matching
+	std::vector<float>	m_MCoors[3];	// Manual coordinates for mode matching weights
 
 	double GetField(int ny, const unsigned int pos[3]);
 	double GetEField(int ny, const unsigned int pos[3]);

--- a/FDTD/extensions/CMakeLists.txt
+++ b/FDTD/extensions/CMakeLists.txt
@@ -26,6 +26,8 @@ set(SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/engine_ext_steadystate.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/operator_ext_lumpedRLC.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/engine_ext_lumpedRLC.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/operator_ext_absorbing_bc.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/engine_ext_absorbing_bc.cpp
   PARENT_SCOPE
 )
 

--- a/FDTD/extensions/engine_ext_absorbing_bc.cpp
+++ b/FDTD/extensions/engine_ext_absorbing_bc.cpp
@@ -1,0 +1,557 @@
+/*
+*	Copyright (C) 2010 Thorsten Liebig (Thorsten.Liebig@gmx.de)
+*
+*	This program is free software: you can redistribute it and/or modify
+*	it under the terms of the GNU General Public License as published by
+*	the Free Software Foundation, either version 3 of the License, or
+*	(at your option) any later version.
+*
+*	This program is distributed in the hope that it will be useful,
+*	but WITHOUT ANY WARRANTY; without even the implied warranty of
+*	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*	GNU General Public License for more details.
+*
+*	You should have received a copy of the GNU General Public License
+*	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "engine_ext_absorbing_bc.h"
+#include "operator_ext_absorbing_bc.h"
+#include "FDTD/engine.h"
+#include "FDTD/engine_sse.h"
+#include "tools/array_ops.h"
+#include "tools/useful.h"
+#include "operator_ext_excitation.h"
+
+#include "CSPropAbsorbingBC.h"
+
+#define SAFE_DELETE(v) 	\
+	if (v != NULL) 		\
+	{ 					\
+		delete[] v;		\
+		v = NULL;		\
+	}					\
+
+Engine_Ext_Absorbing_BC::Engine_Ext_Absorbing_BC(Operator_Ext_Absorbing_BC* op_ext) : Engine_Extension(op_ext)
+{
+
+	m_Op_ABC = op_ext;
+
+	m_K1 = m_Op_ABC->m_K1;
+	m_K2 = m_Op_ABC->m_K2;
+
+	m_numCells = m_Op_ABC->m_numCells;
+	m_numPrims = m_Op_ABC->m_numPrims;
+
+	m_start_TS = 0;
+
+
+	// Initialize shifted positions
+	m_pos_ny0_shift_V = new uint[m_Op_ABC->m_numPrims];
+
+	// For magnetic fields, two containers are necessary
+	m_pos_ny0_I = new uint[m_Op_ABC->m_numPrims];
+	m_pos_ny0_shift_I = new uint[m_Op_ABC->m_numPrims];
+
+	m_posStart = m_Op_ABC->m_sheetX0;
+	m_posStop = m_Op_ABC->m_sheetX1;
+
+	m_dir = m_Op_ABC->m_dir;
+
+	// Initialize shifted location
+	int normDir;
+	uint cDir,cStartPos;
+	for (uint primIdx = 0 ; primIdx < m_Op_ABC->m_numPrims ; primIdx++)
+	{
+		// Change according to normal direction
+		normDir = m_Op_ABC->m_normDir[primIdx];
+		cDir = abs(normDir) - 1;
+		normDir = normDir >= 0 ? 1 : -1;
+
+		cStartPos = m_posStart[primIdx][cDir];
+
+		// This shift is also valid for magnetic field. The half cell
+		// shift is always to the right (positive direction)
+		m_pos_ny0_shift_V[primIdx] = cStartPos + normDir;
+
+		// For SABC, also initialize magnetic field containers
+		if ((CSPropAbsorbingBC::BCtype)(m_Op_ABC->m_boundaryTypes[primIdx]) == CSPropAbsorbingBC::MUR_1ST_1PV_SA)
+		{
+			normDir = normDir >= 0 ? 0 : -1;
+			if (m_pos_ny0_I)
+				m_pos_ny0_I[primIdx] = cStartPos + normDir;
+
+			// Convert normal direction indicator to fit with dual grid
+			normDir = normDir >= 0 ? 1 : -2;
+
+			m_pos_ny0_shift_I[primIdx] = cStartPos + normDir;
+		}
+		else
+		{
+			m_pos_ny0_I = 0;
+			m_pos_ny0_shift_I = 0;
+		}
+
+	}
+
+	m_V_ny1 = new FDTD_FLOAT*[m_Op_ABC->m_numPrims];
+	m_V_ny2 = new FDTD_FLOAT*[m_Op_ABC->m_numPrims];
+
+	m_I_ny1 = new FDTD_FLOAT*[m_Op_ABC->m_numPrims];
+	m_I_ny2 = new FDTD_FLOAT*[m_Op_ABC->m_numPrims];
+
+	m_Ic_ny1 = new FDTD_FLOAT*[m_Op_ABC->m_numPrims];
+	m_Ic_ny2 = new FDTD_FLOAT*[m_Op_ABC->m_numPrims];
+
+	for (uint primIdx = 0 ; primIdx < m_Op_ABC->m_numPrims ; primIdx++)
+	{
+		m_V_ny1[primIdx] = new FDTD_FLOAT[m_numCells[primIdx]];
+		m_V_ny2[primIdx] = new FDTD_FLOAT[m_numCells[primIdx]];
+
+		// Allocate if this is a SABC (maybe in the future something else
+		if ((CSPropAbsorbingBC::BCtype)(m_Op_ABC->m_boundaryTypes[primIdx]) == CSPropAbsorbingBC::MUR_1ST_1PV_SA)
+		{
+			m_I_ny1[primIdx] = new FDTD_FLOAT[m_numCells[primIdx]];
+			m_I_ny2[primIdx] = new FDTD_FLOAT[m_numCells[primIdx]];
+
+			m_Ic_ny1[primIdx] = new FDTD_FLOAT[m_numCells[primIdx]];
+			m_Ic_ny2[primIdx] = new FDTD_FLOAT[m_numCells[primIdx]];
+		}
+		else
+		{
+			m_I_ny1[primIdx] = NULL;
+			m_I_ny2[primIdx] = NULL;
+			m_I_ny1[primIdx] = NULL;
+			m_I_ny2[primIdx] = NULL;
+		}
+
+	}
+
+
+//	//find if some excitation is on this mur-abc and find the max length of this excite, so that the abc can start after the excitation is done...
+//	int maxDelay=-1;
+//
+//	Operator_Ext_Excitation* Exc_ext = m_Op_ABC->m_Op->GetExcitationExtension();
+//
+//	for (unsigned int n=0; n<Exc_ext->GetVoltCount(); ++n)
+//	{
+//		if ( ((Exc_ext->Volt_dir[n] == m_nyP) || (Exc_ext->Volt_dir[n]==m_nyPP)) && (Exc_ext->Volt_index[m_ny][n]==m_LineNr) )
+//		{
+//			if ((int)Exc_ext->Volt_delay[n]>maxDelay)
+//				maxDelay = (int)Exc_ext->Volt_delay[n];
+//		}
+//	}
+//	m_start_TS = 0;
+//	if (maxDelay >= 0)
+//	{
+//		m_start_TS = maxDelay + m_Op_mur->m_Op->GetExcitationSignal()->GetLength() + 10; //give it some extra timesteps, for the excitation to travel at least one cell away
+//		cerr << "Engine_Ext_Mur_ABC::Engine_Ext_Mur_ABC: Warning: Excitation inside the Mur-ABC #" <<  m_ny << "-" << (int)(m_LineNr>0) << " found!!!!  Mur-ABC will be switched on after excitation is done at " << m_start_TS << " timesteps!!! " << endl;
+//	}
+
+	// Da fuq?
+	SetNumberOfThreads(m_Op_ABC->m_Nthreads);
+}
+
+Engine_Ext_Absorbing_BC::~Engine_Ext_Absorbing_BC()
+{
+	for (uint primIdx = 0 ; primIdx < m_Op_ABC->m_numPrims ; primIdx++)
+	{
+		delete[] m_V_ny1[primIdx];
+		delete[] m_V_ny2[primIdx];
+
+		SAFE_DELETE(m_I_ny1[primIdx]);
+		SAFE_DELETE(m_I_ny2[primIdx]);
+
+		SAFE_DELETE(m_Ic_ny1[primIdx]);
+		SAFE_DELETE(m_Ic_ny2[primIdx]);
+
+	}
+
+	delete[] m_V_ny1;
+	delete[] m_V_ny2;
+
+	delete[] m_I_ny1;
+	delete[] m_I_ny2;
+
+	delete[] m_Ic_ny1;
+	delete[] m_Ic_ny2;
+
+	delete[] m_pos_ny0_shift_V;
+	delete[] m_pos_ny0_shift_I;
+	delete[] m_pos_ny0_I;
+}
+
+void Engine_Ext_Absorbing_BC::SetNumberOfThreads(int nrThread)
+{
+	Engine_Extension::SetNumberOfThreads(nrThread);
+
+	// This command assigns the number of jobs (primitives) handled by each thread
+	v_primsPerThread = AssignJobs2Threads(m_numPrims,m_NrThreads,false);
+
+	// Basically cumsum. Starting point of each thread.
+	v_threadStartPrim.resize(m_NrThreads,0);
+	v_threadStartPrim.at(0) = 0;
+	for (size_t threadIdx = 1; threadIdx < v_threadStartPrim.size(); threadIdx++)
+		v_threadStartPrim.at(threadIdx) = v_threadStartPrim.at(threadIdx - 1) + v_primsPerThread.at(threadIdx - 1);
+}
+
+template <typename EngineType>
+void Engine_Ext_Absorbing_BC::DoPreVoltageUpdatesImpl(EngineType* eng, int threadID)
+{
+	if (IsActive()==false) return;
+
+	if (m_Eng==NULL) return;
+
+	if (threadID >= m_NrThreads)
+		return;
+
+	uint pos[] = {0,0,0};
+	uint pos0[] = {0,0,0};
+	uint pos1[] = {0,0,0};
+	uint pos_shift[] = {0,0,0};
+
+	uint dir[] = {0,0,0};
+	uint primIdx = 0;
+
+	uint cellCtr;
+
+	for (uint primCtr = 0 ; primCtr < v_primsPerThread.at(threadID) ; primCtr++)
+	{
+		// current primitive index for this thread
+		primIdx = primCtr + v_threadStartPrim.at(threadID);
+		for (uint dimIdx = 0 ; dimIdx < 3 ; dimIdx++)
+		{
+			// Position #1
+			pos[dimIdx]			= m_posStart[primIdx][dimIdx];
+			pos0[dimIdx]		= m_posStart[primIdx][dimIdx];
+			pos1[dimIdx]		= m_posStop[primIdx][dimIdx];
+			dir[dimIdx]			= m_dir[primIdx][dimIdx];
+		}
+
+		// Store shifted location in this container
+		pos_shift[dir[0]] = m_pos_ny0_shift_V[primIdx];
+
+		cellCtr = 0;
+		for (pos[dir[1]] = pos0[dir[1]] ; pos[dir[1]] < pos1[dir[1]] ; pos[dir[1]]++)
+		{
+			pos_shift[dir[1]] = pos[dir[1]];
+			for (pos[dir[2]] = pos0[dir[2]] ; pos[dir[2]] < pos1[dir[2]] ; pos[dir[2]]++)
+			{
+				pos_shift[dir[2]] = pos[dir[2]];
+				m_V_ny1[primIdx][cellCtr] = eng->EngineType::GetVolt(dir[1],pos_shift) - m_K1[primIdx][dir[0]][cellCtr] * eng->EngineType::GetVolt(dir[1],pos);
+				m_V_ny2[primIdx][cellCtr] = eng->EngineType::GetVolt(dir[2],pos_shift) - m_K1[primIdx][dir[0]][cellCtr] * eng->EngineType::GetVolt(dir[2],pos);
+
+				cellCtr++;
+			}
+		}
+
+	}
+}
+
+void Engine_Ext_Absorbing_BC::DoPreVoltageUpdates(int threadID)
+{
+	ENG_DISPATCH_ARGS(DoPreVoltageUpdatesImpl, threadID);
+}
+
+template <typename EngineType>
+void Engine_Ext_Absorbing_BC::DoPostVoltageUpdatesImpl(EngineType* eng, int threadID)
+{
+	if (IsActive()==false) return;
+
+	if (m_Eng==NULL) return;
+
+	if (threadID >= m_NrThreads)
+		return;
+
+	uint pos[] = {0,0,0};
+	uint pos0[] = {0,0,0};
+	uint pos1[] = {0,0,0};
+	uint pos_shift[] = {0,0,0};
+
+	uint dir[] = {0,0,0};
+	uint primIdx = 0;
+
+	uint cellCtr;
+
+	// Distribute jobs between threads
+	for (uint primCtr = 0 ; primCtr < v_primsPerThread.at(threadID) ; primCtr++)
+	{
+		// current primitive index for this thread
+		primIdx = primCtr + v_threadStartPrim.at(threadID);
+		for (uint dimIdx = 0; dimIdx < 3 ; dimIdx++)
+		{
+			// Position #1
+			pos[dimIdx]			= m_posStart[primIdx][dimIdx];
+			pos0[dimIdx]		= m_posStart[primIdx][dimIdx];
+			pos1[dimIdx]		= m_posStop[primIdx][dimIdx];
+			dir[dimIdx]			= m_dir[primIdx][dimIdx];
+		}
+
+		// Store shifted location in this container
+		pos_shift[dir[0]] = m_pos_ny0_shift_V[primIdx];
+
+		cellCtr = 0;
+		for (pos[dir[1]] = pos0[dir[1]] ; pos[dir[1]] < pos1[dir[1]] ; pos[dir[1]]++)
+		{
+			pos_shift[dir[1]] = pos[dir[1]];
+			for (pos[dir[2]] = pos0[dir[2]] ; pos[dir[2]] < pos1[dir[2]] ; pos[dir[2]]++)
+			{
+				pos_shift[dir[2]] = pos[dir[2]];
+				m_V_ny1[primIdx][cellCtr] += m_K1[primIdx][dir[0]][cellCtr] * eng->EngineType::GetVolt(dir[1],pos_shift);
+				m_V_ny2[primIdx][cellCtr] += m_K1[primIdx][dir[0]][cellCtr] * eng->EngineType::GetVolt(dir[2],pos_shift);
+
+				cellCtr++;
+			}
+		}
+
+	}
+}
+
+void Engine_Ext_Absorbing_BC::DoPostVoltageUpdates(int threadID)
+{
+	ENG_DISPATCH_ARGS(DoPostVoltageUpdatesImpl, threadID);
+}
+
+template <typename EngineType>
+void Engine_Ext_Absorbing_BC::Apply2VoltagesImpl(EngineType* eng, int threadID)
+{
+	// if (IsActive()==false) return;
+
+	if (m_Eng==NULL) return;
+
+	if (threadID >= m_NrThreads)
+		return;
+
+	uint pos[] = {0,0,0};
+	uint pos0[] = {0,0,0};
+	uint pos1[] = {0,0,0};
+
+	uint dir[] = {0,0,0};
+	uint primIdx = 0;
+
+	uint cellCtr;
+
+	for (uint primCtr = 0 ; primCtr < v_primsPerThread.at(threadID) ; primCtr++)
+	{
+		// current primitive index for this thread
+		primIdx = primCtr + v_threadStartPrim.at(threadID);
+		for (uint dimIdx = 0 ; dimIdx < 3 ; dimIdx++)
+		{
+			// Position #1
+			pos[dimIdx]			= m_posStart[primIdx][dimIdx];
+			pos0[dimIdx]		= m_posStart[primIdx][dimIdx];
+			pos1[dimIdx]		= m_posStop[primIdx][dimIdx];
+			dir[dimIdx]			= m_dir[primIdx][dimIdx];
+		}
+
+		// Store shifted location in this container
+		cellCtr = 0;
+		for (pos[dir[1]] = pos0[dir[1]] ; pos[dir[1]] < pos1[dir[1]] ; pos[dir[1]]++)
+		{
+			for (pos[dir[2]] = pos0[dir[2]] ; pos[dir[2]] < pos1[dir[2]] ; pos[dir[2]]++)
+			{
+				eng->EngineType::SetVolt(dir[1],pos, m_V_ny1[primIdx][cellCtr]);
+				eng->EngineType::SetVolt(dir[2],pos, m_V_ny2[primIdx][cellCtr]);
+
+				cellCtr++;
+			}
+		}
+
+	}
+}
+
+void Engine_Ext_Absorbing_BC::Apply2Voltages(int threadID)
+{
+	ENG_DISPATCH_ARGS(Apply2VoltagesImpl, threadID);
+}
+
+template <typename EngineType>
+void Engine_Ext_Absorbing_BC::DoPreCurrentUpdatesImpl(EngineType* eng, int threadID)
+{
+	// if (IsActive()==false) return;
+
+	if (m_Eng==NULL) return;
+
+	if (threadID >= m_NrThreads)
+		return;
+
+	uint pos[] = {0,0,0};
+	uint pos0[] = {0,0,0};
+	uint pos1[] = {0,0,0};
+	uint pos_shift[] = {0,0,0};
+
+	uint dir[] = {0,0,0};
+	uint primIdx = 0;
+
+	uint cellCtr;
+
+	for (uint primCtr = 0 ; primCtr < v_primsPerThread.at(threadID) ; primCtr++)
+	{
+
+		// current primitive index for this thread
+		primIdx = primCtr + v_threadStartPrim.at(threadID);
+
+		// If this isn't the appropriate boundary type, move on to the next primitive
+		if ((CSPropAbsorbingBC::BCtype)(m_Op_ABC->m_boundaryTypes[primIdx]) != CSPropAbsorbingBC::MUR_1ST_1PV_SA)
+			continue;
+
+		for (uint dimIdx = 0 ; dimIdx < 3 ; dimIdx++)
+		{
+			// Position #1
+			pos[dimIdx]			= m_posStart[primIdx][dimIdx];
+			pos0[dimIdx]		= m_posStart[primIdx][dimIdx];
+			pos1[dimIdx]		= m_posStop[primIdx][dimIdx] - 1;	// Deduct 1 because of the dual grid
+			dir[dimIdx]			= m_dir[primIdx][dimIdx];
+		}
+
+		// Convert start position to H field start position
+		pos[dir[0]] = m_pos_ny0_I[primIdx];
+		// Store shifted location in this container
+		pos_shift[dir[0]] = m_pos_ny0_shift_I[primIdx];
+		//switch for different engine types to access faster inline engine functions
+
+		cellCtr = 0;
+		for (pos[dir[1]] = pos0[dir[1]] ; pos[dir[1]] < pos1[dir[1]] ; pos[dir[1]]++)
+		{
+			pos_shift[dir[1]] = pos[dir[1]];
+			for (pos[dir[2]] = pos0[dir[2]] ; pos[dir[2]] < pos1[dir[2]] ; pos[dir[2]]++)
+			{
+				pos_shift[dir[2]] = pos[dir[2]];
+				m_I_ny1[primIdx][cellCtr] = eng->EngineType::GetCurr(dir[1],pos_shift) - m_K1[primIdx][dir[0]][cellCtr] * eng->EngineType::GetCurr(dir[1],pos);
+				m_I_ny2[primIdx][cellCtr] = eng->EngineType::GetCurr(dir[2],pos_shift) - m_K1[primIdx][dir[0]][cellCtr] * eng->EngineType::GetCurr(dir[2],pos);
+
+				cellCtr++;
+			}
+		}
+
+	}
+}
+
+void Engine_Ext_Absorbing_BC::DoPreCurrentUpdates(int threadID)
+{
+	ENG_DISPATCH_ARGS(DoPreCurrentUpdatesImpl, threadID);
+}
+
+template <typename EngineType>
+void Engine_Ext_Absorbing_BC::DoPostCurrentUpdatesImpl(EngineType* eng, int threadID)
+{
+	// if (IsActive()==false) return;
+
+	if (m_Eng==NULL) return;
+
+	if (threadID >= m_NrThreads)
+		return;
+
+	uint pos[] = {0,0,0};
+	uint pos0[] = {0,0,0};
+	uint pos1[] = {0,0,0};
+	uint pos_shift[] = {0,0,0};
+
+	uint dir[] = {0,0,0};
+	uint primIdx = 0;
+
+	uint cellCtr;
+
+	for (uint primCtr = 0 ; primCtr < v_primsPerThread.at(threadID) ; primCtr++)
+	{
+		// current primitive index for this thread
+		primIdx = primCtr + v_threadStartPrim.at(threadID);
+
+		// If this isn't the appropriate boundary type, move on to the next primitive
+		if ((CSPropAbsorbingBC::BCtype)(m_Op_ABC->m_boundaryTypes[primIdx]) != CSPropAbsorbingBC::MUR_1ST_1PV_SA)
+			continue;
+
+		for (uint dimIdx = 0 ; dimIdx < 3 ; dimIdx++)
+		{
+			// Position #1
+			pos[dimIdx]			= m_posStart[primIdx][dimIdx];
+			pos0[dimIdx]		= m_posStart[primIdx][dimIdx];
+			pos1[dimIdx]		= m_posStop[primIdx][dimIdx] - 1; // Deduct 1 because of the H-field dual grid
+			dir[dimIdx]			= m_dir[primIdx][dimIdx];
+		}
+
+		// Convert start position to H field start position
+		pos[dir[0]] = m_pos_ny0_I[primIdx];
+		// Store shifted location in this container
+		pos_shift[dir[0]] = m_pos_ny0_shift_I[primIdx];
+
+
+		cellCtr = 0;
+		for (pos[dir[1]] = pos0[dir[1]] ; pos[dir[1]] < pos1[dir[1]] ; pos[dir[1]]++)
+		{
+			pos_shift[dir[1]] = pos[dir[1]];
+			for (pos[dir[2]] = pos0[dir[2]] ; pos[dir[2]] < pos1[dir[2]] ; pos[dir[2]]++)
+			{
+				pos_shift[dir[2]] = pos[dir[2]];
+				m_I_ny1[primIdx][cellCtr] += m_K1[primIdx][dir[0]][cellCtr] * eng->EngineType::GetCurr(dir[1],pos_shift);
+				m_I_ny2[primIdx][cellCtr] += m_K1[primIdx][dir[0]][cellCtr] * eng->EngineType::GetCurr(dir[2],pos_shift);
+
+				cellCtr++;
+			}
+		}
+
+	}
+}
+
+void Engine_Ext_Absorbing_BC::DoPostCurrentUpdates(int threadID)
+{
+	ENG_DISPATCH_ARGS(DoPostCurrentUpdatesImpl, threadID);
+}
+
+template <typename EngineType>
+void Engine_Ext_Absorbing_BC::Apply2CurrentImpl(EngineType* eng, int threadID)
+{
+	// if (IsActive()==false) return;
+
+	if (m_Eng==NULL) return;
+
+	if (threadID >= m_NrThreads)
+		return;
+
+	uint pos[] = {0,0,0};
+	uint pos0[] = {0,0,0};
+	uint pos1[] = {0,0,0};
+
+	uint dir[] = {0,0,0};
+	uint primIdx = 0;
+
+	uint cellCtr;
+
+	for (uint primCtr = 0 ; primCtr < v_primsPerThread.at(threadID) ; primCtr++)
+	{
+		// current primitive index for this thread
+		primIdx = primCtr + v_threadStartPrim.at(threadID);
+
+		// If this isn't the appropriate boundary type, move on to the next primitive
+		if ((CSPropAbsorbingBC::BCtype)(m_Op_ABC->m_boundaryTypes[primIdx]) != CSPropAbsorbingBC::MUR_1ST_1PV_SA)
+			continue;
+
+		for (uint dimIdx = 0 ; dimIdx < 3 ; dimIdx++)
+		{
+			// Position #1
+			pos[dimIdx]			= m_posStart[primIdx][dimIdx];
+			pos0[dimIdx]		= m_posStart[primIdx][dimIdx];
+			pos1[dimIdx]		= m_posStop[primIdx][dimIdx] - 1;  // Deduct 1 because of the H-field dual grid
+			dir[dimIdx]			= m_dir[primIdx][dimIdx];
+		}
+
+		// Convert start position to H field start position
+		pos[dir[0]] = m_pos_ny0_I[primIdx];
+
+		// First, load the field values calculated by the curl equations
+		cellCtr = 0;
+		for (pos[dir[1]] = pos0[dir[1]] ; pos[dir[1]] < pos1[dir[1]] ; pos[dir[1]]++)
+			for (pos[dir[2]] = pos0[dir[2]] ; pos[dir[2]] < pos1[dir[2]] ; pos[dir[2]]++)
+			{
+				m_Ic_ny1[primIdx][cellCtr] = eng->EngineType::GetCurr(dir[1],pos);
+				m_Ic_ny2[primIdx][cellCtr] = eng->EngineType::GetCurr(dir[2],pos);
+				cellCtr++;
+			}
+
+	}
+}
+
+void Engine_Ext_Absorbing_BC::Apply2Current(int threadID)
+{
+	ENG_DISPATCH_ARGS(Apply2CurrentImpl, threadID);
+}

--- a/FDTD/extensions/engine_ext_absorbing_bc.h
+++ b/FDTD/extensions/engine_ext_absorbing_bc.h
@@ -1,0 +1,104 @@
+/*
+*	Copyright (C) 2010 Thorsten Liebig (Thorsten.Liebig@gmx.de)
+*
+*	This program is free software: you can redistribute it and/or modify
+*	it under the terms of the GNU General Public License as published by
+*	the Free Software Foundation, either version 3 of the License, or
+*	(at your option) any later version.
+*
+*	This program is distributed in the hope that it will be useful,
+*	but WITHOUT ANY WARRANTY; without even the implied warranty of
+*	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*	GNU General Public License for more details.
+*
+*	You should have received a copy of the GNU General Public License
+*	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef ENGINE_EXT_ABSORBING_BC_H
+#define ENGINE_EXT_ABSORBING_BC_H
+
+#include "engine_extension.h"
+#include "FDTD/engine.h"
+#include "FDTD/operator.h"
+#include "engine_extension_dispatcher.h"
+
+class Operator_Ext_Absorbing_BC;
+
+class Engine_Ext_Absorbing_BC : public Engine_Extension
+{
+public:
+	Engine_Ext_Absorbing_BC(Operator_Ext_Absorbing_BC* op_ext);
+	virtual ~Engine_Ext_Absorbing_BC();
+
+	virtual void SetNumberOfThreads(int nrThread);
+
+	virtual void DoPreVoltageUpdates() {Engine_Ext_Absorbing_BC::DoPreVoltageUpdates(0);}
+	virtual void DoPreVoltageUpdates(int threadID);
+	virtual void DoPostVoltageUpdates() {Engine_Ext_Absorbing_BC::DoPostVoltageUpdates(0);}
+	virtual void DoPostVoltageUpdates(int threadID);
+	virtual void Apply2Voltages() {Engine_Ext_Absorbing_BC::Apply2Voltages(0);}
+	virtual void Apply2Voltages(int threadID);
+
+	virtual void DoPreCurrentUpdates() {Engine_Ext_Absorbing_BC::DoPreCurrentUpdates(0);}
+	virtual void DoPreCurrentUpdates(int threadID);
+	virtual void DoPostCurrentUpdates() {Engine_Ext_Absorbing_BC::DoPostCurrentUpdates(0);}
+	virtual void DoPostCurrentUpdates(int threadID);
+	virtual void Apply2Current() {Engine_Ext_Absorbing_BC::Apply2Current(0);}
+	virtual void Apply2Current(int threadID);
+
+protected:
+	Operator_Ext_Absorbing_BC* m_Op_ABC;
+
+	template <typename EngineType>
+	void DoPreVoltageUpdatesImpl(EngineType* eng, int threadID);
+
+	template <typename EngineType>
+	void DoPostVoltageUpdatesImpl(EngineType* eng, int threadID);
+
+	template <typename EngineType>
+	void Apply2VoltagesImpl(EngineType* eng, int threadID);
+
+	template <typename EngineType>
+	void DoPreCurrentUpdatesImpl(EngineType* eng, int threadID);
+
+	template <typename EngineType>
+	void DoPostCurrentUpdatesImpl(EngineType* eng, int threadID);
+
+	template <typename EngineType>
+	void Apply2CurrentImpl(EngineType* eng, int threadID);
+
+	inline bool IsActive() {if (m_Eng->GetNumberOfTimesteps() < m_start_TS) return false; return true;}
+	unsigned int m_start_TS;
+
+	unsigned int 	m_numPrims;
+	unsigned int	*m_numCells;
+	unsigned int	**m_posStart;
+	unsigned int	**m_posStop;
+	unsigned int	*m_pos_ny0_I;
+	unsigned int	*m_pos_ny0_shift_V;
+	unsigned int	*m_pos_ny0_shift_I;
+	unsigned int	**m_dir;
+
+	vector<unsigned int>	v_primsPerThread;
+	vector<unsigned int>	v_threadStartPrim;
+
+	// Coefficients predefined in the operator
+	FDTD_FLOAT		***m_K1;
+	FDTD_FLOAT		***m_K2;
+
+	// Containers for E-fields
+	FDTD_FLOAT		**m_V_ny1; // n+1 direction
+	FDTD_FLOAT		**m_V_ny2; // n+2 direction
+
+	// Containers for H-fields calculated with the ABC
+	FDTD_FLOAT		**m_I_ny1; // n+1 direction
+	FDTD_FLOAT		**m_I_ny2; // n+2 direction
+
+	// Containers for H-fields calculated from the curl equations
+	FDTD_FLOAT		**m_Ic_ny1; // n+1 direction
+	FDTD_FLOAT		**m_Ic_ny2; // n+2 direction
+
+};
+
+#endif // ENGINE_EXT_ABSORBING_BC_H

--- a/FDTD/extensions/operator_ext_absorbing_bc.cpp
+++ b/FDTD/extensions/operator_ext_absorbing_bc.cpp
@@ -1,0 +1,370 @@
+/*
+*	Copyright (C) 2010 Thorsten Liebig (Thorsten.Liebig@gmx.de)
+*
+*	This program is free software: you can redistribute it and/or modify
+*	it under the terms of the GNU General Public License as published by
+*	the Free Software Foundation, either version 3 of the License, or
+*	(at your option) any later version.
+*
+*	This program is distributed in the hope that it will be useful,
+*	but WITHOUT ANY WARRANTY; without even the implied warranty of
+*	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*	GNU General Public License for more details.
+*
+*	You should have received a copy of the GNU General Public License
+*	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "operator_ext_absorbing_bc.h"
+#include "engine_ext_absorbing_bc.h"
+
+#include "tools/array_ops.h"
+
+#include "CSPrimBox.h"
+
+#define COPY_V2A(V,A) std::copy(V.begin(),V.end(),A)
+
+#define SAFE_DELETE(v) 	\
+	if (v != NULL) 		\
+	{ 					\
+		delete[] v;		\
+		v = NULL;		\
+	}					\
+
+Operator_Ext_Absorbing_BC::Operator_Ext_Absorbing_BC(Operator* op) : Operator_Extension(op)
+{
+	Initialize();
+}
+
+Operator_Ext_Absorbing_BC::Operator_Ext_Absorbing_BC(Operator* op, uint numThreads) : Operator_Extension(op)
+{
+	m_Nthreads = numThreads;
+	Initialize();
+}
+
+
+Operator_Ext_Absorbing_BC::~Operator_Ext_Absorbing_BC()
+{
+	for (uint primIdx = 0 ; primIdx < m_numPrims ; primIdx++)
+	{
+		SAFE_DELETE(m_sheetX0[primIdx]);
+		SAFE_DELETE(m_sheetX1[primIdx]);
+
+		SAFE_DELETE(m_dir[primIdx]);
+
+		for (uint dimIdx = 0 ; dimIdx < 3 ; dimIdx++)
+		{
+			SAFE_DELETE(m_K1[primIdx][dimIdx]);
+			SAFE_DELETE(m_K2[primIdx][dimIdx]);
+		}
+
+		SAFE_DELETE(m_K1[primIdx]);
+		SAFE_DELETE(m_K2[primIdx]);
+	}
+
+	// Delete all 2D arrays
+	SAFE_DELETE(m_sheetX0);
+	SAFE_DELETE(m_sheetX1);
+	SAFE_DELETE(m_dir);
+	SAFE_DELETE(m_K1);
+	SAFE_DELETE(m_K2);
+
+	// Delete all 1D arrays
+	SAFE_DELETE(m_numCells);
+	SAFE_DELETE(m_normDir);
+	SAFE_DELETE(m_boundaryTypes);
+
+}
+
+Operator_Ext_Absorbing_BC::Operator_Ext_Absorbing_BC(Operator* op, Operator_Ext_Absorbing_BC* op_ext) : Operator_Extension(op, op_ext)
+{
+	Initialize();
+}
+
+Operator_Extension* Operator_Ext_Absorbing_BC::Clone(Operator* op)
+{
+	if (dynamic_cast<Operator_Ext_Absorbing_BC*>(this)==NULL)
+		return NULL;
+	return new Operator_Ext_Absorbing_BC(op, this);
+}
+
+void Operator_Ext_Absorbing_BC::Initialize()
+{
+	m_sheetX0		= NULL;
+	m_sheetX1		= NULL;
+	m_dir			= NULL;
+	m_normDir		= NULL;
+	m_K1			= NULL;
+	m_K2			= NULL;
+	m_boundaryTypes = NULL;
+	m_numCells		= NULL;
+	m_numPrims		= 0;
+
+}
+
+
+bool Operator_Ext_Absorbing_BC::BuildExtension()
+{
+
+	double dT	= m_Op->GetTimestep();
+	//double fMax	= m_Op->GetExcitationSignal()->GetCenterFreq();
+
+	uint pos[] = {0,0,0};
+
+	// Containers for primitive initialization
+	int							normDir;
+	double						phaseVelocity;
+	CSPropAbsorbingBC::BCtype	boundaryType;
+
+	vector<CSProperties*>		cs_props;
+
+	// Containers for data storage
+	vector<uint>			v_numCells;
+	vector<uint*>			v_dir;
+	vector<int>				v_normDir;
+	vector<uint*>			v_sheetX0;
+	vector<uint*>			v_sheetX1;
+	vector<FDTD_FLOAT**>	v_K1;
+	vector<FDTD_FLOAT**>	v_K2;
+	vector<int>				v_boundaryTypes;
+
+	// Initialize all vectors
+	v_numCells.clear();
+	v_dir.clear();
+	v_normDir.clear();
+	v_sheetX0.clear();
+	v_sheetX1.clear();
+	v_K1.clear();
+	v_K2.clear();
+	v_boundaryTypes.clear();
+
+	// Obtain from CSX (continuous structure) all the lumped RLC properties
+	// Properties are material properties, not the objects themselves
+	cs_props = m_Op->CSX->GetPropertyByType(CSProperties::ABSORBING_BC);
+
+	// Iterate through various properties. In theory, there should be a property set per-
+	// primitive, as each "port" should have it's own unique properties.
+	for(size_t n = 0 ; n < cs_props.size() ; ++n)
+	{
+		// Cast current property to absorbing BC sheet (Absorbing Boundary-condition Sheet : ABS) property continuous structure properties
+		CSPropAbsorbingBC * cs_ABS_props = dynamic_cast<CSPropAbsorbingBC*>(cs_props.at(n));
+		if (cs_ABS_props == NULL)
+			return false; //sanity check: this should never happen!
+
+		// Store direction and type
+		normDir			= cs_ABS_props->GetNormDir();
+		boundaryType	= cs_ABS_props->GetBoundaryType();
+		phaseVelocity	= cs_ABS_props->GetPhaseVelocity();
+
+		// Initialize other two direction containers. Keep in mind that 'normDir'
+		// has the values 1,2,3 or -1,-2,-3. 0 is considered illegal.
+		uint dir[3] = {	 abs(normDir) - 1		,
+						 abs(normDir)      % 3	,
+						(abs(normDir) + 1) % 3};
+
+		// Now iterate through primitive(s). I still think there should be only one per-
+		// material definition, but maybe I'm wrong...
+		vector<CSPrimitives*> cs_ABS_prims = cs_ABS_props->GetAllPrimitives();
+		for (size_t sheetIdx = 0 ; sheetIdx < cs_ABS_prims.size() ; ++sheetIdx)
+		{
+			CSPrimBox* cSheet = dynamic_cast<CSPrimBox*>(cs_ABS_prims.at(sheetIdx));
+
+			// If this just so happen to not be a sheet, ignore this
+			if (!cSheet)
+			{
+				cerr << "Operator_Ext_Absorbing_BC::BuildExtension(): Warning: Absorbing sheet validation failed, skipping. "
+											<< " ID: " << cs_ABS_prims.at(sheetIdx)->GetID() << " @ Property: " << cs_ABS_props->GetName() << endl;
+				continue;
+			}
+
+
+			// Check that this is actually a sheet
+			// Get box start and stop positions
+			uint 	uiStart[3],
+					uiStop[3];
+
+			// snap to the native coordinate system
+			int Snap_Dimension =
+				m_Op->SnapBox2Mesh(
+						cSheet->GetStartCoord()->GetCoords(m_Op->m_MeshType),	// Start Coord
+						cSheet->GetStopCoord()->GetCoords(m_Op->m_MeshType),	// Stop Coord
+						uiStart,	// Start Index
+						uiStop,		// Stop Index
+						false,		// Dual (doublet) Grid?
+						true);		// Full mesh?
+
+			// Verify that snapped dimension is correct
+			if (Snap_Dimension <= 0)
+			{
+				if (Snap_Dimension>=-1)
+					cerr << "Operator_Ext_Absorbing_BC::BuildExtension(): Warning: Absorbing sheet snapping failed! Dimension is: " << Snap_Dimension << " skipping. "
+							<< " ID: " << cs_ABS_prims.at(sheetIdx)->GetID() << " @ Property: " << cs_ABS_props->GetName() << endl;
+				// Snap_Dimension == -2 means outside the simulation domain --> no special warning, but box probably marked as unused!
+				continue;
+			}
+
+			uint	Ncells[3] = {0,0,0},
+					totCells = 1;
+			for (uint dimIdx = 0 ; dimIdx < 3 ; dimIdx++)
+			{
+				Ncells[dimIdx] = uiStop[dimIdx] - uiStart[dimIdx] + 1;
+				totCells *= Ncells[dimIdx];
+			}
+
+
+			// check that one of the dimensions is 1, and only one
+			uint sheetCheck = 0;
+			for (uint dimIdx = 0 ; dimIdx < 3 ; dimIdx++)
+				sheetCheck += Ncells[dimIdx] == 1;
+			if (sheetCheck != 1)
+			{
+				cerr 	<< "Operator_Ext_Absorbing_BC::BuildExtension(): Error: Absorbing sheet is not a sheet! Skipping. "
+						<< " ID: " << cs_ABS_prims.at(sheetIdx)->GetID() << " @ Property: " << cs_ABS_props->GetName() << endl;
+				continue;
+			}
+
+			// Now check that the direction is compatible with the sheet
+			if (Ncells[dir[0]] != 1)
+			{
+				cerr 	<< "Operator_Ext_Absorbing_BC::BuildExtension(): Error: Absorbing sheet is not a sheet! Skipping. "
+						<< " ID: " << cs_ABS_prims.at(sheetIdx)->GetID() << " @ Property: " << cs_ABS_props->GetName() << endl;
+				continue;
+			}
+
+			// The position starts and stops in the same place.
+			pos[dir[0]] = uiStart[dir[0]];
+
+			// The position is considered in the middle of the mesh cell.
+			double delta = fabs(m_Op->GetEdgeLength(dir[0],pos));
+
+
+			// Initialize coefficients for this engine extension
+			FDTD_FLOAT vt = phaseVelocity*dT;
+
+
+			uint 		*temp_dir = new uint[3];
+			uint		*temp_sheetX0 = new uint[3];
+			uint		*temp_sheetX1 = new uint[3];
+
+
+			for (uint dimIdx = 0 ; dimIdx < 3 ; dimIdx++)
+			{
+				temp_dir[dimIdx] = dir[dimIdx];
+				temp_sheetX0[dimIdx] = uiStart[dimIdx];
+				temp_sheetX1[dimIdx] = uiStop[dimIdx];
+			}
+
+			if ((boundaryType == CSPropAbsorbingBC::MUR_1ST_1PV) || (boundaryType == CSPropAbsorbingBC::MUR_1ST_1PV_SA))
+			{
+				FDTD_FLOAT	**temp_K1 = new FDTD_FLOAT*[3];
+
+				for (int dimIdx = 0 ; dimIdx < 3 ; dimIdx++)
+				{
+					// In this revision, initialize all coefficients
+					vector<FDTD_FLOAT> temp_v_K1(totCells,(vt - delta) / (vt + delta));
+					temp_K1[dimIdx] = new FDTD_FLOAT[totCells];
+					COPY_V2A(temp_v_K1,temp_K1[dimIdx]);
+				}
+
+				v_K1.push_back(temp_K1);
+			}
+
+			if (boundaryType == CSPropAbsorbingBC::MUR_1ST_1PV_SA)
+			{
+				FDTD_FLOAT	**temp_K2 = new FDTD_FLOAT*[3];
+
+				for (int dimIdx = 0 ; dimIdx < 3 ; dimIdx++)
+				{
+					// In this revision, initialize all coefficients
+					vector<FDTD_FLOAT> temp_v_K2(totCells,vt/delta);
+					temp_K2[dimIdx] = new FDTD_FLOAT[totCells];
+					COPY_V2A(temp_v_K2,temp_K2[dimIdx]);
+				}
+
+				v_K2.push_back(temp_K2);
+			}
+
+			v_numCells.push_back(totCells);
+			v_dir.push_back(temp_dir);
+			v_normDir.push_back(normDir);
+			v_sheetX0.push_back(temp_sheetX0);
+			v_sheetX1.push_back(temp_sheetX1);
+			v_boundaryTypes.push_back((int)boundaryType);
+
+
+			// Mark as used
+			cSheet->SetPrimitiveUsed(true);
+		}
+		// Clear before next iteration
+		cs_ABS_prims.clear();
+	}
+
+	// Count number of primitives that are absorbers
+	m_numPrims = v_numCells.size();
+
+	// Copy all vectors to arrays
+	m_numCells	= new uint[m_numPrims];
+	m_dir		= new uint*[m_numPrims];
+	m_sheetX0	= new uint*[m_numPrims];
+	m_sheetX1	= new uint*[m_numPrims];
+	m_normDir	= new int[m_numPrims];
+	m_boundaryTypes = new int[m_numPrims];
+
+	m_K1 = new FDTD_FLOAT**[m_numPrims];
+
+	COPY_V2A(v_numCells,m_numCells);
+	COPY_V2A(v_dir,m_dir);
+	COPY_V2A(v_sheetX0,m_sheetX0);
+	COPY_V2A(v_sheetX1,m_sheetX1);
+	COPY_V2A(v_normDir,m_normDir);
+	COPY_V2A(v_boundaryTypes,m_boundaryTypes);
+
+	COPY_V2A(v_K1,m_K1);
+
+	if (boundaryType == CSPropAbsorbingBC::MUR_1ST_1PV_SA)
+	{
+		m_K2 = new FDTD_FLOAT**[m_numPrims];
+		COPY_V2A(v_K2,m_K2);
+	}
+
+
+
+	return true;
+}
+
+
+Engine_Extension* Operator_Ext_Absorbing_BC::CreateEngineExtention()
+{
+	Engine_Ext_Absorbing_BC* eng_ext = new Engine_Ext_Absorbing_BC(this);
+	return eng_ext;
+}
+
+void Operator_Ext_Absorbing_BC::ShowStat(ostream &ostr) const
+{
+	Operator_Extension::ShowStat(ostr);
+//	string XYZ[3] = {"x","y","z"};
+//	char pmSign = (m_normDir > 0) ? '+' : '-';
+//
+//
+//	ostr << " Active direction\t: " << pmSign << XYZ[abs(m_ny)] << " at line: " << m_LineNr << endl;
+//	if (m_v_phase)
+//		ostr << " Used phase velocity\t: " << m_v_phase << " (" << m_v_phase/__C0__ << " * c_0)" << endl;
+
+	uint totCells = 0;
+	for (uint primIdx ; primIdx < m_numPrims ; primIdx++)
+	{
+		totCells += m_numCells[primIdx];
+	}
+
+	ostr << " Number of absorbing BCs\t: " << m_numPrims << " total cells: " << totCells << endl;
+
+}
+
+
+
+
+
+
+
+
+

--- a/FDTD/extensions/operator_ext_absorbing_bc.h
+++ b/FDTD/extensions/operator_ext_absorbing_bc.h
@@ -1,0 +1,77 @@
+/*
+*	Copyright (C) 2010 Thorsten Liebig (Thorsten.Liebig@gmx.de)
+*
+*	This program is free software: you can redistribute it and/or modify
+*	it under the terms of the GNU General Public License as published by
+*	the Free Software Foundation, either version 3 of the License, or
+*	(at your option) any later version.
+*
+*	This program is distributed in the hope that it will be useful,
+*	but WITHOUT ANY WARRANTY; without even the implied warranty of
+*	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+*	GNU General Public License for more details.
+*
+*	You should have received a copy of the GNU General Public License
+*	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPERATOR_EXT_ABSORBING_BC_H
+#define OPERATOR_EXT_ABSORBING_BC_H
+
+#include "FDTD/operator.h"
+#include "operator_extension.h"
+
+#include "CSPropAbsorbingBC.h"
+
+class Operator_Ext_Absorbing_BC : public Operator_Extension
+{
+	friend class Engine_Ext_Absorbing_BC;
+public:
+	//Operator_Ext_Absorbing_BC(Operator* op, Operator_Ext_Absorbing_BC* op_ext);
+	Operator_Ext_Absorbing_BC(Operator* op);
+	Operator_Ext_Absorbing_BC(Operator* op, uint numThreads);
+	~Operator_Ext_Absorbing_BC();
+
+	virtual Operator_Extension* Clone(Operator* op);
+
+
+
+	virtual bool BuildExtension();
+
+	virtual Engine_Extension* CreateEngineExtention();
+
+	//virtual bool IsMPISave() const {return true;}
+
+	virtual string GetExtensionName() const {return string("Local absorbing boundary condition sheet");}
+
+	virtual void ShowStat(ostream &ostr) const;
+
+protected:
+
+	Operator_Ext_Absorbing_BC(Operator* op, Operator_Ext_Absorbing_BC* op_ext);
+	void Initialize();
+
+	uint 		m_numPrims;		// Number of primitives that will apply absorbing B.C.
+	uint		*m_numCells;	// Number of cells in each primitive
+
+	// Storage for the modulated direcions. m_dir[primIdx][0] is the normal, the rest are the tangential components.
+	uint		**m_dir;
+
+	// Storage for sheet bounding box start and stop.
+	uint		**m_sheetX0;
+	uint		**m_sheetX1;
+
+	// Storage for the normal direction of each sheet
+	int			*m_normDir;
+
+	// Coefficients, to be initialized on-demand.
+	FDTD_FLOAT	***m_K1;
+	FDTD_FLOAT	***m_K2;
+
+	int			*m_boundaryTypes;
+
+	uint		m_Nthreads;
+
+};
+
+#endif // OPERATOR_EXT_ABSORBING_BC_H

--- a/FDTD/extensions/operator_ext_excitation.cpp
+++ b/FDTD/extensions/operator_ext_excitation.cpp
@@ -161,6 +161,7 @@ bool Operator_Ext_Excitation::BuildExtension()
 						elec = prop->ToExcitation();
 						if (elec==NULL)
 							continue;
+						// Case #1: Excitaion type 0 or 1 E-field excitation (soft) or current source (hard)
 						if ((elec->GetActiveDir(n)) && ( (elec->GetExcitType()==0) || (elec->GetExcitType()==1) ))//&& (pos[n]<numLines[n]-1))
 						{
 							amp = elec->GetWeightedExcitation(n,volt_coord)*m_Op->GetEdgeLength(n,pos);// delta[n]*gridDelta;

--- a/FDTD/operator.h
+++ b/FDTD/operator.h
@@ -40,6 +40,7 @@ class Operator : public Operator_Base
 	friend class Operator_Ext_UPML;
 	friend class Operator_Ext_Cylinder;
 	friend class Operator_Ext_LumpedRLC;		// Gadi: I now know why the two previous remarks are here.
+	friend class Operator_Ext_Absorbing_BC;		// Gadi: I now know why the two previous remarks are here.
 
 	// So apparaently I have to use functionality from operator
 	// in my "lumpedRLC" class. This is ugly...

--- a/openems.cpp
+++ b/openems.cpp
@@ -34,6 +34,7 @@
 #include "FDTD/extensions/operator_ext_lumpedRLC.h"
 #include "FDTD/extensions/operator_ext_conductingsheet.h"
 #include "FDTD/extensions/operator_ext_steadystate.h"
+#include "FDTD/extensions/operator_ext_absorbing_bc.h"
 #include "FDTD/extensions/engine_ext_steadystate.h"
 #include "FDTD/engine_interface_fdtd.h"
 #include "FDTD/engine_interface_cylindrical_fdtd.h"
@@ -507,9 +508,24 @@ bool openEMS::SetupProcessing()
 				{
 					ProcessModeMatch* pmm = new ProcessModeMatch(NewEngineInterface());
 					pmm->SetFieldType(pb->GetProbeType()-10);
-					pmm->SetModeFunction(0,pb->GetAttributeValue("ModeFunctionX"));
-					pmm->SetModeFunction(1,pb->GetAttributeValue("ModeFunctionY"));
-					pmm->SetModeFunction(2,pb->GetAttributeValue("ModeFunctionZ"));
+
+					// Check if this has manually initialized weight functions or not
+					std::vector<float> testMW = pb->GetManualWeights(0);
+					// If there are elements in the test vector, assume that there were manual weights set
+					if (testMW.size())
+					{
+						for (uint dirIdx = 0 ; dirIdx < 3 ; dirIdx++)
+						{
+							pmm->SetManualWeights(dirIdx, pb->GetManualWeights(dirIdx));
+							pmm->SetManualCoors(dirIdx, pb->GetManualWeightCoors(dirIdx));
+						}
+					}
+					else
+					{
+						pmm->SetModeFunction(0,pb->GetAttributeValue("ModeFunctionX"));
+						pmm->SetModeFunction(1,pb->GetAttributeValue("ModeFunctionY"));
+						pmm->SetModeFunction(2,pb->GetAttributeValue("ModeFunctionZ"));
+					}
 					proc = pmm;
 				}
 				else
@@ -1094,6 +1110,8 @@ int openEMS::SetupFDTD()
 		FDTD_Op->AddExtension(new Operator_Ext_ConductingSheet(FDTD_Op, m_Exc->GetMaxFreq()));
 	if (m_CSX->GetQtyPropertyType(CSProperties::LUMPED_ELEMENT)>0)
 		FDTD_Op->AddExtension(new Operator_Ext_LumpedRLC(FDTD_Op));
+	if (m_CSX->GetQtyPropertyType(CSProperties::ABSORBING_BC)>0)
+		FDTD_Op->AddExtension(new Operator_Ext_Absorbing_BC(FDTD_Op,m_engine_numThreads));
 
 
 	//check all properties to request material storage during operator creation...

--- a/python/openEMS/openEMS.pyx
+++ b/python/openEMS/openEMS.pyx
@@ -322,7 +322,7 @@ cdef class openEMS:
                     grid.AddLine(n, stop[n])
         return port
 
-    def AddWaveGuidePort(self, port_nr, start, stop, p_dir, E_func, H_func, kc, excite=0, **kw):
+    def AddWaveGuidePort(self, port_nr, start, stop, p_dir, E_func, H_func, kc, excite=0, excite_type=0, **kw):
         """ AddWaveGuidePort(self, port_nr, start, stop, p_dir, E_func, H_func, kc, excite=0, **kw)
 
         Add a arbitrary waveguide port.
@@ -333,7 +333,7 @@ cdef class openEMS:
         """
         if self.__CSX is None:
             raise Exception('AddWaveGuidePort: CSX is not set!')
-        return ports.WaveguidePort(self.__CSX, port_nr, start, stop, p_dir, E_func, H_func, kc, excite, **kw)
+        return ports.WaveguidePort(self.__CSX, port_nr, start, stop, p_dir, E_func, H_func, kc, excite, excite_type, **kw)
 
     def AddRectWaveGuidePort(self, port_nr, start, stop, p_dir, a, b, mode_name, excite=0, **kw):
         """ AddRectWaveGuidePort(port_nr, start, stop, p_dir, a, b, mode_name, excite=0, **kw)

--- a/python/openEMS/ports.py
+++ b/python/openEMS/ports.py
@@ -328,51 +328,100 @@ class WaveguidePort(Port):
     Port, RectWGPort
 
     """
-    def __init__(self, CSX, port_nr, start, stop, exc_dir, E_WG_func, H_WG_func, kc, excite=0, **kw):
-        super(WaveguidePort, self).__init__(CSX, port_nr=port_nr, start=start, stop=stop, excite=excite, **kw)
+    def __init__(self, CSX, port_nr, start, stop, exc_dir, E_WG_func, H_WG_func, kc, excite=0, excite_type=0, **kw):
+        super(WaveguidePort, self).__init__(CSX, port_nr=port_nr, start=start, stop=stop, excite=excite, excite_type=excite_type, **kw)
         self.exc_ny  = CheckNyDir(exc_dir)
         self.ny_P  = (self.exc_ny+1)%3
         self.ny_PP = (self.exc_ny+2)%3
         self.direction = np.sign(stop[self.exc_ny]-start[self.exc_ny])
         self.ref_index = 1
-
-        if (self.excite!=0 and stop[self.exc_ny]==start[self.exc_ny]):
+        
+        # This line is due to the fact that in the openEMS code the propagation direction is set
+		# by the size of the box. No ideal, but it is Ok for now.
+        if (self.excite != 0) and (stop[self.exc_ny] == start[self.exc_ny]):
             raise Exception('Port length in excitation direction may not be zero if port is excited!')
-
+        
         self.kc = kc
         self.E_func = E_WG_func
         self.H_func = H_WG_func
-
-        if excite!=0:
+        
+        isEcustomWeighting = False    
+        isHcustomWeighting = False
+        
+        if excite != 0:
             e_start = np.array(start)
             e_stop  = np.array(stop)
             e_stop[self.exc_ny] = e_start[self.exc_ny]
             e_vec = np.ones(3)
-            e_vec[self.exc_ny]=0
-            exc = CSX.AddExcitation(self.lbl_temp.format('excite'), exc_type=0, exc_val=e_vec, delay=self.delay)
-            exc.SetWeightFunction([str(x) for x in self.E_func])
+            e_vec[self.exc_ny] = 0
+            exc = CSX.AddExcitation(self.lbl_temp.format('excite'), exc_type=excite_type, exc_val=e_vec, delay=self.delay)
+        
+            
+            # Check wether this is manual weighting or string function
+            
+            if self.E_func.__class__.__name__ == 'ndarray':
+                if not (self.E_func.shape[1] == 6):
+                    raise Exception('"E_func" must have 6 columns')
+                                        
+                isEcustomWeighting = True
+            elif len(self.E_func) == 3:
+                if excite_type == 0:
+                    exc.SetWeightFunction([str(x) for x in self.E_func])
+            else:
+                raise Exception('Unsupported list length {} for "E_func"'.format(len(self.E_func)))
+                        
+            if self.H_func.__class__.__name__ == 'ndarray':
+                # Now check everything is of "float" type
+                
+                if not ((self.H_func.shape[0] == self.E_func.shape[0]) and (self.H_func.shape[1] == 6)):
+                    raise Exception('"H_func" must be of equal length to E_func')
+                        
+                isHcustomWeighting = True
+            elif len(self.H_func) == 3:
+                if excite_type == 2:
+                    exc.SetWeightFunction([str(x) for x in self.H_func])
+            else:
+                raise Exception('Unsupported list length {} for "H_func"'.format(len(self.H_func)))
+        
+            if isEcustomWeighting != isHcustomWeighting:
+                raise Exception('Both "E_func" and "H_func" must both be custom or string.')
+            if isEcustomWeighting and (excite_type == 0):
+                exc.SetManualWeights(self.E_func)
+            if isHcustomWeighting and (excite_type == 2):
+                exc.SetManualWeights(self.H_func)
+            
             exc.AddBox(e_start, e_stop, priority=self.priority)
-
+        
         # voltage/current planes
         m_start = np.array(start)
         m_stop  = np.array(stop)
+        
+        # In case this is a custom probe, measure on the plane (why do otherwise, anyway?)
+        # if (isEcustomWeighting or isHcustomWeighting):
+        #     m_stop[self.exc_ny] = m_start[self.exc_ny]
+        # else:
+        #     m_start[self.exc_ny] = m_stop[self.exc_ny]
         m_start[self.exc_ny] = m_stop[self.exc_ny]
+            
         self.measplane_shift = np.abs(stop[self.exc_ny] - start[self.exc_ny])
-
+        
         self.U_filenames = [self.lbl_temp.format('ut'), ]
-
+        
         u_probe = CSX.AddProbe(self.U_filenames[0], p_type=10, mode_function=self.E_func)
         u_probe.AddBox(m_start, m_stop)
-
+        
         self.I_filenames = [self.lbl_temp.format('it'), ]
         i_probe = CSX.AddProbe(self.I_filenames[0], p_type=11, weight=self.direction, mode_function=self.H_func)
         i_probe.AddBox(m_start, m_stop)
 
 
-    def CalcPort(self, sim_path, freq, ref_impedance=None, ref_plane_shift=None, signal_type='pulse'):
+    def CalcPort(self, sim_path, freq, ref_impedance=None, ref_plane_shift=None, signal_type='pulse', ZL = -1):
         k = 2.0*np.pi*freq/C0*self.ref_index
         self.beta = np.sqrt(k**2 - self.kc**2)
-        self.ZL = k * Z0 / self.beta    #analytic waveguide impedance
+        if ZL <= 0:
+            self.ZL = k * Z0 / self.beta    #analytic waveguide impedance
+        else:
+            self.ZL = ZL
         if ref_impedance is None:
             self.Z_ref = self.ZL
         super(WaveguidePort, self).CalcPort(sim_path, freq, ref_impedance, ref_plane_shift, signal_type)


### PR DESCRIPTION
There are two additions in this pull requests:

1. Support for Mur B.C. locally (not necessary on the edge) as a primitive
Same use cases as specified in the CSXCAD PR
- Horn antennaspattern calculation
- Coaxial to PCB transitions.
Two types or Mur B.Cs were implemented:
- Regular first-order Mur
- Super-absorbing Mur B.C (see reference [1]). I'm pretty sure at this point that the functionality is at least similar to surface-impedance boundary conditions. They did increase convergence rate in some cases.

2. Externally calculated modes are also integrated for V\I calculations. S-Parameters verified, as well.
![image](https://github.com/user-attachments/assets/d4a53a90-07eb-4453-b0da-defe541a132b)

All original functionality is maintained. All functions can be used as before, as well.

[1] Betz, Vaughn Timothy, and R. Mittra. "Absorbing boundary conditions for the finite-difference time-domain analysis of guided-wave structures." Coordinated Science Laboratory Report no. UILU-ENG-93-2243 (1993).‏

