### PR TITLE
Fix build error on MSVC in allocator.

### DIFF
--- a/tools/arraylib/impl/allocator.h
+++ b/tools/arraylib/impl/allocator.h
@@ -67,7 +67,7 @@ public:
 
 		T* buf;
 #ifdef WIN32
-		buf = _mm_malloc(numelem * sizeof(T), alignment);
+		buf = (T*) _mm_malloc(numelem * sizeof(T), alignment);
 		if (buf == NULL)
 		{
 			std::cerr << "Failed to allocate aligned memory" << std::endl;


### PR DESCRIPTION
The error message was:

```
...\openEMS\tools\arraylib\impl\allocator.h(70,9): error C2440: '=': cannot convert from 'void *' to 'T *' [...\build\openEMS-prefix\src\openEMS-build\openEMS.vcxproj] [...\build\openEMS.vcxproj]
...\openEMS\tools\arraylib\impl\allocator.h(70,9): error C2440: with [...\build\openEMS-prefix\src\openEMS-build\openEMS.vcxproj] [...\build\openEMS.vcxproj]
...\openEMS\tools\arraylib\impl\allocator.h(70,9): error C2440: [ [...\build\openEMS-prefix\src\openEMS-build\openEMS.vcxproj] [...\build\openEMS.vcxproj]
...\openEMS\tools\arraylib\impl\allocator.h(70,9): error C2440: T=float [...\build\openEMS-prefix\src\openEMS-build\openEMS.vcxproj] [...\build\openEMS.vcxproj]
...\openEMS\tools\arraylib\impl\allocator.h(70,9): error C2440: ] [...\build\openEMS-prefix\src\openEMS-build\openEMS.vcxproj] [...\build\openEMS.vcxproj]
```