### PR TITLE
NF2FF Directivity calculation seems wrong when radius != 1

### DIFF
--- a/nf2ff/nf2ff_calc.cpp
+++ b/nf2ff/nf2ff_calc.cpp
@@ -522,7 +522,9 @@ bool nf2ff_calc::AddSinglePlane(float **lines, unsigned int* numLines, complex<f
 	delete[] edge_length_PP; edge_length_PP=NULL;
 	delete[] thread_data; thread_data=NULL;
 
-	m_maxDir = 4*M_PI*P_max / m_radPower;
+	// Maximum directivity (unitless) across sampled angles theta and phi
+	// P_max (W/m^2), m_radPower (W), m_radius (m)
+	m_maxDir = P_max * (4*M_PI * m_radius*m_radius / m_radPower);
 
 	return true;
 }


### PR DESCRIPTION
When I set radius>1 when calling CalcNF2FF() from Python, Dmax ends up being lower than expected. I expected Dmax to be independent of radius.

This fix includes a radius^2 factor in the calculation of m_maxDir.

This radius^2 factor was once included in the P_max calculation but was removed because it didn't belong there. I think putting it in m_maxDir will complete the fix.