### PR TITLE
Improve Readability of Operator_Ext_Mur_ABC and Engine_Ext_Mur_ABC

### DIFF
--- a/FDTD/extensions/engine_ext_mur_abc.h
+++ b/FDTD/extensions/engine_ext_mur_abc.h
@@ -56,8 +56,8 @@ protected:
 	inline bool IsActive() {if (m_Eng->GetNumberOfTimesteps()<m_start_TS) return false; return true;}
 	unsigned int m_start_TS;
 
-	int m_ny;
-	int m_nyP,m_nyPP;
+	// See detailed comments in operator_ext_mur_abc.h, not repeated here.
+	int m_ny, m_nyP, m_nyPP;
 	unsigned int m_LineNr;
 	int m_LineNr_Shift;
 	unsigned int m_numLines[2];

--- a/FDTD/extensions/operator_ext_mur_abc.h
+++ b/FDTD/extensions/operator_ext_mur_abc.h
@@ -15,6 +15,16 @@
 *	along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+// Boundary condition "MUR_ABC" implements an absorbing boundary condition
+// first proposed by Gerrit Mur [1]. Better explanations are available in
+// standard FDTD textbooks, so readers are recommended to use textbooks (see
+// Learn More) on the openEMS website instead of Mur's original paper.
+//
+// G. Mur, "Absorbing Boundary Conditions for the Finite-Difference
+// Approximation of the Time-Domain Electromagnetic-Field Equations," in
+// IEEE Transactions on Electromagnetic Compatibility, vol. EMC-23, no. 4,
+// pp. 377-382, Nov. 1981, doi: 10.1109/TEMC.1981.303970.
+
 #ifndef OPERATOR_EXT_MUR_ABC_H
 #define OPERATOR_EXT_MUR_ABC_H
 
@@ -52,16 +62,40 @@ public:
 protected:
 	Operator_Ext_Mur_ABC(Operator* op, Operator_Ext_Mur_ABC* op_ext);
 	void Initialize();
-	int m_ny;
-	int m_nyP,m_nyPP;
+
+	// The simulation box contains 6 faces, m_ny gives the normal direction
+	// of the surface on which Mur's ABC is active, can be 0, 1, 2 for x, y, z.
+	// If ABC is enabled on more than one face, multiple instances are created.
+	int m_ny; // ny = axis (n) of the Yee (y) mesh
+
+	// The next and second next orthogonal direction with respect to ABC's
+	// normal direction m_ny. If the ABC's normal direction is Y (1),
+	// m_nyP and m_nyPP would be 2 (Z) and 0 (X). This value wraps back to X.
+	int m_nyP, m_nyPP; // P = Plus 1, PP = Plus 2.
+
+	// Whether the current face is on the "top" (or leftmost, or front)
+	// side of the simulation box.
 	bool m_top;
+
+	// Size of the Mur ABC 2D surface controlled by us. The physical significance
+	// is that Mur's ABC is installed at a single face of the simulation box,
+	// thus from our point of view, we only need to keep track of a 2D surface
+	// m_numLines[2], not m_numLines[3]. m_numLines[0] and m_numLines[1] are the
+	// number of Yee mesh lines on the direction m_nyP and m_nyPP.
+	unsigned int m_numLines[2];
+
+	// The line at which the Mur ABC is active, with respect to m_ny.
 	unsigned int m_LineNr;
+
+	// The nearest neighboring line from Mur ABC's active face, with respect to
+	// m_ny. If the ABC is enabled on the "last" face of the plane (m_top == true),
+	// m_LineNr is set to 0, and m_LineNr_Shift is set to 1. If the ABC is
+	// enabled on the "first" face of the plane (!m_top), m_LineNr is set to
+	// the last line of the mesh, and m_LineNr_Shift is set to the second last
+	// line.
 	int m_LineNr_Shift;
 
 	double m_v_phase;
-
-	unsigned int m_numLines[2];
-
 	ArrayLib::ArrayIJ<FDTD_FLOAT> m_Mur_Coeff_nyP;
 	ArrayLib::ArrayIJ<FDTD_FLOAT> m_Mur_Coeff_nyPP;
 };


### PR DESCRIPTION
This commit improves the readability of Mur ABC (as highlighted [1]) by doing the following:

1. The meaning of most member variables in `Operator_Ext_Mur_ABC` are now explained in the comments.

2. Variables `ny`, `nyP`, and `nyPP` are renamed to `dir1`, `dir2` and `dir3` so they're self-explanatory.

3. The extension update loops use arrays as loop variables, including array `pos`, `pos_shift`, and they're combined with counters including `lineX`, `m_start`, and `m_numX`. This makes the loop structure difficult to understand, as it's difficult to see which variable is in control. The commit rewrites the loop using the idiomatic `i` and `j` as loop variables, which is then used to derive `pos[3]` and `pos_shift[3]`.

[1] https://github.com/thliebig/openEMS-Project/discussions/273