### PR TITLE
Revert "CI: remove non working oldoldstable debian"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,11 @@ jobs:
             ancient: true
             docker-image: "ubuntu:14.04"
 
+          - name: "Debian oldoldstable"
+            libc: "GNU"
+            ancient: false
+            docker-image: "debian:oldoldstable"
+
           - name: "Debian oldstable"
             libc: "GNU"
             ancient: false


### PR DESCRIPTION
This reverts commit 76c61e73cb11dff1ddba4ef12186e265a58cc8ab.

In this case, the oldoldstable Debian was broken because the old Debian repo URL went offline, and the Docker image ceased to function. Now, it automatically works again without any changes on our side, so clearly the maintainer of that Docker image has already performed the necessary fixes. We need to do nothing, simply to re-enable the oldoldstable target.