### PR TITLE
Fix Python RectWGPort excitation for TE01, TE11, TE12, etc

### DIFF
--- a/python/openEMS/ports.py
+++ b/python/openEMS/ports.py
@@ -438,14 +438,8 @@ class RectWGPort(WaveguidePort):
         b = self.WG_size[1]
 
         xyz = 'xyz'
-        if self.start[self.ny_P]!=0:
-            name_P = '({}-{})'.format(xyz[self.ny_P], self.start[self.ny_P])
-        else:
-            name_P = xyz[self.ny_P]
-        if self.start[self.ny_PP]!=0:
-            name_PP = '({}-{})'.format(xyz[self.ny_P], self.start[self.ny_P])
-        else:
-            name_PP = xyz[self.ny_P]
+        name_P = '({}-{})'.format(xyz[self.ny_P], self.start[self.ny_P])
+        name_PP = '({}-{})'.format(xyz[self.ny_PP], self.start[self.ny_PP])
 
         kc = np.sqrt((self.M*np.pi/a)**2 + (self.N*np.pi/b)**2)
 


### PR DESCRIPTION
There's a small typo where `self.ny_P` should be `self.ny_PP` in:
`name_PP = '({}-{})'.format(xyz[self.ny_P], self.start[self.ny_P])`

The problem doesn't show up in the tutorial as it excites TE10, but I was able to produce the problem and test the fix by specifying TE11 and increasing the height of the tutorial waveguide the mode is not cutoff (otherwise the analytic impedance calculation fails).

I removed the if/else. I think it's unnecessary as long as we're okay with the equation `(x - 0.0)` instead of simply `x`. I noticed the MATLAB version doesn't have this code.