### PR TITLE
python/ports: Fix single filenames for ReadUI

### DIFF
--- a/python/openEMS/ports.py
+++ b/python/openEMS/ports.py
@@ -100,14 +100,14 @@ class Port(object):
         self.u_data = UI_data(self.U_filenames, sim_path, freq, signal_type )
         self.uf_tot = 0
         self.ut_tot = 0
-        for n in range(len(self.U_filenames)):
+        for n in range(len(self.u_data.fns)):
             self.uf_tot += self.u_data.ui_f_val[n]
             self.ut_tot += self.u_data.ui_val[n]
 
         self.i_data = UI_data(self.I_filenames, sim_path, freq, signal_type )
         self.if_tot = 0
         self.it_tot = 0
-        for n in range(len(self.U_filenames)):
+        for n in range(len(self.i_data.fns)):
             self.if_tot += self.i_data.ui_f_val[n]
             self.it_tot += self.i_data.ui_val[n]
 


### PR DESCRIPTION
In case one uses a single string/filename in the port, looping over `self.{U,I}_filenames` will cause it to loop over the characters in the filename rather than the list of files, causing an index out of bounds error.

This scenario is already handled in `UI_data` with `fns`, hence we just re-use this in ReadUI, such that we have the filenames
iterable in all the cases