### PR TITLE
matlab: reformat all docstrings as legal Markdown.

### DIFF
--- a/matlab/AR_estimate.m
+++ b/matlab/AR_estimate.m
@@ -3,26 +3,28 @@ function [val_ar t_ar f_val_ar EC] = AR_estimate( t, val, freq, nu, mu, expand_f
 %
 % apply autoregressive signal model to improve dft results
 %
-% t     : time vector
-% val   : time domain values
-% freq  : frequency vector for dft
+% * t     : time vector
+% * val   : time domain values
+% * freq  : frequency vector for dft
 %
 % optional
-% nu    : AR order (default 40)
-% mu    : number of timesteps to train the model (default 3*nu)
-% expand_factor : increase signal length by this factor (default 5)
+%
+% * nu    : AR order (default 40)
+% * mu    : number of timesteps to train the model (default 3*nu)
+% * expand_factor : increase signal length by this factor (default 5)
 %
 % return values:
-% val_ar:   AR estimated time signal
-% t_ar:     time vector
-% f_val_ar: FD transformed AR estimated signal
-% EC:       error code
-%           0 --> no error
-%           1 --> input error: t and val mismatch
-%           2 --> input error: mu has to be larger than 2*nu
-%           3 --> input error: expand_factor has to be larger than 1
-%           10 --> AR error: signal is to short for AR estimate --> decrease AR order
-%           11 --> AR error: estimated signal appears to be unstable --> use a different mu
+%
+% * val_ar:   AR estimated time signal
+% * t_ar:     time vector
+% * f_val_ar: FD transformed AR estimated signal
+% * EC:       error code
+%             0 --> no error
+%             1 --> input error: t and val mismatch
+%             2 --> input error: mu has to be larger than 2*nu
+%             3 --> input error: expand_factor has to be larger than 1
+%             10 --> AR error: signal is to short for AR estimate --> decrease AR order
+%             11 --> AR error: estimated signal appears to be unstable --> use a different mu
 %
 % openEMS matlab interface
 % -----------------------

--- a/matlab/AddCPWPort.m
+++ b/matlab/AddCPWPort.m
@@ -1,35 +1,37 @@
 function [CSX,port] = AddCPWPort( CSX, prio, portnr, materialname, start, stop, gap_width, dir, evec, varargin )
 % [CSX,port] = AddCPWPort( CSX, prio, portnr, materialname, start, stop, gap_width, dir, evec, varargin )
 %
-% CSX:          CSX-object created by InitCSX()
-% prio:         priority for excitation and probe boxes
-% portnr:       (integer) number of the port
-% materialname: property for the CPW (created by AddMetal())
-% start:        3D start rowvector for port definition
-% stop:         3D end rowvector for port definition
-% gap_width:    width of the CPW gap (left and right)
-% dir:          direction of wave propagation (choices: 0, 1, 2 or 'x','y','z')
-% evec:         excitation vector, which defines the direction of the e-field (must be the same as used in AddExcitation())
+% - CSX:          CSX-object created by InitCSX()
+% - prio:         priority for excitation and probe boxes
+% - portnr:       (integer) number of the port
+% - materialname: property for the CPW (created by AddMetal())
+% - start:        3D start rowvector for port definition
+% - stop:         3D end rowvector for port definition
+% - gap_width:    width of the CPW gap (left and right)
+% - dir:          direction of wave propagation (choices: 0, 1, 2 or 'x','y','z')
+% - evec:         excitation vector, which defines the direction of the e-field (must be the same as used in AddExcitation())
 %
 % variable input:
-%  varargin:    optional additional excitations options, see also AddExcitation
-% 'ExcitePort'  true/false to make the port an active feeding port (default
-%               is false)
-% 'FeedShift'   shift to port from start by a given distance in drawing
-%               units. Default is 0. Only active if 'ExcitePort' is set!
-% 'Feed_R'      Specify a lumped port resistance. Default is no lumped
-%               port resistance --> port has to end in an ABC.
-% 'MeasPlaneShift'  Shift the measurement plane from start t a given distance
-%               in drawing units. Default is the middle of start/stop.
-% 'PortNamePrefix' a prefix to the port name
+%
+% -  varargin:    optional additional excitations options, see also AddExcitation
+% - 'ExcitePort'  true/false to make the port an active feeding port (default
+%                 is false)
+% - 'FeedShift'   shift to port from start by a given distance in drawing
+%                 units. Default is 0. Only active if 'ExcitePort' is set!
+% - 'Feed_R'      Specify a lumped port resistance. Default is no lumped
+%                 port resistance --> port has to end in an ABC.
+% - 'MeasPlaneShift'  Shift the measurement plane from start t a given distance
+%                 in drawing units. Default is the middle of start/stop.
+% - 'PortNamePrefix' a prefix to the port name
 %
 % Important: The mesh has to be already set and defined by DefineRectGrid!
 %
 % example:
-%   CSX = AddMetal( CSX, 'metal' ); %create a PEC called 'metal'
-%   start = [0       -width/2  0];
-%   stop  = [length  +width/2  0];
-%   [CSX,port] = AddCPWPort( CSX, 0, 1, 'metal', start, stop, gap_width, 'x', ...
+%
+%     CSX = AddMetal( CSX, 'metal' ); %create a PEC called 'metal'
+%     start = [0       -width/2  0];
+%     stop  = [length  +width/2  0];
+%     [CSX,port] = AddCPWPort( CSX, 0, 1, 'metal', start, stop, gap_width, 'x', ...
 %                                   [0 0 -1], 'ExcitePort', true, 'Feed_R', 50 )
 % Explanation:
 %   - this defines a stripline in x-direction (dir='x')

--- a/matlab/AddCircWaveGuidePort.m
+++ b/matlab/AddCircWaveGuidePort.m
@@ -3,32 +3,34 @@ function [CSX,port] = AddCircWaveGuidePort( CSX, prio, portnr, start, stop, radi
 % 
 % Create a circular waveguide port, including an optional excitation and probes
 % 
-% Note: - The excitation will be located at the start position in the given direction
-%       - The voltage and current probes at the stop position in the given direction
+% Note:
+% - The excitation will be located at the start position in the given direction
+% - The voltage and current probes at the stop position in the given direction
 %
 % input:
-%   CSX:        complete CSX structure (must contain a mesh)
-%   prio:       priority of primitives
-%   start:      start coordinates of waveguide port box
-%   stop:       stop  coordinates of waveguide port box
-%   radius:     circular waveguide radius (in meter)
-%   mode_name:  mode name, e.g. 'TE11' or 'TM21'
-%   pol_ang:    polarization angle (e.g. 0 = horizontal, pi/2 = vertical)
-%   exc_amp:    excitation amplitude (set 0 to be passive)
+% - CSX:        complete CSX structure (must contain a mesh)
+% - prio:       priority of primitives
+% - start:      start coordinates of waveguide port box
+% - stop:       stop  coordinates of waveguide port box
+% - radius:     circular waveguide radius (in meter)
+% - mode_name:  mode name, e.g. 'TE11' or 'TM21'
+% - pol_ang:    polarization angle (e.g. 0 = horizontal, pi/2 = vertical)
+% - exc_amp:    excitation amplitude (set 0 to be passive)
 %
 % optional (key/values):
-%   varargin:   optional additional excitations options, see also AddExcitation
-%   'PortNamePrefix': a prefix to the port name
+% * varargin:   optional additional excitations options, see also AddExcitation
+% * 'PortNamePrefix': a prefix to the port name
 %
 % output:
-%   CSX:        modified CSX structure
-%   port:       port structure to use with calcPort
+% * CSX:        modified CSX structure
+% * port:       port structure to use with calcPort
 %
 % example:
-%   % create a TE11 circular waveguide mode, using cylindircal coordinates
-%   start=[mesh.r(1)   mesh.a(1)   0  ];
-%   stop =[mesh.r(end) mesh.a(end) 100];
-%   [CSX,port] = AddCircWaveGuidePort( CSX, 99, 1, start, stop, 320e-3, 'TE11', 0, 1);
+%
+%     % create a TE11 circular waveguide mode, using cylindircal coordinates
+%     start=[mesh.r(1)   mesh.a(1)   0  ];
+%     stop =[mesh.r(end) mesh.a(end) 100];
+%     [CSX,port] = AddCircWaveGuidePort( CSX, 99, 1, start, stop, 320e-3, 'TE11', 0, 1);
 %
 % openEMS matlab interface
 % -----------------------

--- a/matlab/AddCoaxialPort.m
+++ b/matlab/AddCoaxialPort.m
@@ -1,30 +1,30 @@
 function [CSX,port] = AddCoaxialPort( CSX, prio, portnr, pec_name, materialname, start, stop, dir, r_i, r_o, r_os, varargin )
 % function [CSX,port] = AddCoaxialPort( CSX, prio, portnr, pec_name, materialname, start, stop, dir, r_i, r_o, r_os, varargin )
 %
-% CSX:          CSX-object created by InitCSX()
-% prio:         priority for excitation and probe boxes
-% portnr:       (integer) number of the port
-% pec_name:     metal property for coaxial inner/outer conductor (created by AddMetal())
-% materialname: substrate property for coaxial line (created by AddMaterial())
-%               Note: this may be empty for an "air filled" coaxial line
-% start:        3D start rowvector for coaxial cable axis
-% stop:         3D end rowvector for coaxial cable axis
-% dir:          direction of wave propagation (choices: 0, 1, 2 or 'x','y','z')
-% r_i:          inner coaxial radius (in drawing unit)
-% r_o:          outer coaxial radius (in drawing unit)
-% r_os:         outer shell coaxial radius (in drawing unit)
+% - CSX:          CSX-object created by InitCSX()
+% - prio:         priority for excitation and probe boxes
+% - portnr:       (integer) number of the port
+% - pec_name:     metal property for coaxial inner/outer conductor (created by AddMetal())
+% - materialname: substrate property for coaxial line (created by AddMaterial())
+%                 Note: this may be empty for an "air filled" coaxial line
+% - start:        3D start rowvector for coaxial cable axis
+% - stop:         3D end rowvector for coaxial cable axis
+% - dir:          direction of wave propagation (choices: 0, 1, 2 or 'x','y','z')
+% - r_i:          inner coaxial radius (in drawing unit)
+% - r_o:          outer coaxial radius (in drawing unit)
+% - r_os:         outer shell coaxial radius (in drawing unit)
 %
 % variable input:
-%  varargin:    optional additional excitations options, see also AddExcitation
-% 'ExciteAmp'   excitation amplitude of transversal electric field profile,
-%               set to 0 (default) for a passive port
-% 'FeedShift'   shift to port from start by a given distance in drawing
-%               units. Default is 0. Only active if 'ExciteAmp' is set!
-% 'Feed_R'      Specify a lumped port resistance. Default is no lumped
-%               port resistance --> port has to end in an ABC.
-% 'MeasPlaneShift'  Shift the measurement plane from start t a given distance
-%               in drawing units. Default is the middle of start/stop.
-% 'PortNamePrefix' a prefix to the port name
+% -  varargin:    optional additional excitations options, see also AddExcitation
+% - 'ExciteAmp'   excitation amplitude of transversal electric field profile,
+%                 set to 0 (default) for a passive port
+% - 'FeedShift'   shift to port from start by a given distance in drawing
+%                 units. Default is 0. Only active if 'ExciteAmp' is set!
+% - 'Feed_R'      Specify a lumped port resistance. Default is no lumped
+%                 port resistance --> port has to end in an ABC.
+% - 'MeasPlaneShift'  Shift the measurement plane from start t a given distance
+%                 in drawing units. Default is the middle of start/stop.
+% - 'PortNamePrefix' a prefix to the port name
 %
 % the mesh must be already initialized
 %

--- a/matlab/AddCurvePort.m
+++ b/matlab/AddCurvePort.m
@@ -5,26 +5,28 @@ function [CSX,port] = AddCurvePort( CSX, prio, portnr, R, start, stop, excite, v
 % The mesh must already be initialized.
 %
 % input:
-%   CSX:    CSX-object created by InitCSX()
-%   prio:   priority for excitation, metal, sheet and probe boxes
-%   portnr: (integer) number of the port
-%   R:      internal resistance of the port
-%   start:  3D start rowvector for port definition
-%   stop:   3D end rowvector for port definition
-%   excite (optional): if true, the port will be switched on (see AddExcitation())
+% - CSX:    CSX-object created by InitCSX()
+% - prio:   priority for excitation, metal, sheet and probe boxes
+% - portnr: (integer) number of the port
+% - R:      internal resistance of the port
+% - start:  3D start rowvector for port definition
+% - stop:   3D end rowvector for port definition
+% - excite (optional): if true, the port will be switched on (see AddExcitation())
 %                       Note: for legacy support a string will be accepted
 % optional (key/values):
 %   varargin:   optional additional excitations options, see also AddExcitation
 %   'PortNamePrefix': a prefix to the port name
 %
 % output:
-%   CSX:
-%   port:
+% - CSX:
+% - port:
 %
 % example:
-%   start = [0 0 0]; stop = [0 0 12];
-%   this defines a lumped port in z-direction
-%   the excitation/probe is placed between start(1) and stop(1)
+%
+%     start = [0 0 0]; stop = [0 0 12];
+%
+% this defines a lumped port in z-direction
+% the excitation/probe is placed between start(1) and stop(1)
 %
 % (C) 2010 Sebastian Held <sebastian.held@uni-due.de>
 % See also InitCSX AddExcitation

--- a/matlab/AddLumpedPort.m
+++ b/matlab/AddLumpedPort.m
@@ -6,26 +6,30 @@ function [CSX, port] = AddLumpedPort( CSX, prio, portnr, R, start, stop, dir, ex
 % A lumped port consists of an excitation, a lumped resistor, a voltage and
 % current probe.
 %
-% CSX:      CSX-object created by InitCSX()
-% prio:     priority for substrate and probe boxes
-% portnr:   (integer) number of the port
-% R:        internal resistance of the port (lumped element)
-% start:    3D start rowvector for port definition
-% stop:     3D end rowvector for port definition
-% dir:      direction/amplitude of port (e.g.: [1 0 0], [0 1 0] or [0 0 1])
-% excite (optional): if true, the port will be switched on (see AddExcitation())
+% - CSX:      CSX-object created by InitCSX()
+% - prio:     priority for substrate and probe boxes
+% - portnr:   (integer) number of the port
+% - R:        internal resistance of the port (lumped element)
+% - start:    3D start rowvector for port definition
+% - stop:     3D end rowvector for port definition
+% - dir:      direction/amplitude of port (e.g.: [1 0 0], [0 1 0] or [0 0 1])
+% - excite (optional): if true, the port will be switched on (see AddExcitation())
 %                       Note: for legacy support a string will be accepted
-% V_Probe_Weight:  additional weight for the voltage probes
-% I_Probe_Weight:  additional weight for the current probes
+% - V_Probe_Weight:  additional weight for the voltage probes
+% - I_Probe_Weight:  additional weight for the current probes
+%
 % optional (key/values):
-%   'PortNamePrefix': an prefix to the port name
+%
+% - 'PortNamePrefix': an prefix to the port name
+%
 % varargin (optional): additional excitations options, see also AddExcitation
 %
 % example:
-%   start = [0 -width/2 0];
-%   stop  = [0  width/2 height];
-%   [CSX] = AddLumpedPort(CSX, 5 ,1 , 50, start, stop, [0 0 1], true);
-%   %this defines an active lumped port in z-direction with a 50 Ohm port impedance
+%
+%     start = [0 -width/2 0];
+%     stop  = [0  width/2 height];
+%     [CSX] = AddLumpedPort(CSX, 5 ,1 , 50, start, stop, [0 0 1], true);
+%     %this defines an active lumped port in z-direction with a 50 Ohm port impedance
 %
 % openEMS matlab interface
 % -----------------------

--- a/matlab/AddMRStub.m
+++ b/matlab/AddMRStub.m
@@ -1,24 +1,24 @@
 function CSX = AddMRStub( CSX, materialname, prio, MSL_width, len, alpha, resolution, orientation, normVector, position )
-% CSX = AddMRStub( CSX, materialname, prio, MSL_width, len, alpha,
-% resolution, orientation, normVector, position )
+% CSX = AddMRStub( CSX, materialname, prio, MSL_width, len, alpha, resolution, orientation, normVector, position )
 %
 % Microstrip Radial Stub
 %
-% CSX: CSX-object created by InitCSX()
-% materialname: property for the MSL (created by AddMetal() or AddMaterial())
-% prio: priority
-% MSL_width: width of the MSL to connect the stub to
-% len: length of the radial stub
-% alpha: angle subtended by the radial stub (degrees) 
-% resolution: discrete angle spacing (degrees)
-% orientation: angle of main direction of the radial stub (degrees)
-% normVector: normal vector of the stub
-% position: position of the end of the MSL
+% - CSX: CSX-object created by InitCSX()
+% - materialname: property for the MSL (created by AddMetal() or AddMaterial())
+% - prio: priority
+% - MSL_width: width of the MSL to connect the stub to
+% - len: length of the radial stub
+% - alpha: angle subtended by the radial stub (degrees) 
+% - resolution: discrete angle spacing (degrees)
+% - orientation: angle of main direction of the radial stub (degrees)
+% - normVector: normal vector of the stub
+% - position: position of the end of the MSL
 %
 % This radial stub definition is equivalent to the one Agilent ADS uses.
 %
 % example:
-% CSX = AddMRStub( CSX, 'PEC', 10, 1000, 5900, 30, 1, -90, [0 0 1], [0 -10000 254] );
+%
+%     CSX = AddMRStub( CSX, 'PEC', 10, 1000, 5900, 30, 1, -90, [0 0 1], [0 -10000 254] );
 %
 %
 % Sebastian Held <sebastian.held@gmx.de>

--- a/matlab/AddMSLPort.m
+++ b/matlab/AddMSLPort.m
@@ -1,34 +1,35 @@
 function [CSX,port] = AddMSLPort( CSX, prio, portnr, materialname, start, stop, dir, evec, varargin )
 % [CSX,port] = AddMSLPort( CSX, prio, portnr, materialname, start, stop, dir, evec, varargin )
 %
-% CSX:          CSX-object created by InitCSX()
-% prio:         priority for excitation and probe boxes
-% portnr:       (integer) number of the port
-% materialname: property for the MSL (created by AddMetal())
-% start:        3D start rowvector for port definition
-% stop:         3D end rowvector for port definition
-% dir:          direction of wave propagation (choices: 0, 1, 2 or 'x','y','z')
-% evec:         excitation vector, which defines the direction of the e-field (must be the same as used in AddExcitation())
+% - CSX:          CSX-object created by InitCSX()
+% - prio:         priority for excitation and probe boxes
+% - portnr:       (integer) number of the port
+% - materialname: property for the MSL (created by AddMetal())
+% - start:        3D start rowvector for port definition
+% - stop:         3D end rowvector for port definition
+% - dir:          direction of wave propagation (choices: 0, 1, 2 or 'x','y','z')
+% - evec:         excitation vector, which defines the direction of the e-field (must be the same as used in AddExcitation())
 % 
 % variable input:
-%  varargin:    optional additional excitations options, see also AddExcitation
-% 'ExcitePort'  true/false to make the port an active feeding port (default
-%               is false)
-% 'FeedShift'   shift to port from start by a given distance in drawing
-%               units. Default is 0. Only active if 'ExcitePort' is set!
-% 'Feed_R'      Specify a lumped port resistance. Default is no lumped
-%               port resistance --> port has to end in an ABC.
-% 'MeasPlaneShift'  Shift the measurement plane from start t a given distance 
-%               in drawing units. Default is the middle of start/stop.
-% 'PortNamePrefix' a prefix to the port name
+% - varargin:    optional additional excitations options, see also AddExcitation
+% - 'ExcitePort'  true/false to make the port an active feeding port (default
+%                 is false)
+% - 'FeedShift'   shift to port from start by a given distance in drawing
+%                 units. Default is 0. Only active if 'ExcitePort' is set!
+% - 'Feed_R'      Specify a lumped port resistance. Default is no lumped
+%                 port resistance --> port has to end in an ABC.
+% - 'MeasPlaneShift'  Shift the measurement plane from start t a given distance 
+%                     in drawing units. Default is the middle of start/stop.
+% - 'PortNamePrefix' a prefix to the port name
 % 
 % Important: The mesh has to be already set and defined by DefineRectGrid!
 %
 % example:
-%   CSX = AddMetal( CSX, 'metal' ); %create a PEC called 'metal'
-%   start = [0       -width/2  height];
-%   stop  = [length  +width/2  0     ];
-%   [CSX,port] = AddMSLPort( CSX, 0, 1, 'metal', start, stop, 'x', [0 0 -1], ...
+%
+%     CSX = AddMetal( CSX, 'metal' ); %create a PEC called 'metal'
+%     start = [0       -width/2  height];
+%     stop  = [length  +width/2  0     ];
+%     [CSX,port] = AddMSLPort( CSX, 0, 1, 'metal', start, stop, 'x', [0 0 -1], ...
 %                           'ExcitePort', true, 'Feed_R', 50 )
 % Explanation:
 %   - this defines a MSL in x-direction (dir='x')

--- a/matlab/AddPML.m
+++ b/matlab/AddPML.m
@@ -9,26 +9,29 @@ function mesh = AddPML( mesh, numcells, CoordSystem )
 % The mesh is sorted and duplicate lines are removed.
 %
 % input:
-%   mesh:     mesh structure
-%   numcells: 1x6 vector (xmin,xmax,ymin,ymax,zmin,zmax) with number of
+%
+% - mesh:     mesh structure
+% - numcells: 1x6 vector (xmin,xmax,ymin,ymax,zmin,zmax) with number of
 %             cells to add to this direction
-%   CoordSystem (optional): set to 1 in case of cylindrical mesh using
-%               mesh.r, mesh.a and mesh.z
+% - CoordSystem (optional): set to 1 in case of cylindrical mesh using
+%                           mesh.r, mesh.a and mesh.z
 %
 % output:
-%   mesh:     new mesh with the added lines
+%
+% - mesh:     new mesh with the added lines
 %
 % example:
-%   % some fixed mesh lines
-%   mesh.x = [-100 0 100];
-%   mesh.y = [-100 0 100];
-%   mesh.z = [0 500];
-%   mesh = DetectEdges(CSX, mesh); %detect edges
-%   mesh = SmoothMesh(mesh, c0/fmax/20/unit); % smooth the mesh
 %
-%   mesh = AddPML(mesh, 8); % add 8 lines to all directions
-%   % or
-%   mesh = AddPML(mesh, [0 0 0 0 8 8]); % add 8 lines in both z-directions
+%     % some fixed mesh lines
+%     mesh.x = [-100 0 100];
+%     mesh.y = [-100 0 100];
+%     mesh.z = [0 500];
+%     mesh = DetectEdges(CSX, mesh); %detect edges
+%     mesh = SmoothMesh(mesh, c0/fmax/20/unit); % smooth the mesh
+%
+%     mesh = AddPML(mesh, 8); % add 8 lines to all directions
+%     % or
+%     mesh = AddPML(mesh, [0 0 0 0 8 8]); % add 8 lines in both z-directions
 %
 % See also DefineRectGrid, SmoothMesh, DetectEdges
 %

--- a/matlab/AddRectWaveGuidePort.m
+++ b/matlab/AddRectWaveGuidePort.m
@@ -7,28 +7,29 @@ function [CSX,port] = AddRectWaveGuidePort( CSX, prio, portnr, start, stop, dir,
 %       - The voltage and current probes at the stop position in the given direction
 %
 % input:
-%   CSX:        complete CSX structure (must contain a mesh)
-%   prio:       priority of primitives
-%   start:      start coordinates of waveguide port box
-%   stop:       stop  coordinates of waveguide port box
-%   dir:        direction of port (0/1/2 or 'x'/'y'/'z'-direction)
-%   a,b:        rectangular waveguide width and height (in meter)
-%   mode_name:  mode name, e.g. 'TE11' or 'TM21'
-%   exc_amp:    excitation amplitude (set 0 to be passive)
+% - CSX:        complete CSX structure (must contain a mesh)
+% - prio:       priority of primitives
+% - start:      start coordinates of waveguide port box
+% - stop:       stop  coordinates of waveguide port box
+% - dir:        direction of port (0/1/2 or 'x'/'y'/'z'-direction)
+% - a,b:        rectangular waveguide width and height (in meter)
+% - mode_name:  mode name, e.g. 'TE11' or 'TM21'
+% - exc_amp:    excitation amplitude (set 0 to be passive)
 %
 % optional (key/values):
-%   varargin:   optional additional excitations options, see also AddExcitation
-%   'PortNamePrefix': a prefix to the port name
+% - varargin:   optional additional excitations options, see also AddExcitation
+% - 'PortNamePrefix': a prefix to the port name
 %
 % output:
-%   CSX:        modified CSX structure
-%   port:       port structure to use with calcPort
+% - CSX:        modified CSX structure
+% - port:       port structure to use with calcPort
 %
 % example:
-%   % create a TE10 circular waveguide mode, using cylindircal coordinates
-%   start=[mesh.r(1)   mesh.a(1)   0  ];
-%   stop =[mesh.r(end) mesh.a(end) 100];
-%   [CSX,port] = AddCircWaveGuidePort( CSX, 99, 1, start, stop, 320e-3, 'TE11', 0, 1);
+%
+%     % create a TE10 circular waveguide mode, using cylindircal coordinates
+%     start=[mesh.r(1)   mesh.a(1)   0  ];
+%     stop =[mesh.r(end) mesh.a(end) 100];
+%     [CSX,port] = AddCircWaveGuidePort( CSX, 99, 1, start, stop, 320e-3, 'TE11', 0, 1);
 %
 % openEMS matlab interface
 % -----------------------

--- a/matlab/AddStripLinePort.m
+++ b/matlab/AddStripLinePort.m
@@ -1,36 +1,37 @@
 function [CSX,port] = AddStripLinePort( CSX, prio, portnr, materialname, start, stop, height, dir, evec, varargin )
 % [CSX,port] = AddStripLinePort( CSX, prio, portnr, materialname, start, stop, height, dir, evec, varargin )
 %
-% CSX:          CSX-object created by InitCSX()
-% prio:         priority for excitation and probe boxes
-% portnr:       (integer) number of the port
-% materialname: property for the stripline (created by AddMetal())
-% start:        3D start rowvector for port definition
-% stop:         3D end rowvector for port definition
-% height:       height of the stripline (top and bottom)
-% dir:          direction of wave propagation (choices: 0, 1, 2 or 'x','y','z')
-% evec:         excitation vector, which defines the direction of the e-field (must be the same as used in AddExcitation())
+% - CSX:          CSX-object created by InitCSX()
+% - prio:         priority for excitation and probe boxes
+% - portnr:       (integer) number of the port
+% - materialname: property for the stripline (created by AddMetal())
+% - start:        3D start rowvector for port definition
+% - stop:         3D end rowvector for port definition
+% - height:       height of the stripline (top and bottom)
+% - dir:          direction of wave propagation (choices: 0, 1, 2 or 'x','y','z')
+% - evec:         excitation vector, which defines the direction of the e-field (must be the same as used in AddExcitation())
 %
 % variable input:
-%  varargin:    optional additional excitations options, see also AddExcitation
-% 'ExcitePort'  true/false to make the port an active feeding port (default
-%               is false)
-% 'FeedShift'   shift to port from start by a given distance in drawing
-%               units. Default is 0. Only active if 'ExcitePort' is set!
-% 'Feed_R'      Specify a lumped port resistance. Default is no lumped
-%               port resistance --> port has to end in an ABC.
-% 'MeasPlaneShift'  Shift the measurement plane from start t a given distance
-%               in drawing units. Default is the middle of start/stop.
-% 'PortNamePrefix' a prefix to the port name
+% - varargin:    optional additional excitations options, see also AddExcitation
+% - 'ExcitePort'  true/false to make the port an active feeding port (default
+%                 is false)
+% - 'FeedShift'   shift to port from start by a given distance in drawing
+%                 units. Default is 0. Only active if 'ExcitePort' is set!
+% - 'Feed_R'      Specify a lumped port resistance. Default is no lumped
+%                 port resistance --> port has to end in an ABC.
+% - 'MeasPlaneShift'  Shift the measurement plane from start t a given distance
+%                 in drawing units. Default is the middle of start/stop.
+% - 'PortNamePrefix' a prefix to the port name
 %
 % Important: The mesh has to be already set and defined by DefineRectGrid!
 %
 % example:
-%   CSX = AddMetal( CSX, 'metal' ); %create a PEC called 'metal'
-%   start = [0       -width/2  0];
-%   stop  = [length  +width/2  0];
-%   [CSX,port] = AddStripLinePort( CSX, 0, 1, 'metal', start, stop, height, 'x', ...
-%                                   [0 0 -1], 'ExcitePort', true, 'Feed_R', 50 )
+%
+%     CSX = AddMetal( CSX, 'metal' ); %create a PEC called 'metal'
+%     start = [0       -width/2  0];
+%     stop  = [length  +width/2  0];
+%     [CSX,port] = AddStripLinePort( CSX, 0, 1, 'metal', start, stop, height, 'x', ...
+%                                     [0 0 -1], 'ExcitePort', true, 'Feed_R', 50 )
 % Explanation:
 %   - this defines a stripline in x-direction (dir='x')
 %     --> the wave travels along the x-direction

--- a/matlab/AddWaveGuidePort.m
+++ b/matlab/AddWaveGuidePort.m
@@ -7,43 +7,44 @@ function [CSX,port] = AddWaveGuidePort( CSX, prio, portnr, start, stop, dir, E_W
 %       - The voltage and current probes at the stop position in the given direction
 %
 % parameter:
-%   CSX:        complete CSX structure (must contain a mesh)
-%   prio:       priority of primitives
-%   start:      start coordinates of waveguide port box
-%   stop:       stop  coordinates of waveguide port box
-%   dir:        direction of port (0/1/2 or 'x'/'y'/'z'-direction)
-%   E_WG_func:  electric field mode profile function as a string
-%   H_WG_func:  magnetic field mode profile function as a string
-%   kc:         cutoff wavenumber (defined by the waveguide dimensions)
-%   exc_amp:    excitation amplitude (set 0 to be passive)
+% - CSX:        complete CSX structure (must contain a mesh)
+% - prio:       priority of primitives
+% - start:      start coordinates of waveguide port box
+% - stop:       stop  coordinates of waveguide port box
+% - dir:        direction of port (0/1/2 or 'x'/'y'/'z'-direction)
+% - E_WG_func:  electric field mode profile function as a string
+% - H_WG_func:  magnetic field mode profile function as a string
+% - kc:         cutoff wavenumber (defined by the waveguide dimensions)
+% - exc_amp:    excitation amplitude (set 0 to be passive)
 %
 % optional (key/values):
-%   varargin:   optional additional excitations options, see also AddExcitation
-%   'PortNamePrefix': a prefix to the port name
+% - varargin:   optional additional excitations options, see also AddExcitation
+% - 'PortNamePrefix': a prefix to the port name
 %
 % output:
-%   CSX:        modified CSX structure
-%   port:       port structure to use with calcPort
+% - CSX:        modified CSX structure
+% - port:       port structure to use with calcPort
 %
 % example:
-%   % create a TE11 circular waveguide mode, using cylindircal coordinates
-%   p11 = 1.841;
-%   kc = p11 / radius;  % cutoff wavenumber with radius in meter
-%   kc_draw = kc*unit;  % cutoff wavenumber in drawing units
 %
-%   % electric field mode profile
-%   func_E{1} = [ num2str(-1/kc_draw^2,15) '/rho*cos(a)*j1('  num2str(kc_draw,15) '*rho)'];
-%   func_E{2} = [ num2str(1/kc_draw,15) '*sin(a)*0.5*(j0('  num2str(kc_draw,15) '*rho)-jn(2,'  num2str(kc_draw,15) '*rho))'];
-%   func_E{3} = 0;
+%     % create a TE11 circular waveguide mode, using cylindircal coordinates
+%     p11 = 1.841;
+%     kc = p11 / radius;  % cutoff wavenumber with radius in meter
+%     kc_draw = kc*unit;  % cutoff wavenumber in drawing units
 %
-%   % magnetic field mode profile
-%   func_H{1} = [ '-1*' num2str(1/kc_draw,15) '*sin(a)*0.5*(j0('  num2str(kc_draw,15) '*rho)-jn(2,'  num2str(kc_draw,15) '*rho))'];
-%   func_H{2} = [ num2str(-1/kc_draw^2,15) '/rho*cos(a)*j1('  num2str(kc_draw,15) '*rho)'];
-%   func_H{3} = 0;
+%     % electric field mode profile
+%     func_E{1} = [ num2str(-1/kc_draw^2,15) '/rho*cos(a)*j1('  num2str(kc_draw,15) '*rho)'];
+%     func_E{2} = [ num2str(1/kc_draw,15) '*sin(a)*0.5*(j0('  num2str(kc_draw,15) '*rho)-jn(2,'  num2str(kc_draw,15) '*rho))'];
+%     func_E{3} = 0;
 %
-%   start=[mesh.r(1)   mesh.a(1)   0  ];
-%   stop =[mesh.r(end) mesh.a(end) 100];
-%   [CSX, port{1}] = AddWaveGuidePort(CSX, 0, 1, start, stop, 2, func_E, func_H, kc, 1);
+%     % magnetic field mode profile
+%     func_H{1} = [ '-1*' num2str(1/kc_draw,15) '*sin(a)*0.5*(j0('  num2str(kc_draw,15) '*rho)-jn(2,'  num2str(kc_draw,15) '*rho))'];
+%     func_H{2} = [ num2str(-1/kc_draw^2,15) '/rho*cos(a)*j1('  num2str(kc_draw,15) '*rho)'];
+%     func_H{3} = 0;
+%
+%     start=[mesh.r(1)   mesh.a(1)   0  ];
+%     stop =[mesh.r(end) mesh.a(end) 100];
+%     [CSX, port{1}] = AddWaveGuidePort(CSX, 0, 1, start, stop, 2, func_E, func_H, kc, 1);
 %
 % openEMS matlab interface
 % -----------------------

--- a/matlab/AnalyzeNF2FF.m
+++ b/matlab/AnalyzeNF2FF.m
@@ -4,18 +4,18 @@ function [E_theta,E_phi,Prad,Dmax] = AnalyzeNF2FF( Sim_Path, nf2ff, f, theta, ph
 % calculates the farfield via a near field to far field transformation
 %
 % input:
-%   Sim_Path:    simulation directory
-%   nf2ff:       structure on filenames etc. as created by CreateNF2FFBox 
-%   f:           frequency (Hz) for far field calculation
-%   theta:       (degrees) vector of discrete theta values to calculate the far field for
-%   phi:         (degrees) vector of discrete phi values to calculate the far field for
-%   r:           (optional) Radius (m) at which the E-fields are calculated (default: 1 m)
+% - Sim_Path:    simulation directory
+% - nf2ff:       structure on filenames etc. as created by CreateNF2FFBox 
+% - f:           frequency (Hz) for far field calculation
+% - theta:       (degrees) vector of discrete theta values to calculate the far field for
+% - phi:         (degrees) vector of discrete phi values to calculate the far field for
+% - r:           (optional) Radius (m) at which the E-fields are calculated (default: 1 m)
 %
 % output:
-%   E_theta:     E_theta(theta,phi); theta component of the electric field strength at radius r
-%   E_phi:       E_phi(theta,phi);     phi component of the electric field strength at radius r
-%   Prad:        time averaged radiated power
-%   Dmax:        maximum directivity
+% - E_theta:     E_theta(theta,phi); theta component of the electric field strength at radius r
+% - E_phi:       E_phi(theta,phi);     phi component of the electric field strength at radius r
+% - Prad:        time averaged radiated power
+% - Dmax:        maximum directivity
 %
 % example:
 %   see examples/NF2FF/infDipol.m

--- a/matlab/CalcNF2FF.m
+++ b/matlab/CalcNF2FF.m
@@ -9,30 +9,30 @@ function nf2ff = CalcNF2FF(nf2ff, Sim_Path, freq, theta, phi, varargin)
 % position! See optional parameter below!! Default is [0 0 0]
 %
 % parameter:
-% nf2ff:    data structure created by CreateNF2FFBox
-% Sim_Path: path to simulation data
-% freq:     array of frequencies to analyse
-% theta,phi: spherical coordinates to evaluate the far-field on (in radians)
+% - nf2ff:    data structure created by CreateNF2FFBox
+% - Sim_Path: path to simulation data
+% - freq:     array of frequencies to analyse
+% - theta,phi: spherical coordinates to evaluate the far-field on (in radians)
 %
 % optional parameter:
-% 'Center': nf2ff phase center, default is [0 0 0]
-%           !! Make sure the center is never outside of your nf2ff box!!
-%           Definition is the correct coordinate system necessary
-%           --> either Cartesian or cylindrical coordinates
-% 'Mode':   'Mode', 0 -> read only, if data already exist (default)
-%           'Mode', 1 -> calculate anyway, overwrite existing
-%           'Mode', 2 -> read only, fail if not existing
-% 'Outfile': alternative nf2ff result hdf5 file name
-%            default is: <nf2ff.name>.h5
-% 'Verbose': set verbose level for the nf2ff calculation 0-2 supported
-% 'Radius':  specify the radius for the nf2ff
-% 'Eps_r':   specify the relative electric permittivity for the nf2ff
-% 'Mue_r':   specify the relative magnetic permeability for the nf2ff
+% - 'Center': nf2ff phase center, default is [0 0 0]
+%             !! Make sure the center is never outside of your nf2ff box!!
+%             Definition is the correct coordinate system necessary
+%             --> either Cartesian or cylindrical coordinates
+% - 'Mode':   'Mode', 0 -> read only, if data already exist (default)
+%             'Mode', 1 -> calculate anyway, overwrite existing
+%             'Mode', 2 -> read only, fail if not existing
+% - 'Outfile': alternative nf2ff result hdf5 file name
+%              default is: <nf2ff.name>.h5
+% - 'Verbose': set verbose level for the nf2ff calculation 0-2 supported
+% - 'Radius':  specify the radius for the nf2ff
+% - 'Eps_r':   specify the relative electric permittivity for the nf2ff
+% - 'Mue_r':   specify the relative magnetic permeability for the nf2ff
 %
-% 'Mirror':  Add mirroring in a given direction (dir), with a given 
-%            mirror type (PEC or PMC) and a mirror position in the given
-%            direction.
-%            Example: 'Mirror', {0, 'PMC', +100}
+% - 'Mirror':  Add mirroring in a given direction (dir), with a given 
+%              mirror type (PEC or PMC) and a mirror position in the given
+%              direction.
+%              Example: 'Mirror', {0, 'PMC', +100}
 %
 % See also: CreateNF2FFBox, ReadNF2FF
 %

--- a/matlab/CheckQueue.m
+++ b/matlab/CheckQueue.m
@@ -4,7 +4,7 @@ function [queue running] = CheckQueue(queue, query_time)
 % Check the given queue for finished tasks.
 %
 % Parameter:
-%   query_time (optional): time interval to check for finished tasks
+% - query_time (optional): time interval to check for finished tasks
 %                          (in seconds, default is 5)
 %
 % For more details see: InitQueue

--- a/matlab/ConvertHDF5_VTK.m
+++ b/matlab/ConvertHDF5_VTK.m
@@ -4,22 +4,23 @@ function ConvertHDF5_VTK(hdf_file, vtk_prefix, varargin)
 % Convert openEMS field data stored in the given hdf5 file to a vtk file.
 %
 % arguments:
-%   hdf_file:   source hdf5 file
-%   vtk_prefix: output vtk files prefix
+% - hdf_file:   source hdf5 file
+% - vtk_prefix: output vtk files prefix
 %
 % optional arguments:
-%   'TD_Dump':  activate dump for time-domain data (default is off)
-%   'FD_Dump':  activate dump for frequency-domain data (default is on)
-%   'NumPhase': number of phase to dump frequency domain data animation
+% - 'TD_Dump':  activate dump for time-domain data (default is off)
+% - 'FD_Dump':  activate dump for frequency-domain data (default is on)
+% - 'NumPhase': number of phase to dump frequency domain data animation
 %               (default is 36 --> 10°)
-%   'FieldName': field name written to vtk, e.g. 'E-Field'
-%   'weight':   field weighting
+% - 'FieldName': field name written to vtk, e.g. 'E-Field'
+% - 'weight':   field weighting
 %
 %   for more optional augments have a look at ReadHDF5Dump
 %
 % example:
-%   % read time-domian data from hdf5, perform dft and dump as vtk
-%   ConvertHDF5_VTK('Et.h5','Ef','NumPhase',18,'Frequency',1e9)
+%
+%     % read time-domian data from hdf5, perform dft and dump as vtk
+%     ConvertHDF5_VTK('Et.h5','Ef','NumPhase',18,'Frequency',1e9)
 %
 % openEMS matlab interface
 % -----------------------

--- a/matlab/CreateNF2FFBox.m
+++ b/matlab/CreateNF2FFBox.m
@@ -4,24 +4,24 @@ function [CSX nf2ff] = CreateNF2FFBox(CSX, name, start, stop, varargin)
 % create the dump boxes needed for the near field to far field transformation
 % 
 % input:
-%   name:       name of this nf2ff box
-%   start/stop: start/stop coordinates for the nf2ff box (this box has to
+% - name:       name of this nf2ff box
+% - start/stop: start/stop coordinates for the nf2ff box (this box has to
 %               enclose all radiating structures!)
 % optional inputs:
-%   'Directions': enable/disable specific directions, e.g.
+% - 'Directions': enable/disable specific directions, e.g.
 %                 'Directions',[1 1 0 0 1 1]
 %                   -> disable nf2ff in +/-y direction
-%   'Frequency': dump nf2ff in frequency domain, this will save disk-space
+% - 'Frequency': dump nf2ff in frequency domain, this will save disk-space
 %                but is less flexible, since only this frequencies can be
 %                used for the nf2ff calculations by CalcNF2FF
 %                See also AddDump for more information
-%   'OptResolution': specify a dump resolution, this will save disk-space
+% - 'OptResolution': specify a dump resolution, this will save disk-space
 %                    See also AddDump for more information
 %                    e.g.: 'OptResolution', c0/max_freq/unit/15
 %
 % example:
-%   see Tutorials/Simple_Patch_Antenna.m
-%   see Tutorials/Helical_Antenna.m
+% -  see Tutorials/Simple_Patch_Antenna.m
+% -  see Tutorials/Helical_Antenna.m
 % 
 % See also CalcNF2FF
 %

--- a/matlab/DFT_time2freq.m
+++ b/matlab/DFT_time2freq.m
@@ -4,23 +4,24 @@ function f_val = DFT_time2freq( t, val, freq, signal_type )
 % computes the DFT at the given frequencies
 %
 % parameter:
-% t  : time vector
-% val: data vector
-% freq: DFT frequency vector
-% signal_type: 'pulse' (default), 'periodic'
+% - t  : time vector
+% - val: data vector
+% - freq: DFT frequency vector
+% - signal_type: 'pulse' (default), 'periodic'
 %
 % return values:
-% f_val:  single-sided spectrum
+% - f_val:  single-sided spectrum
 %
 % example:
-%   t=linspace(0,1,100);
-%   t_val=0.9*sin(2*pi*3*t); % sine wave; amplitude 0.9; frequency 3 Hz
-%   f=linspace(1,5,101);
-%   f_val=DFT_time2freq( t, t_val, f, 'periodic' );
-%   interp1(f,abs(f_val),3)
-% ans = 0.8910
-%   plot( t, t_val )
-%   plot( f, abs(f_val) )
+%
+%     t=linspace(0,1,100);
+%     t_val=0.9*sin(2*pi*3*t); % sine wave; amplitude 0.9; frequency 3 Hz
+%     f=linspace(1,5,101);
+%     f_val=DFT_time2freq( t, t_val, f, 'periodic' );
+%     interp1(f,abs(f_val),3)
+%     % ans = 0.8910
+%     plot( t, t_val )
+%     plot( f, abs(f_val) )
 
 if numel(t) ~= numel(val)
     error 'numel(t) ~= numel(val)'

--- a/matlab/DelayFidelity.m
+++ b/matlab/DelayFidelity.m
@@ -8,31 +8,32 @@ function [delay, fidelity, nf2ff_out] = DelayFidelity(nf2ff, port, path, weight_
 % Oversampling is an input parameter to InitFDTD. The rows of delay and fidelity correspond to theta and the columns to phi.
 % 
 % input:
-%   nf2ff: return value of CreateNF2FFBox.
-%   port: return value of AddLumpedPort
-%   path: path of the simulation results.
-%   weight_theta: weight of the E_theta component 
-%   weight_phi: weight of the E_phi component
+% - nf2ff: return value of CreateNF2FFBox.
+% - port: return value of AddLumpedPort
+% - path: path of the simulation results.
+% - weight_theta: weight of the E_theta component 
+% - weight_phi: weight of the E_phi component
 %     -> with both (possibly complex) parameters any polarization can be examined
-%   theta: theta values to be simulated
-%   phi: phi values to be simulated
-%   f_0: center frequency of SetGaussExcite
-%   f_c: cutoff frequency of SetGaussExcite
+% - theta: theta values to be simulated
+% - phi: phi values to be simulated
+% - f_0: center frequency of SetGaussExcite
+% - f_c: cutoff frequency of SetGaussExcite
 %
 % variable input:
-%   'Center': phase center of the antenna for CalcNF2FF
-%   'Radius': radius for CalcNF2FF
-%   'Mode': mode CalcNF2FF
+% - 'Center': phase center of the antenna for CalcNF2FF
+% - 'Radius': radius for CalcNF2FF
+% - 'Mode': mode CalcNF2FF
 %   
 % example:
-%   theta = [-180:10:180] * pi / 180;
-%   phi = [0, 90] * pi / 180;
-%   % use circular right handed polarization
-%   [delay, fidelity] = DelayFidelity2(nf2ff, port, Sim_Path, -1i, 1, theta, phi, f_0, f_c, 'Mode', 1);
-%   figure
-%   polar(theta.', delay(:,1) * 3e11); % delay in mm
-%   figure
-%   polar(theta', (fidelity(:,1)-0.95)/0.05); % last 5 percent of fidelity
+%
+%     theta = [-180:10:180] * pi / 180;
+%     phi = [0, 90] * pi / 180;
+%     % use circular right handed polarization
+%     [delay, fidelity] = DelayFidelity2(nf2ff, port, Sim_Path, -1i, 1, theta, phi, f_0, f_c, 'Mode', 1);
+%     figure
+%     polar(theta.', delay(:,1) * 3e11); % delay in mm
+%     figure
+%     polar(theta', (fidelity(:,1)-0.95)/0.05); % last 5 percent of fidelity
 % 
 % Author: Georg Michel 
 

--- a/matlab/Dump2VTK.m
+++ b/matlab/Dump2VTK.m
@@ -4,8 +4,8 @@ function Dump2VTK(filename, fields, mesh, fieldname, varargin)
 %   Dump fields extracted from an hdf5 file to a vtk file format
 %
 %   possible arguments:
-%       'NativeDump': 0 (default) / 1, dump in native coordinate system
-%       'CloseAlpha': 0 (default) / 1, repeat first/last line in
+%   -   'NativeDump': 0 (default) / 1, dump in native coordinate system
+%   -   'CloseAlpha': 0 (default) / 1, repeat first/last line in
 %                     alpha-direction for a full cylindrical mesh
 %
 %   example:

--- a/matlab/DumpFF2VTK.m
+++ b/matlab/DumpFF2VTK.m
@@ -4,25 +4,26 @@ function DumpFF2VTK(filename, farfield, thetaRange, phiRange, varargin)
 %  Dump 3D far field pattern to a vtk file
 %
 % input:
-%   filename:      filename of VTK file, existing file will be overwritten
-%   farfield:      far field in V/m
-%   thetaRange:    theta range in deg
-%   phiRange:      phi range in deg
+% - filename:      filename of VTK file, existing file will be overwritten
+% - farfield:      far field in V/m
+% - thetaRange:    theta range in deg
+% - phiRange:      phi range in deg
 %
 % variable input:
-%   'scale':       - linear scale of plot, doesn't affect gain values
-%   'logscale':    - if set, show far field with logarithmic scale
-%                  - set the dB value for point of origin
-%                  - values below will be clamped
-%   'maxgain':     - add max gain in dB to normalized far field
-%                  - only valid if logscale is set
-%                  - default is 0dB
+% - 'scale':       linear scale of plot, doesn't affect gain values
+% - 'logscale':    if set, show far field with logarithmic scale
+%                  set the dB value for point of origin
+%                  values below will be clamped
+% - 'maxgain':     add max gain in dB to normalized far field
+%                  only valid if logscale is set
+%                  default is 0dB
 %
-%   example:
-%       DumpFF2VTK(filename, farfield, thetaRange, phiRange, ...
-%                    'scale', 2, 'logscale', -20, 'maxgain', 3)
+% example:
 %
-%       see also examples/NF2FF/infDipol.m
+%      DumpFF2VTK(filename, farfield, thetaRange, phiRange, ...
+%                   'scale', 2, 'logscale', -20, 'maxgain', 3)
+%
+% - see also examples/NF2FF/infDipol.m
 %
 % See also CreateNF2FFBox, CalcNF2FF
 % 

--- a/matlab/FindFreeSSH.m
+++ b/matlab/FindFreeSSH.m
@@ -5,13 +5,13 @@ function host = FindFreeSSH(host_list, Settings, wait_time, command)
 % 
 % internal function used by RunOpenEMS
 % 
-% host_list: give a list of possible host
+% - host_list: give a list of possible host
 % 
-% wait_time: wait x seconds after not finding a free host and rechecking
+% - wait_time: wait x seconds after not finding a free host and rechecking
 %            default: 600 seconds
 % 
-% command: unix command to check for free host (empty result --> free)
-%          default: 'ps -e | grep openEMS'
+% - command: unix command to check for free host (empty result --> free)
+%            default: 'ps -e | grep openEMS'
 %
 % See also RunOpenEMS
 %

--- a/matlab/FinishQueue.m
+++ b/matlab/FinishQueue.m
@@ -4,7 +4,7 @@ function [queue] = FinishQueue(queue, query_time)
 % Wait for the given queue to finish.
 %
 % Parameter:
-%   query_time (optional): time interval to check for finished tasks
+% - query_time (optional): time interval to check for finished tasks
 %                          (in seconds, default is 5)
 %
 % For more details see: InitQueue

--- a/matlab/GetField_Interpolation.m
+++ b/matlab/GetField_Interpolation.m
@@ -1,24 +1,25 @@
 function [field_i mesh_i] = GetField_Interpolation(field, mesh, lines, varargin)
 % [field_i mesh_i] = GetField_Interpolation(field, mesh, lines, varargin)
 %
-%   Get an interpolated field, e.g. read by ReadHDF5Dump 
+% Get an interpolated field, e.g. read by ReadHDF5Dump 
 % 
-%   homogeneous interpolation given by a 3x1 vector: e.g. [21,1,101]
+% homogeneous interpolation given by a 3x1 vector: e.g. [21,1,101]
 % 
-%   arbitrary interpolation on a given mesh:
-%               e.g.:   mesh_interp{1} = linspace(0,  1,101) * 1e-3;
-%                       mesh_interp{2} = linspace(0,0.5, 51) * 1e-3;
-%                       mesh_interp{3} = linspace(0,0.2, 21) * 1e-3;
+% arbitrary interpolation on a given mesh, e.g.:
+%     mesh_interp{1} = linspace(0,  1,101) * 1e-3;
+%     mesh_interp{2} = linspace(0,0.5, 51) * 1e-3;
+%     mesh_interp{3} = linspace(0,0.2, 21) * 1e-3;
 % 
-%   example:
-%   [field mesh] = ReadHDF5Dump('Et.h5');
-%   %interpolate on a mesh with 21x21x101 lines
-%   [field_i mesh_i] = GetField_Interpolation(field, mesh, [21 21 101]);
-%   or
-%   [field_i mesh_i] = GetField_Interpolation(field, mesh, mesh_interp);
-%   
-%   %or both steps in one with the same result:
-%   [field_i mesh_i] = ReadHDF5Dump('Et.h5','Interpolation', [21 21 101]);
+% example:
+%
+%     [field mesh] = ReadHDF5Dump('Et.h5');
+%     %interpolate on a mesh with 21x21x101 lines
+%     [field_i mesh_i] = GetField_Interpolation(field, mesh, [21 21 101]);
+%     or
+%     [field_i mesh_i] = GetField_Interpolation(field, mesh, mesh_interp);
+%     
+%     %or both steps in one with the same result:
+%     [field_i mesh_i] = ReadHDF5Dump('Et.h5','Interpolation', [21 21 101]);
 %
 % openEMS matlab interface
 % -----------------------

--- a/matlab/GetField_Range.m
+++ b/matlab/GetField_Range.m
@@ -1,21 +1,22 @@
 function [field_i mesh_i] = GetField_Range(field, mesh, range)
 % [field_i mesh_i] = GetField_Range(field, mesh, range)
 %
-%   Get a field dump subset within a given mesh range 
+% Get a field dump subset within a given mesh range 
 % 
-%   example:
-%       % specify a mesh range
-%       range{1} = [0 150] * 1e-3;  % x in range 0..150mm
-%       range{2} = [0];             % only one line close to y==0
-%       range{3} = [];              % no range restriction
+% example:
+%
+%      % specify a mesh range
+%      range{1} = [0 150] * 1e-3;  % x in range 0..150mm
+%      range{2} = [0];             % only one line close to y==0
+%      range{3} = [];              % no range restriction
 % 
-%       % read hdf data
-%       [field mesh] = ReadHDF5Dump('Et.h5');
-%       % extract a ranged subset
-%       [field_i mesh_i] = GetField_Range(field, mesh, range);
+%      % read hdf data
+%      [field mesh] = ReadHDF5Dump('Et.h5');
+%      % extract a ranged subset
+%      [field_i mesh_i] = GetField_Range(field, mesh, range);
 %     
-%       %or both steps in one with the same result:
-%       [field_i mesh_i] = ReadHDF5Dump('Et.h5','Range', range);
+%      %or both steps in one with the same result:
+%      [field_i mesh_i] = ReadHDF5Dump('Et.h5','Range', range);
 % 
 % openEMS matlab interface
 % -----------------------

--- a/matlab/GetField_SubSampling.m
+++ b/matlab/GetField_SubSampling.m
@@ -1,9 +1,9 @@
 function [field_i mesh_i] = GetField_SubSampling(field, mesh, subsampling, varargin)
 % [field_i mesh_i] = GetField_SubSampling(field, mesh, subsampling, varargin)
 %
-%   Get a sub-sampled field, e.g. read by ReadHDF5Dump
+% Get a sub-sampled field, e.g. read by ReadHDF5Dump
 %
-%   sub-sampling e.g. skipping every second line in x/r direction: [2 1 1]
+% sub-sampling e.g. skipping every second line in x/r direction: [2 1 1]
 %
 % openEMS matlab interface
 % -----------------------

--- a/matlab/GetField_TD2FD.m
+++ b/matlab/GetField_TD2FD.m
@@ -5,9 +5,10 @@ function field = GetField_TD2FD(field, freq)
 % Auto-corrects the half-timestep offset of the H-field
 % 
 % example:
-%   freq = linspace(0,1e9,100); %target frequency vector (Hz)
-%   field = ReadHDF5FieldData('tmp/Ht.h5');
-%   field_FD = GetField_TD2FD(field, freq);
+%
+%     freq = linspace(0,1e9,100); %target frequency vector (Hz)
+%     field = ReadHDF5FieldData('tmp/Ht.h5');
+%     field_FD = GetField_TD2FD(field, freq);
 %
 % openEMS matlab interface
 % -----------------------

--- a/matlab/InitCylindricalFDTD.m
+++ b/matlab/InitCylindricalFDTD.m
@@ -3,10 +3,15 @@ function FDTD = InitCylindricalFDTD(NrTS, endCrit, varargin)
 %
 % see also InitFDTD
 %
-% e.g FDTD = InitCylindricalFDTD(5e5,1e-6,'OverSampling',10)
+% e.g
+%
+%     FDTD = InitCylindricalFDTD(5e5,1e-6,'OverSampling',10)
 % 
 % WARNING: This function is depreciated, use InitFDTD with 'CoordSystem',1
-%          e.g.: InitFDTD(5e5,1e-6,'OverSampling',10, 'CoordSystem',1)
+%
+% e.g.:
+%
+%     InitFDTD(5e5,1e-6,'OverSampling',10, 'CoordSystem',1)
 %
 % openEMS matlab interface
 % -----------------------

--- a/matlab/InitFDTD.m
+++ b/matlab/InitFDTD.m
@@ -4,30 +4,31 @@ function FDTD = InitFDTD(varargin)
 % Initialize the FDTD data-structure.
 %
 % optional field arguments for usage with openEMS:
-%   NrTS:           max. number of timesteps to simulate (e.g. default=1e9)
-%   EndCriteria:    end criteria, e.g. 1e-5, simulations stops if energy has
+% - NrTS:           max. number of timesteps to simulate (e.g. default=1e9)
+% - EndCriteria:    end criteria, e.g. 1e-5, simulations stops if energy has
 %                   decayed by this value (<1e-4 is recommended, default=1e-5)
-%   MaxTime:        max. real time in seconds to simulate
-%   OverSampling:   nyquist oversampling of time domain dumps
-%   CoordSystem:    choose coordinate system (0 Cartesian, 1 Cylindrical)
-%   MultiGrid:      define a cylindrical sub-grid radius
-%   TimeStep:       force to use a given timestep (dangerous!)
-%   TimeStepFactor: reduce the timestep by a given factor (>0 to <=1)
-%   TimeStepMethod: 1 or 3 chose timestep method (1=CFL, 3=Rennigs (default))
-%   CellConstantMaterial: set to 1 to assume a material is constant inside
+% - MaxTime:        max. real time in seconds to simulate
+% - OverSampling:   nyquist oversampling of time domain dumps
+% - CoordSystem:    choose coordinate system (0 Cartesian, 1 Cylindrical)
+% - MultiGrid:      define a cylindrical sub-grid radius
+% - TimeStep:       force to use a given timestep (dangerous!)
+% - TimeStepFactor: reduce the timestep by a given factor (>0 to <=1)
+% - TimeStepMethod: 1 or 3 chose timestep method (1=CFL, 3=Rennigs (default))
+% - CellConstantMaterial: set to 1 to assume a material is constant inside
 %                         a cell (material probing in cell center)
 %
 % examples:
-%   %default init with 1e9 max. timesteps and -50dB end-criteria
-%   FDTD = InitFDTD();
 %
-%   %init with 1e6 max. timesteps and -60dB end-criteria
-%   FDTD = InitFDTD('NrTS', 1e6, 'EndCriteria', 1e-6);
+%     %default init with 1e9 max. timesteps and -50dB end-criteria
+%     FDTD = InitFDTD();
 %
-%   %cylindrical FDTD simulation
-%   FDTD = InitFDTD('CoordSystem', 1);
+%     %init with 1e6 max. timesteps and -60dB end-criteria
+%     FDTD = InitFDTD('NrTS', 1e6, 'EndCriteria', 1e-6);
 %
-%   See also InitCSX
+%     %cylindrical FDTD simulation
+%     FDTD = InitFDTD('CoordSystem', 1);
+%
+% See also InitCSX
 %
 % openEMS matlab interface
 % -----------------------

--- a/matlab/InitQueue.m
+++ b/matlab/InitQueue.m
@@ -7,9 +7,9 @@ function [queue] = InitQueue(varargin)
 % on multiple remote machines.
 %
 % Options:
-%   DependPath: Add multiple paths, your script may depend on
-%   UseOctave:  Enable/Disable octave usage
-%   MaxThreads: max. number of parallel executions
+% - DependPath: Add multiple paths, your script may depend on
+% - UseOctave:  Enable/Disable octave usage
+% - MaxThreads: max. number of parallel executions
 %
 % Note:
 %   - Currently only Linux/Unix is supported
@@ -21,27 +21,28 @@ function [queue] = InitQueue(varargin)
 %   machines using a SSH.host_list setting --> See also RunOpenEMS
 %
 % Example:
-%   %serial version:
-%   for n=1:10
-%       % manipulate parameter etc.
-%       [result1(n) result2(n)] = Parallel_Func_Name(param1, param2);
-%   end
 %
-%   %parallel version:
-%   queue = InitQueue('DependPath',{'/opt/openEMS/CSXCAD/matlab', ...
-%                                   '/opt/openEMS/openEMS/matlab'});
-%   for n=1:10
-%       % manipulate parameter etc.
-%       queue = Add2Queue(queue, 'Parallel_Func_Name', {param1, param2});
-%   end
+%     %serial version:
+%     for n=1:10
+%         % manipulate parameter etc.
+%         [result1(n) result2(n)] = Parallel_Func_Name(param1, param2);
+%     end
 %
-%   % wait for all to finish
-%   [queue] = FinishQueue(queue);
+%     %parallel version:
+%     queue = InitQueue('DependPath',{'/opt/openEMS/CSXCAD/matlab', ...
+%                                     '/opt/openEMS/openEMS/matlab'});
+%     for n=1:10
+%         % manipulate parameter etc.
+%         queue = Add2Queue(queue, 'Parallel_Func_Name', {param1, param2});
+%     end
 %
-%   % retrieve result
-%   for n=1:numel(stub_sweep)
-%     [result1(n) result2(n)] = ResultsQueue(queue,n);
-%   end
+%     % wait for all to finish
+%     [queue] = FinishQueue(queue);
+%
+%     % retrieve result
+%     for n=1:numel(stub_sweep)
+%       [result1(n) result2(n)] = ResultsQueue(queue,n);
+%     end
 %
 % See also: Add2Queue, FinishQueue, ResultsQueue, RunOpenEMS,
 %           RunOpenEMS_Parallel, FindFreeSSH

--- a/matlab/PlotHDF5FieldData.m
+++ b/matlab/PlotHDF5FieldData.m
@@ -2,12 +2,13 @@ function PlotHDF5FieldData(file, PlotArgs)
 % function PlotHDF5FieldData(file, PlotArgs)
 %
 % e.g.
-% PlotArgs.slice = {0 [10 20] 0};
-% PlotArgs.pauseTime=0.01;
-% PlotArgs.component=2;
-% PlotArgs.Limit = 'auto';
+%
+%     PlotArgs.slice = {0 [10 20] 0};
+%     PlotArgs.pauseTime=0.01;
+%     PlotArgs.component=2;
+%     PlotArgs.Limit = 'auto';
 % 
-% PlotHDF5FieldData('tmp/Et.h5',PlotArgs)
+%     PlotHDF5FieldData('tmp/Et.h5',PlotArgs)
 %
 % openEMS matlab interface
 % -----------------------

--- a/matlab/ReadHDF5Dump.m
+++ b/matlab/ReadHDF5Dump.m
@@ -1,25 +1,27 @@
 function [field mesh] = ReadHDF5Dump(file, varargin)
 %[field mesh] = ReadHDF5Dump(file, varargin)
 %
-%   Read a hdf5 field dump, including an interpolation and frequency domain
-%   transformation.
+% Read a hdf5 field dump, including an interpolation and frequency domain
+% transformation.
 %
-%   For more information about the output, refer to the help of
-%   ReadHDF5Mesh and ReadHDF5FieldData
+% For more information about the output, refer to the help of
+% ReadHDF5Mesh and ReadHDF5FieldData
 %
-%   possible arguments:
-%       'Range'             see GetField_Range
-%       'Interpolation'     see GetField_Interpolation
-%       'SubSampling'       see GetField_SubSampling
-%       'Frequency'         see GetField_TD2FD
-%       'CloseAlpha': 0 (default) / 1
+% possible arguments:
 %
-%   example:
-%   [field mesh] = ReadHDF5Dump('Et.h5');
-%   or
-%   [field mesh] = ReadHDF5Dump('Et.h5','Range',{[0 100],[-20 20],[50 90]});
-%   or
-%   [field mesh] = ReadHDF5Dump('Et.h5','Interpolation',[21 1 101],'Frequency',300e6);
+% - 'Range'             see GetField_Range
+% - 'Interpolation'     see GetField_Interpolation
+% - 'SubSampling'       see GetField_SubSampling
+% - 'Frequency'         see GetField_TD2FD
+% - 'CloseAlpha': 0 (default) / 1
+%
+% example:
+%
+%     [field mesh] = ReadHDF5Dump('Et.h5');
+%     %or
+%     [field mesh] = ReadHDF5Dump('Et.h5','Range',{[0 100],[-20 20],[50 90]});
+%     %or
+%     [field mesh] = ReadHDF5Dump('Et.h5','Interpolation',[21 1 101],'Frequency',300e6);
 %
 % openEMS matlab interface
 % -----------------------

--- a/matlab/ReadHDF5FieldData.m
+++ b/matlab/ReadHDF5FieldData.m
@@ -2,22 +2,24 @@ function hdf_fielddata = ReadHDF5FieldData(file)
 % function hdf_fielddata = ReadHDF5FieldData(file)
 %
 % returns:
-% % time domain data (if exist)
-% hdf_fielddata.TD.time
-% hdf_fielddata.TD.names
-% hdf_fielddata.TD.values
-% hdf_fielddata.TD.DataType (0 --> real value data)
+% - time domain data (if exist)
+%   - hdf_fielddata.TD.time
+%   - hdf_fielddata.TD.names
+%   - hdf_fielddata.TD.values
+%   - hdf_fielddata.TD.DataType (0 --> real value data)
 %
-% % frequency domain data (if exist)
-% hdf_fielddata.FD.frequency
-% hdf_fielddata.FD.values
-% hdf_fielddata.FD.DataType (0 / 1 --> real / complex value data)
+% - frequency domain data (if exist)
+%   - hdf_fielddata.FD.frequency
+%   - hdf_fielddata.FD.values
+%   - hdf_fielddata.FD.DataType (0 / 1 --> real / complex value data)
 %
 % example: values of timestep 12:
-% hdf_fielddata.TD.values{12}: array (x,y,z,polarization)
+%
+%     hdf_fielddata.TD.values{12}: array (x,y,z,polarization)
 %
 % plot z-field component along y-direction for timestep 12:
-% plot( hdf_fielddata.TD.values{12}(1,:,1,3) )
+%
+%     plot( hdf_fielddata.TD.values{12}(1,:,1,3) )
 %
 % openEMS matlab interface
 % -----------------------

--- a/matlab/ReadHDF5Mesh.m
+++ b/matlab/ReadHDF5Mesh.m
@@ -4,9 +4,10 @@ function hdf_mesh = ReadHDF5Mesh(file)
 %   Get the raw mesh data stored in the hdf5 dump file created by openEMS
 %
 % returns:
-% hdf_mesh.type     (0-> Cartesian, 1-> cylindrical mesh type)
-% hdf_mesh.names    (e.g. 'Mesh/y')
-% hdf_mesh.lines    (e.g. [0,1,2,3,4])
+%
+% - hdf_mesh.type     (0-> Cartesian, 1-> cylindrical mesh type)
+% - hdf_mesh.names    (e.g. 'Mesh/y')
+% - hdf_mesh.lines    (e.g. [0,1,2,3,4])
 %
 % openEMS matlab interface
 % -----------------------

--- a/matlab/ReadUI.m
+++ b/matlab/ReadUI.m
@@ -11,19 +11,20 @@ function UI = ReadUI(files, path, freq, varargin)
 %    exp(-j*w*t(1))
 %
 % optional parameter:
-% freq: frequency-domain values will be calculated according to 'freq'
-%       if 'freq' is not given, a (zero padded) FFT will be used
+% - freq: frequency-domain values will be calculated according to 'freq'
+%         if 'freq' is not given, a (zero padded) FFT will be used
 %
 % optional key,value pairs:
-% 'AR'  : auto-regressive model to improve FD accuracy
-%         values: order to use within an AR model or 'auto'
+% - 'AR'  : auto-regressive model to improve FD accuracy
+%           values: order to use within an AR model or 'auto'
 %
-% % examples:
-% U = ReadUI({'ut1_1','ut1_2'},'tmp' );
-% I = ReadUI('it1'            ,'tmp',[0.5e9 1e9 1.5e9]);
-% 
-% % using the auto-regressive model
-% U = ReadUI('port_ut1' , 'tmp', 'AR', 'auto');
+% examples:
+%
+%     U = ReadUI({'ut1_1','ut1_2'},'tmp' );
+%     I = ReadUI('it1'            ,'tmp',[0.5e9 1e9 1.5e9]);
+%     
+%     % using the auto-regressive model
+%     U = ReadUI('port_ut1' , 'tmp', 'AR', 'auto');
 % 
 % openEMS matlab interface
 % -----------------------

--- a/matlab/RunOpenEMS.m
+++ b/matlab/RunOpenEMS.m
@@ -4,60 +4,62 @@ function RunOpenEMS(Sim_Path, Sim_File, opts, Settings)
 % Run an openEMS simulation.
 %
 % arguments:
-% Sim_Path: specify the simulation folder (folder must exist!)
-% Sim_File: xml-filename to simulate, created by WriteOpenEMS
+% _ Sim_Path: specify the simulation folder (folder must exist!)
+% _ Sim_File: xml-filename to simulate, created by WriteOpenEMS
 %
 % optional arguments
 % 
 % opts:  list of openEMS options
-%        possible options:
-%         --disable-dumps      Disable all field dumps for faster simulation
-%         --debug-material     Dump material distribution to a vtk file for debugging
-%         --debug-PEC          Dump metal distribution to a vtk file for debugging
-%         --debug-operator     Dump operator to vtk file for debugging
-%         --debug-boxes        Dump e.g. probe boxes to vtk file for debugging
-%         --debug-CSX          Write CSX geometry file to debugCSX.xml
-%         --engine=<type>      Choose engine type
-%             --engine=fastest         fastest available engine (default)
-%             --engine=basic           basic FDTD engine
-%             --engine=sse             engine using sse vector extensions
-%             --engine=sse-compressed  engine using compressed operator + sse vector extensions
-%             --engine=MPI             engine using compressed operator + sse vector extensions + MPI parallel processing
-%             --engine=multithreaded   engine using compressed operator + sse vector extensions + MPI + multithreading
-%         --numThreads=<n>     Force use n threads for multithreaded engine
-%         --no-simulation      only run preprocessing; do not simulate
-%         --dump-statistics    dump simulation statistics to 'openEMS_run_stats.txt' and 'openEMS_stats.txt'
 %
-%          Additional global arguments
-%         --showProbeDiscretization    Show probe discretization information
-%         --nativeFieldDumps           Dump all fields using the native field components
-%         -v,-vv,-vvv                  Set debug level: 1 to 3
+%     possible options:
+%      --disable-dumps      Disable all field dumps for faster simulation
+%      --debug-material     Dump material distribution to a vtk file for debugging
+%      --debug-PEC          Dump metal distribution to a vtk file for debugging
+%      --debug-operator     Dump operator to vtk file for debugging
+%      --debug-boxes        Dump e.g. probe boxes to vtk file for debugging
+%      --debug-CSX          Write CSX geometry file to debugCSX.xml
+%      --engine=<type>      Choose engine type
+%          --engine=fastest         fastest available engine (default)
+%          --engine=basic           basic FDTD engine
+%          --engine=sse             engine using sse vector extensions
+%          --engine=sse-compressed  engine using compressed operator + sse vector extensions
+%          --engine=MPI             engine using compressed operator + sse vector extensions + MPI parallel processing
+%          --engine=multithreaded   engine using compressed operator + sse vector extensions + MPI + multithreading
+%      --numThreads=<n>     Force use n threads for multithreaded engine
+%      --no-simulation      only run preprocessing; do not simulate
+%      --dump-statistics    dump simulation statistics to 'openEMS_run_stats.txt' and 'openEMS_stats.txt'
+%
+%       Additional global arguments
+%      --showProbeDiscretization    Show probe discretization information
+%      --nativeFieldDumps           Dump all fields using the native field components
+%      -v,-vv,-vvv                  Set debug level: 1 to 3
 %
 %
 % settings: list of Matlab settings
-%       possible settings:
-%           Settings.LogFile = 'openEMS.log'
-%           Settings.Silent  = 0
+% - possible settings:
+%   - Settings.LogFile = 'openEMS.log'
+%   - Settings.Silent  = 0
 %
-%       additional remote simulation settings
-%       Note: ssh only on unix with working ssh client or windows with putty client
-%           openEMS Linux server or Windows with cygwin necessary
-%       Settings.SSH.host = '<hostname or ip>'
-%       Settings.SSH.bin = '<path_to_openEMS>/openEMS.sh'
-%       ssh optional:
-%       Settings.SSH.host_list = {'list','of','hosts'}; %searches for a free host
-%       %on Windows needed additionally
-%       Settings.SSH.Putty.Path = '<path_to>\putty';
-%       Settings.SSH.Putty.Key = '<path_to>\putty_private_key.ppk';
+% - additional remote simulation settings
+%   Note: ssh only on unix with working ssh client or windows with putty client
+%   openEMS Linux server or Windows with cygwin necessary
 %
-%       MPI settings:
-%       Settings.MPI.xxx --> help RunOpenEMS_MPI
-% 
+%   - Settings.SSH.host = '<hostname or ip>'
+%   - Settings.SSH.bin = '<path_to_openEMS>/openEMS.sh'
+% - ssh optional:
+%   - Settings.SSH.host_list = {'list','of','hosts'}; %searches for a free host
+%   - %on Windows needed additionally
+%     Settings.SSH.Putty.Path = '<path_to>\putty';
+%     Settings.SSH.Putty.Key = '<path_to>\putty_private_key.ppk';
+%
+% - MPI settings:
+%   - Settings.MPI.xxx --> help RunOpenEMS_MPI
 %
 % example:
-% %create CSX and FDTD
-% WriteOpenEMS('/tmp/path_to_run_in/myfile.xml', FDTD, CSX)
-% RunOpenEMS('/tmp/path_to_run_in','myfile.xml','-v')
+%
+%     %create CSX and FDTD
+%     WriteOpenEMS('/tmp/path_to_run_in/myfile.xml', FDTD, CSX)
+%     RunOpenEMS('/tmp/path_to_run_in','myfile.xml','-v')
 %
 % See also WriteOpenEMS FindFreeSSH InitCSX InitFDTD RunOpenEMS_MPI
 %

--- a/matlab/RunOpenEMS_MPI.m
+++ b/matlab/RunOpenEMS_MPI.m
@@ -3,14 +3,14 @@ function RunOpenEMS_MPI(Sim_Path, Sim_File, opts, Settings)
 %
 % Run an openEMS simulation with MPI support
 %
-% % mpi binary path on all nodes needed
-% Settings.MPI.Binary = '/opt/openEMS/openEMS';
-% % number of processes to run
-% Settings.MPI.NrProc = 3;
-% % define the mpi hosts :
-% Settings.MPI.Hosts = {'host1','host2','host3'};
+%     % mpi binary path on all nodes needed
+%     Settings.MPI.Binary = '/opt/openEMS/openEMS';
+%     % number of processes to run
+%     Settings.MPI.NrProc = 3;
+%     % define the mpi hosts :
+%     Settings.MPI.Hosts = {'host1','host2','host3'};
 %
-% RunOpenEMS(Sim_Path, Sim_File, NrProc, opts, Settings)
+%     RunOpenEMS(Sim_Path, Sim_File, NrProc, opts, Settings)
 %
 % See also SetupMPI, WriteOpenEMS, RunOpenEMS
 %

--- a/matlab/RunOpenEMS_Parallel.m
+++ b/matlab/RunOpenEMS_Parallel.m
@@ -7,12 +7,12 @@ function [stdout, stderr] = RunOpenEMS_Parallel(Sim_Paths, Sim_Files, opts, Sett
 % This function relies on InitQueue etc.
 % 
 % input:
-%       Sim_Paths:  cell array of paths to simulate by RunOpenEMS
-%       Sim_Files:  filename or cell array of filenames to simulate
-%       opts:       openEMS options. see also RunOpenEMS
-%       Settings:   use the settings to define multiple host for simulation
-%                   e.g.: Settings.SSH.bin ='<path_to_openEMS>/openEMS.sh';
-%                         Settings.SSH.host_list = {'list','of','hosts'};
+% - Sim_Paths:  cell array of paths to simulate by RunOpenEMS
+% - Sim_Files:  filename or cell array of filenames to simulate
+% - opts:       openEMS options. see also RunOpenEMS
+% - Settings:   use the settings to define multiple host for simulation
+%               e.g.: Settings.SSH.bin ='<path_to_openEMS>/openEMS.sh';
+%                     Settings.SSH.host_list = {'list','of','hosts'};
 % 
 % Note: If no SSH host_list is defined, this function will skip the
 %       parallel run and switch back to a default RunOpenEMS!

--- a/matlab/SetBoundaryCond.m
+++ b/matlab/SetBoundaryCond.m
@@ -1,38 +1,47 @@
 function FDTD = SetBoundaryCond(FDTD, BC, varargin)
 % FDTD = SetBoundaryCond(FDTD, BC, varargin)
 %
-% BC = [xmin xmax ymin ymax zmin zmax];
-% or BC = {xmin xmax ymin ymax zmin zmax};
+%     BC = [xmin xmax ymin ymax zmin zmax];
+%
+% or
+%
+%     BC = {xmin xmax ymin ymax zmin zmax};
+%
 % ?min/?max: 
-%   0 = PEC      or  'PEC'
-%   1 = PMC      or  'PMC'
-%   2 = MUR-ABC  or  'MUR'
-%   3 = PML-ABC  or  'PML_x' with pml size x => 4..50
+%
+% - 0 = PEC      or  'PEC'
+% - 1 = PMC      or  'PMC'
+% - 2 = MUR-ABC  or  'MUR'
+% - 3 = PML-ABC  or  'PML_x' with pml size x => 4..50
 % 
 % example:
-% BC = [ 1     1     0     0     2     3     ]  %using numbers or
-% BC = {'PMC' 'PMC' 'PEC' 'PEC' 'MUR' 'PML_8'}  %using equivalent strings
+%
+%     BC = [ 1     1     0     0     2     3     ]  %using numbers or
+%     BC = {'PMC' 'PMC' 'PEC' 'PEC' 'MUR' 'PML_8'}  %using equivalent strings
 %
 % mur-abc definitions
 % define a phase-velocity to be used by the mur-abc
 % useful e.g. for dispersive waveguides
-% FDTD = SetBoundaryCond(FDTD,BC,'MUR_PhaseVelocity',299792457.93272);
+%
+%     FDTD = SetBoundaryCond(FDTD,BC,'MUR_PhaseVelocity',299792457.93272);
 % 
-% 
-% pml definitions
-% 	arguments:  'PML_Grading','gradFunction'
-% 		Define the pml grading grading function.
-% 		Predefined variables in this grading function are:
-% 			D  = depth in the pml in meter
-% 			dl = mesh delta inside the pml in meter
-% 			W  = width (length) of the pml in meter
-% 			N  = number of cells for the pml
-% 			Z  = wave impedance at the current depth and position
+% pml definitions arguments: 
+%   - 'PML_Grading','gradFunction'
+%     - Define the pml grading grading function.
+%   - Predefined variables in this grading function are:
+%     - D  = depth in the pml in meter
+%     - dl = mesh delta inside the pml in meter
+%     - W  = width (length) of the pml in meter
+%     - N  = number of cells for the pml
+%     - Z  = wave impedance at the current depth and position
 % 
 % example: 
-% FDTD = SetBoundaryCond(FDTD,BC); 
+%
+%   FDTD = SetBoundaryCond(FDTD,BC); 
+%
 % or
-% FDTD = SetBoundaryCond(FDTD,BC,'PML_Grading','-log(1e-6)*log(2.5)/(2*dl*pow(2.5,W/dl)-1) * pow(2.5, D/dl) / Z');
+%
+%   FDTD = SetBoundaryCond(FDTD,BC,'PML_Grading','-log(1e-6)*log(2.5)/(2*dl*pow(2.5,W/dl)-1) * pow(2.5, D/dl) / Z');
 %
 % 
 % openEMS matlab interface

--- a/matlab/SetCustomExcite.m
+++ b/matlab/SetCustomExcite.m
@@ -1,15 +1,16 @@
 function FDTD = SetCustomExcite(FDTD,f0,funcStr)
 % function FDTD = SetCustomExcite(FDTD,f0,funcStr)
 %
-% f0 : nyquist rate
-% funcStr : string describing the excitation function e(t)
+% - f0 : nyquist rate
+% - funcStr : string describing the excitation function e(t)
 %
 % see also SetSinusExcite SetGaussExcite
 %
 % e.g for a ramped sinus excite...
-% T = 1/f0;
-% FDTD = SetCustomExcite(FDTD,1e9,..
-% [ '(1-exp(-1*(t/' num2str(T) ')^2) ) * sin(2*pi*' num2str(f0) '*t)' ]);
+%
+%     T = 1/f0;
+%     FDTD = SetCustomExcite(FDTD,1e9,..
+%     [ '(1-exp(-1*(t/' num2str(T) ')^2) ) * sin(2*pi*' num2str(f0) '*t)' ]);
 %
 % openEMS matlab interface
 % -----------------------

--- a/matlab/SetGaussExcite.m
+++ b/matlab/SetGaussExcite.m
@@ -1,12 +1,14 @@
 function FDTD = SetGaussExcite(FDTD,f0,fc)
 % function FDTD = SetGaussExcite(FDTD,f0,fc);
 %
-% f0 : center frequency
-% fc : 20dB cutoff frequency --> bandwidth is 2*fc
+% - f0 : center frequency
+% - fc : 20dB cutoff frequency --> bandwidth is 2*fc
 %
 % see also SetSinusExcite SetCustomExcite
 %
-% e.g FDTD = SetGaussExcite(FDTD,1e9,1e8);
+% e.g
+%
+%     FDTD = SetGaussExcite(FDTD,1e9,1e8);
 %
 % openEMS matlab interface
 % -----------------------

--- a/matlab/SetSinusExcite.m
+++ b/matlab/SetSinusExcite.m
@@ -3,7 +3,9 @@ function FDTD = SetSinusExcite(FDTD,f0)
 %
 % see also SetGaussExcite SetCustomExcite
 %
-% e.g FDTD = SetSinusExcite(FDTD,1e9);
+% e.g
+%
+%     FDTD = SetSinusExcite(FDTD,1e9);
 %
 % openEMS matlab interface
 % -----------------------

--- a/matlab/SetupMPI.m
+++ b/matlab/SetupMPI.m
@@ -1,10 +1,10 @@
 function FDTD = SetupMPI(FDTD, varargin)
 % function FDTD = SetupMPI(FDTD, varargin);
 %
-% % example, split the FDTD mesh in 2 equal parts in x-direction
-% % and split the FDTD mesh in 3 parts in z-direction, split at z=-500 and z=500
-% % this will need a Settings.MPI.NrProc of 2*3=6
-% FDTD = SetupMPI(FDTD,'SplitN_X',2 ,'SplitPos_Z', '-500,500');
+%     % example, split the FDTD mesh in 2 equal parts in x-direction
+%     % and split the FDTD mesh in 3 parts in z-direction, split at z=-500 and z=500
+%     % this will need a Settings.MPI.NrProc of 2*3=6
+%     FDTD = SetupMPI(FDTD,'SplitN_X',2 ,'SplitPos_Z', '-500,500');
 % 
 % See also RunOpenEMS_MPI
 % 

--- a/matlab/WriteHDF5.m
+++ b/matlab/WriteHDF5.m
@@ -2,12 +2,12 @@ function WriteHDF5(filename,hdf_fielddata,hdf_mesh)
 % function WriteHDF5(filename,hdf_fielddata,hdf_mesh)
 %
 % input:
-%   hdf_fielddata.time
-%   hdf_fielddata.names
-%   hdf_fielddata.values
-%   hdf_mesh.type
-%   hdf_mesh.names
-%   hdf_mesh.lines
+% - hdf_fielddata.time
+% - hdf_fielddata.names
+% - hdf_fielddata.values
+% - hdf_mesh.type
+% - hdf_mesh.names
+% - hdf_mesh.lines
 %
 % openEMS matlab interface
 % -----------------------

--- a/matlab/WriteOpenEMS.m
+++ b/matlab/WriteOpenEMS.m
@@ -4,9 +4,10 @@ function WriteOpenEMS(filename, FDTD, CSX)
 % Write the FDTD and CSX structures to a file.
 %
 % example:
-% CSX = InitCSX();
-% FDTD = InitFDTD();
-% WriteOpenEMS('test.xml',FDTD,CSX)
+%
+%     CSX = InitCSX();
+%     FDTD = InitFDTD();
+%     WriteOpenEMS('test.xml',FDTD,CSX)
 %
 % See also InitFDTD InitCSX CSXGeomPlot
 %

--- a/matlab/calcLumpedPort.m
+++ b/matlab/calcLumpedPort.m
@@ -6,30 +6,32 @@ function [port] = calcLumpedPort( port, SimDir, f, varargin)
 % The port has to be created by e.g. AddLumpedPort().
 %
 % input:
-%   port:       return value of e.g. AddMSLPort()
-%   SimDir:     directory, where the simulation files are
-%   f:          frequency vector for DFT
+% - port:       return value of e.g. AddMSLPort()
+% - SimDir:     directory, where the simulation files are
+% - f:          frequency vector for DFT
 %
 % variable input:
-%   'RefImpedance':  - use a given reference impedance to calculate inc and
+% - 'RefImpedance':    use a given reference impedance to calculate inc and
 %                      ref voltages and currents
-%                    - default is given port or calculated line impedance
-%   'SwitchDirection': 0/1, switch assumed direction of propagation
+%                      default is given port or calculated line impedance
+% - 'SwitchDirection': 0/1, switch assumed direction of propagation
 %
 % output:
-%   % output signals/values in time domain (TD):
-%   port.ut.tot     total voltage (time-domain)
-%   port.ut.time    voltage time vector
-%   port.it.tot     total current (time-domain)
-%   port.it.time    current time vector
 %
-%   % output signals/values in frequency domain (FD):
-%   port.f                  the given frequency factor
-%   port.uf.tot/inc/ref     total, incoming and reflected voltage
-%   port.if.tot/inc/ref     total, incoming and reflected current
+% - output signals/values in time domain (TD):
+%   - port.ut.tot:    total voltage (time-domain)
+%   - port.ut.time:   voltage time vector
+%   - port.it.tot:    total current (time-domain)
+%   - port.it.time:   current time vector
+%
+% - output signals/values in frequency domain (FD):
+%   - port.f:                 the given frequency factor
+%   - port.uf.tot/inc/ref:    total, incoming and reflected voltage
+%   - port.if.tot/inc/ref:    total, incoming and reflected current
 %
 % example:
-%   port{1} = calcLumpedPort( port{1}, Sim_Path, f, 'RefImpedance', 50);
+%
+%     port{1} = calcLumpedPort( port{1}, Sim_Path, f, 'RefImpedance', 50);
 %
 % openEMS matlab interface
 % -----------------------

--- a/matlab/calcPort.m
+++ b/matlab/calcPort.m
@@ -8,43 +8,44 @@ function [port] = calcPort( port, SimDir, f, varargin)
 % The port has to be created by e.g. AddMSLPort(), AddLumpedPort() or AddCurvePort
 %
 % input:
-%   port:       return value of AddMSLPort()
-%   SimDir:     directory, where the simulation files are
-%   f:          frequency vector for DFT
+% - port:       return value of AddMSLPort()
+% - SimDir:     directory, where the simulation files are
+% - f:          frequency vector for DFT
 % 
 % variable input:
-%   'RefImpedance':  - use a given reference impedance to calculate inc and
+% - 'RefImpedance':    use a given reference impedance to calculate inc and
 %                      ref voltages and currents
-%                    - default is given port or calculated line impedance
-%   'RefPlaneShift': for transmission lines only, See also calcTLPort for
+%                      default is given port or calculated line impedance
+% - 'RefPlaneShift': for transmission lines only, See also calcTLPort for
 %                    more details
-%   'SwitchDirection': 0/1, switch assumed direction of propagation
-%   'SignalType':    'pulse' (default) or 'periodic'
+% - 'SwitchDirection': 0/1, switch assumed direction of propagation
+% - 'SignalType':    'pulse' (default) or 'periodic'
 %
 % output: 
-%   % output signals/values in time domain (TD):
-%   port.ut.tot     total voltage (time-domain)
-%   port.ut.time    voltage time vector
-%   port.it.tot     total current (time-domain)
-%   port.it.time    current time vector
+%   - output signals/values in time domain (TD):
+%     - port.ut.tot:    total voltage (time-domain)
+%     - port.ut.time:   voltage time vector
+%     - port.it.tot:    total current (time-domain)
+%     - port.it.time:   current time vector
 %
-%   % output signals/values in frequency domain (FD):
-%   port.f                  the given frequency fector
-%   port.uf.tot/inc/ref     total, incoming and reflected voltage
-%   port.if.tot/inc/ref     total, incoming and reflected current
-%   port.ZL_ref             used reference impedance
+%   - output signals/values in frequency domain (FD):
+%     - port.f:                 the given frequency fector
+%     - port.uf.tot/inc/ref:    total, incoming and reflected voltage
+%     - port.if.tot/inc/ref:    total, incoming and reflected current
+%     - port.ZL_ref:            used reference impedance
 %
-%   port.P_inc              incoming power
-%   port.P_ref              reflected power
-%   port.P_acc              accepted power (incoming minus reflected,
-%                           may be negative for passive ports)
+%     - port.P_inc:             incoming power
+%     - port.P_ref:             reflected power
+%     - port.P_acc:             accepted power (incoming minus reflected,
+%                               may be negative for passive ports)
 %
-%   if port is a transmission line port:
-%   port.beta:              propagation constant
-%   port.ZL:                characteristic line impedance
+%   - if port is a transmission line port:
+%     - port.beta:              propagation constant
+%     - port.ZL:                characteristic line impedance
 %
 % example:
-%   port = calcPort(port, Sim_Path, f, 'RefImpedance', 50);
+%
+%     port = calcPort(port, Sim_Path, f, 'RefImpedance', 50);
 %
 % openEMS matlab interface
 % -----------------------

--- a/matlab/calcTLPort.m
+++ b/matlab/calcTLPort.m
@@ -7,40 +7,44 @@ function [port] = calcTLPort( port, SimDir, f, varargin)
 % The port has to be created by e.g. AddMSLPort().
 %
 % input:
-%   port:       return value of e.g. AddMSLPort()
-%   SimDir:     directory, where the simulation files are
-%   f:          frequency vector for DFT
+% - port:       return value of e.g. AddMSLPort()
+% - SimDir:     directory, where the simulation files are
+% - f:          frequency vector for DFT
 %
 % variable input:
-%   'RefImpedance':  - use a given reference impedance to calculate inc and
+% - 'RefImpedance':  - use a given reference impedance to calculate inc and
 %                      ref voltages and currents
 %                    - default is given port or calculated line impedance
-%   'RefPlaneShift': - use a given reference plane shift from port beginning
+% - 'RefPlaneShift': - use a given reference plane shift from port beginning
 %                      for a desired phase correction
 %                    - default is the measurement plane
 %                    - the plane shift has to be given in drawing units!
-%   'SwitchDirection': 0/1, switch assumed direction of propagation
+% - 'SwitchDirection': 0/1, switch assumed direction of propagation
 %
 % output:
-%   % output signals/values in time domain (TD):
-%   port.ut.tot     total voltage (time-domain)
-%   port.ut.time    voltage time vector
-%   port.it.tot     total current (time-domain)
-%   port.it.time    current time vector
 %
-%   % output signals/values in frequency domain (FD):
-%   port.f                  the given frequency fector
-%   port.uf.tot/inc/ref     total, incoming and reflected voltage
-%   port.if.tot/inc/ref     total, incoming and reflected current
-%   port.beta:              propagation constant
-%   port.ZL:                characteristic line impedance
-%   port.ZL_ref             used reference impedance
+% - output signals/values in time domain (TD):
+%   - port.ut.tot     total voltage (time-domain)
+%   - port.ut.time    voltage time vector
+%   - port.it.tot     total current (time-domain)
+%   - port.it.time    current time vector
+%
+% - output signals/values in frequency domain (FD):
+%   - port.f                  the given frequency fector
+%   - port.uf.tot/inc/ref     total, incoming and reflected voltage
+%   - port.if.tot/inc/ref     total, incoming and reflected current
+%   - port.beta:              propagation constant
+%   - port.ZL:                characteristic line impedance
+%   - port.ZL_ref             used reference impedance
 %
 % example:
-%   port{1} = calcTLPort( port{1}, Sim_Path, f, 'RefImpedance', 50);
 %
-% reference: W. K. Gwarek, "A Differential Method of Reflection Coefficient Extraction From FDTD Simulations",
-%            IEEE Microwave and Guided Wave Letters, Vol. 6, No. 5, May 1996
+%     port{1} = calcTLPort( port{1}, Sim_Path, f, 'RefImpedance', 50);
+%
+% reference:
+%
+% = W. K. Gwarek, "A Differential Method of Reflection Coefficient Extraction From FDTD Simulations",
+%   IEEE Microwave and Guided Wave Letters, Vol. 6, No. 5, May 1996
 %
 % openEMS matlab interface
 % -----------------------

--- a/matlab/calcWGPort.m
+++ b/matlab/calcWGPort.m
@@ -7,39 +7,40 @@ function [port] = calcWGPort( port, SimDir, f, varargin)
 % The port has to be created by e.g. AddWaveGuidePort().
 %
 % input:
-%   port:       return value of e.g. AddWaveGuidePort()
-%   SimDir:     directory, where the simulation files are
-%   f:          frequency vector for DFT
+% - port:       return value of e.g. AddWaveGuidePort()
+% - SimDir:     directory, where the simulation files are
+% - f:          frequency vector for DFT
 %
 % variable input:
-%   'RefImpedance':  - use a given reference impedance to calculate inc and
+% - 'RefImpedance':    use a given reference impedance to calculate inc and
 %                      ref voltages and currents
-%                    - default is given port or calculated line impedance
-%   'RefPlaneShift': - use a given reference plane shift from port beginning
+%                      default is given port or calculated line impedance
+% - 'RefPlaneShift':   use a given reference plane shift from port beginning
 %                      for a desired phase correction
-%                    - default is the measurement plane at the end of the
+%                      default is the measurement plane at the end of the
 %                      port
-%                    - the plane shift has to be given in drawing units!
-%   'RefractiveIndex': set a material refractive index
-%   'SwitchDirection': 0/1, switch assumed direction of propagation
+%                      the plane shift has to be given in drawing units!
+% - 'RefractiveIndex': set a material refractive index
+% - 'SwitchDirection': 0/1, switch assumed direction of propagation
 %
 % output:
-%   % output signals/values in time domain (TD):
-%   port.ut.tot     total voltage (time-domain)
-%   port.ut.time    voltage time vector
-%   port.it.tot     total current (time-domain)
-%   port.it.time    current time vector
+%   - output signals/values in time domain (TD):
+%     - port.ut.tot:    total voltage (time-domain)
+%     - port.ut.time:   voltage time vector
+%     - port.it.tot:    total current (time-domain)
+%     - port.it.time:   current time vector
 %
-%   % output signals/values in frequency domain (FD):
-%   port.f                  the given frequency fector
-%   port.uf.tot/inc/ref     total, incoming and reflected voltage
-%   port.if.tot/inc/ref     total, incoming and reflected current
-%   port.beta:              propagation constant
-%   port.ZL:                characteristic line impedance
-%   port.ZL_ref             used reference impedance
+%   - output signals/values in frequency domain (FD):
+%     - port.f:                 the given frequency fector
+%     - port.uf.tot/inc/ref:    total, incoming and reflected voltage
+%     - port.if.tot/inc/ref:    total, incoming and reflected current
+%     - port.beta:              propagation constant
+%     - port.ZL:                characteristic line impedance
+%     - port.ZL_ref:            used reference impedance
 %
 % example:
-%   port{1} = calcWGPort( port{1}, Sim_Path, f, 'RefImpedance', 50);
+%
+%     port{1} = calcWGPort( port{1}, Sim_Path, f, 'RefImpedance', 50);
 %
 % openEMS matlab interface
 % -----------------------

--- a/matlab/calc_ypar.m
+++ b/matlab/calc_ypar.m
@@ -1,10 +1,10 @@
 function Y = calc_ypar( f, ports, Sim_Path_Prefix )
 % Y = calc_ypar( f, ports, Sim_Path_Prefix )
 %
-% f: frequency vector (Hz)
-% ports: cell array of ports (see AddMSLPort() and AddLumpedPort())
-% Sim_Path_Prefix: prefix of the simulation dirs (will be postfixed by
-% excitation port number)
+% - f: frequency vector (Hz)
+% - ports: cell array of ports (see AddMSLPort() and AddLumpedPort())
+% - Sim_Path_Prefix: prefix of the simulation dirs (will be postfixed by
+%   excitation port number)
 %
 % This function calculates the Y-matrix representation of the ports
 %

--- a/matlab/harminv.m
+++ b/matlab/harminv.m
@@ -2,13 +2,15 @@ function [f,decay,Q,amp,phase,err]=harminv( timeseries, timestep, start_freq, st
 % [f,decay,Q,amp,phase,err]=harminv( timeseries, timestep, start_freq, stop_freq )
 %
 % reconstruct time signal with:
-% real(amp(n) * exp(-1i*(2*pi*freq(n)*t-phase(n))-decay(n)*t)));
+%
+%     real(amp(n) * exp(-1i*(2*pi*freq(n)*t-phase(n))-decay(n)*t)));
 %
 % example:
-% t = linspace(0,(1/0.3e9)*5,1000);
-% u =     0.8 * sin(2*pi*0.7e9 * t + 0/180*pi);
-% u = u + 0.3 * sin(2*pi*0.3e9 * t + 0/180*pi);
-% [freq,decay,Q,amp,phase,err]=harminv( u, t(2)-t(1), 0, 1e9 );
+%
+%     t = linspace(0,(1/0.3e9)*5,1000);
+%     u =     0.8 * sin(2*pi*0.7e9 * t + 0/180*pi);
+%     u = u + 0.3 * sin(2*pi*0.3e9 * t + 0/180*pi);
+%     [freq,decay,Q,amp,phase,err]=harminv( u, t(2)-t(1), 0, 1e9 );
 %
 % -----------------------
 % Sebastian Held <sebastian.held@gmx.de>

--- a/matlab/optimize.m
+++ b/matlab/optimize.m
@@ -2,23 +2,23 @@ function [params,result] = optimize( optimdir, params, options, algorithm )
 %params = optimize( optimdir, params, options, algorithm )
 %
 % input:
-%   optimdir:   folder where to optimize
-%   params:     array of structures with parameters to optimize
-%     .name       char string   parameter name (e.g. 'length1')
-%     .value      number  
-%     .step       number        discretization of .value
-%     .range      row vector    range of .value (e.g. [1 10])
-%     .active     (0/1)         1=optimize this parameter
-%   options:    structure
-%     .folder_matlabstart   set the startup folder for matlab or octave
-%     .simfun               char string with the simulation function name
-%     .octave_exe           if this field is present, octave is used
-%     .clean                clean the optimization folder before optimization start
-%   algorithm:  'asco' or 'simplex-downhill'
+% - optimdir:   folder where to optimize
+% - params:     array of structures with parameters to optimize
+%   - .name -     char string - parameter name (e.g. 'length1')
+%   - .value -    number  
+%   - .step -     number      - discretization of .value
+%   - .range -    row vector  - range of .value (e.g. [1 10])
+%   - .active -   (0/1)       - 1=optimize this parameter
+% - options:    structure
+%   - .folder_matlabstart:  set the startup folder for matlab or octave
+%   - .simfun:              char string with the simulation function name
+%   - .octave_exe:          if this field is present, octave is used
+%   - .clean:               clean the optimization folder before optimization start
+% - algorithm:  'asco' or 'simplex-downhill'
 %   
 % output:
-%   params: optimal values
-%   result: optimization criterion for optimal values
+% - params: optimal values
+% - result: optimization criterion for optimal values
 %
 % example:
 %   see openEMS/matlab/examples/optimizer

--- a/matlab/plotFF3D.m
+++ b/matlab/plotFF3D.m
@@ -4,21 +4,22 @@ function h = plotFF3D(nf2ff,varargin)
 %  plot normalized 3D far field pattern
 %
 % input:
-%   nf2ff:      output of CalcNF2FF
+% - nf2ff:      output of CalcNF2FF
 %
 % variable input:
-%   'freq_index':  - use the given frequency index, see nf2ff.freq
-%                  - default is 1
-%   'logscale':    - if set, show far field with logarithmic scale
-%                  - set the dB value for point of origin
-%                  - values below will be clamped
-%   'normalize':   - true/false, normalize linear plot
-%                  - default is false, log-plot is always normalized!
+% - 'freq_index':    use the given frequency index, see nf2ff.freq
+%                    default is 1
+% - 'logscale':      if set, show far field with logarithmic scale
+%                    set the dB value for point of origin
+%                    values below will be clamped
+% - 'normalize':     true/false, normalize linear plot
+%                    default is false, log-plot is always normalized!
 %
-%   example:
-%       plotFF3D(nf2ff, 'freq_index', 2, 'logscale', -20)
+% example:
 %
-%       see examples/antennas/infDipol.m
+%     plotFF3D(nf2ff, 'freq_index', 2, 'logscale', -20)
+%
+% see examples/antennas/infDipol.m
 %
 % See also CalcNF2FF, plotFFdB, polarFF
 % 

--- a/matlab/plotFFdB.m
+++ b/matlab/plotFFdB.m
@@ -4,21 +4,22 @@ function h = plotFFdB(nf2ff,varargin)
 %  plot far field pattern in dBi
 %
 % input:
-%   nf2ff:      output of CalcNF2FF
+% -  nf2ff:      output of CalcNF2FF
 %
 % variable input:
-%   'freq_index':  - use the given frequency index, see nf2ff.freq
-%                  - default is 1
-%   'xaxis':       - 'phi' (default) or 'theta'
-%   'param':       - array positions of parametric plot
-%                  - if xaxis='phi', theta is parameter, and vice versa
-%                  - default is 1
+% -  'freq_index':   use the given frequency index, see nf2ff.freq
+%                    default is 1
+% -  'xaxis':        'phi' (default) or 'theta'
+% -  'param':        array positions of parametric plot
+%                    if xaxis='phi', theta is parameter, and vice versa
+%                    default is 1
 %
-%   example:
-%       plotFFdB(nf2ff, 'freq_index', 2, ...
-%                       'xaxis', 'phi', 'param', [1 46 91])
+% example:
 %
-%       see examples/NF2FF/infDipol.m
+%     plotFFdB(nf2ff, 'freq_index', 2, ...
+%                     'xaxis', 'phi', 'param', [1 46 91])
+%
+% see examples/NF2FF/infDipol.m
 %
 % See also CalcNF2FF, plotFF3D, polarFF
 % 

--- a/matlab/plotRefl.m
+++ b/matlab/plotRefl.m
@@ -8,21 +8,23 @@ function h = plotRefl(port, varargin)
 %  the lowest reflection.
 %
 % input:
-%   port:      port data structure. Call calcPort with an appropriate 
-%              frequency vector before calling this routine
+% -  port:      port data structure. Call calcPort with an appropriate 
+%               frequency vector before calling this routine
 % 
 % output:      graphics handle for further modification of the plot.
 %
 % variable input:
-%   'precision':   - number of decimal places (floating point precision) 
-%                    for the frequency (always in MHz), default is 0
-%   'threshold':   - Threshold value (in dB) for the upper and lower
-%                    cutoff frequency, default is -3
-%   'fmarkers':    - set lower and upper frequency marker in Hz manually, 
+% - 'precision':     number of decimal places (floating point precision) 
+%                     for the frequency (always in MHz), default is 0
+% - 'threshold':     Threshold value (in dB) for the upper and lower
+%                     cutoff frequency, default is -3
+% - 'fmarkers':      set lower and upper frequency marker in Hz manually, 
 %                    like so: [4e9, 6.5e9]
-%   example:
-%       myport = calcPort(myport, Sim_Path, linspace(f_0-f_c, f_0+f_c, 200));
-%       plotRefl(myport, 'fmarkers', [4e9, 6.5e9]);
+%
+% example:
+%
+%     myport = calcPort(myport, Sim_Path, linspace(f_0-f_c, f_0+f_c, 200));
+%     plotRefl(myport, 'fmarkers', [4e9, 6.5e9]);
 %
 % See also calcPort
 % 

--- a/matlab/polarFF.m
+++ b/matlab/polarFF.m
@@ -4,36 +4,37 @@ function h = polarFF(nf2ff,varargin)
 %  plot polar far field pattern
 %
 % input:
-%   nf2ff:      output of CalcNF2FF
+% - nf2ff:      output of CalcNF2FF
 %
 % variable input:
-%   'freq_index':  - use the given frequency index, see nf2ff.freq
-%                  - default is 1
-%   'xaxis':       - 'phi' (default) or 'theta'
-%   'param':       - array positions of parametric plot
-%                  - if xaxis='phi', theta is parameter, and vice versa
-%                  - default is 1
-%   'normalize':   - true/false, normalize linear plot
-%                  - default is false, log-plot is always normalized!
-%   'logscale':    - if set, plot logarithmic polar
-%                  - set the dB value for point of origin if scalar
-%                  - set point of origin and maximum if 2-element array
-%                  - values below minimum will be clamped
-%                  - default is -20
-%   'xtics':       - set the number of tics for polar grid
-%                  - default is 5
+% - 'freq_index':  use the given frequency index, see nf2ff.freq
+%                  default is 1
+% - 'xaxis':       'phi' (default) or 'theta'
+% - 'param':       array positions of parametric plot
+%                  if xaxis='phi', theta is parameter, and vice versa
+%                  default is 1
+% - 'normalize':   true/false, normalize linear plot
+%                  default is false, log-plot is always normalized!
+% - 'logscale':    if set, plot logarithmic polar
+%                  set the dB value for point of origin if scalar
+%                  set point of origin and maximum if 2-element array
+%                  values below minimum will be clamped
+%                  default is -20
+% - 'xtics':       set the number of tics for polar grid
+%                  default is 5
 %
-%   example:
-%       polarFF(nf2ff, 'freq_index', 2, ...
-%                      'xaxis', 'phi', 'param', [1 46 91] );
+% example:
 %
-%       polarFF(..., 'normalize', true );
-%       polarFF(..., 'logscale', -30 );
-%       polarFF(..., 'logscale', [-30 10]);
+%     polarFF(nf2ff, 'freq_index', 2, ...
+%                    'xaxis', 'phi', 'param', [1 46 91] );
 %
-%       polarFF(..., 'xtics', 10);
+%     polarFF(..., 'normalize', true );
+%     polarFF(..., 'logscale', -30 );
+%     polarFF(..., 'logscale', [-30 10]);
 %
-%       see examples/antenna/infDipol.m
+%     polarFF(..., 'xtics', 10);
+%
+% see examples/antenna/infDipol.m
 %
 % See also CalcNF2FF, plotFFdB, plotFF3D
 % 


### PR DESCRIPTION
This commit reformats all docstrings in the Matlab/Octave code as legal Markdown text, which can be used for automatic generation of online documentation, while still being human-readable as plaintext.

This Pull Request should be merged together with https://github.com/thliebig/openEMS-Project/pull/311 for consistency. 