### PR TITLE
CMakeLists.txt: check "system" only if Boost <= 1.68

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,13 +122,17 @@ INCLUDE_DIRECTORIES (${HDF5_INCLUDE_DIRS})
 # boost
 find_package(Boost 1.46 COMPONENTS
   thread
-  system
   date_time
   serialization
   chrono
   program_options
   REQUIRED
 )
+if (${Boost_MINOR_VERSION} LESS 69)
+    # Since Boost 1.69, "system" is header only, so a check
+    # is needed only in Boost 1.68 and earlier.
+    find_package(Boost 1.46 COMPONENTS system REQUIRED)
+endif()
 message(STATUS "Boost_INCLUDE_DIRS: ${Boost_INCLUDE_DIRS}")
 message(STATUS "Boost_LIBRARIES: ${Boost_LIBRARIES}")
 INCLUDE_DIRECTORIES (${Boost_INCLUDE_DIRS})


### PR DESCRIPTION
Since Boost 1.69, "system" is header only, so a check is needed only in Boost 1.68 and earlier. Since Boost 1.89, the "system" library is completely dropped, so it must not be checked due to the following error:

    CMake Error at /opt/homebrew/lib/cmake/Boost-1.89.0/BoostConfig.cmake:141 (find_package):
      Could not find a package configuration file provided by "boost_system"
      (requested version 1.89.0) with any of the following names:

        boost_systemConfig.cmake
        boost_system-config.cmake

See: https://github.com/boostorg/system/issues/132/