### PR TITLE
Add missed macOS fix: nf2ff/CMakeLists.txt: use 3.0...3.10 as minimum version.

### DIFF
--- a/nf2ff/CMakeLists.txt
+++ b/nf2ff/CMakeLists.txt
@@ -7,7 +7,11 @@ ELSE()
 ENDIF()
 
 PROJECT(nf2ff CXX)
-cmake_minimum_required(VERSION 2.8)
+
+# In CMake 4, 3.10 is deprecated and 3.5 has been removed.
+# use 3.0...3.10 so all of these versions are acceptable as min. version.
+# https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html
+cmake_minimum_required(VERSION 3.0...3.10)
 
 set(LIB_VERSION_MAJOR 0)
 set(LIB_VERSION_MINOR 1)


### PR DESCRIPTION
In CMake 4, 3.10 is deprecated and 3.5 has been removed. Use 3.0...3.10 so all of these versions are acceptable as minimum version. This fix is identical to the previous Pull Request (PR #183), but with the missing fix for nf2ff sub-project added. This problem was not detected earlier on macOS because it already failed at the `fparser` step. Once `fparser` has been fixed, this problem became exposed.