### PR TITLE
FDTD: remove "using namespace std" from global headers

### DIFF
--- a/Common/processcurrent.cpp
+++ b/Common/processcurrent.cpp
@@ -20,6 +20,9 @@
 #include "FDTD/engine_interface_fdtd.h"
 #include <iomanip>
 
+using std::cerr;
+using std::endl;
+
 ProcessCurrent::ProcessCurrent(Engine_Interface_Base* eng_if) : ProcessIntegral(eng_if)
 {
 	m_SnapMethod=1;
@@ -29,7 +32,7 @@ ProcessCurrent::~ProcessCurrent()
 {
 }
 
-string ProcessCurrent::GetIntegralName(int row) const
+std::string ProcessCurrent::GetIntegralName(int row) const
 {
 	if (row==0)
 		return "current";

--- a/Common/processfields.cpp
+++ b/Common/processfields.cpp
@@ -22,6 +22,9 @@
 #include "processfields.h"
 #include "FDTD/engine_interface_fdtd.h"
 
+using std::cerr;
+using std::endl;
+
 ProcessFields::ProcessFields(Engine_Interface_Base* eng_if) : Processing(eng_if)
 {
 	m_DumpType = E_FIELD_DUMP;
@@ -59,7 +62,7 @@ ProcessFields::~ProcessFields()
 	}
 }
 
-string ProcessFields::GetFieldNameByType(DumpType type)
+std::string ProcessFields::GetFieldNameByType(DumpType type)
 {
 	switch (type)
 	{
@@ -219,7 +222,7 @@ void ProcessFields::CalcMeshPos()
 {
 	if ((m_SampleType==SUBSAMPLE) || (m_SampleType==NONE))
 	{
-		vector<unsigned int> tmp_pos;
+		std::vector<unsigned int> tmp_pos;
 
 		for (int n=0; n<3; ++n)
 		{
@@ -242,7 +245,7 @@ void ProcessFields::CalcMeshPos()
 	}
 	if ((m_SampleType==OPT_RESOLUTION))
 	{
-		vector<unsigned int> tmp_pos;
+		std::vector<unsigned int> tmp_pos;
 		double oldPos=0;
 		for (int n=0; n<3; ++n)
 		{

--- a/FDTD/engine.cpp
+++ b/FDTD/engine.cpp
@@ -19,6 +19,9 @@
 #include "extensions/engine_extension.h"
 #include "extensions/operator_extension.h"
 
+using std::cout;
+using std::endl;
+
 //! \brief construct an Engine instance
 //! it's the responsibility of the caller to free the returned pointer
 Engine* Engine::New(const Operator* op)

--- a/FDTD/engine.h
+++ b/FDTD/engine.h
@@ -138,7 +138,7 @@ protected:
 
 	virtual void InitExtensions();
 	virtual void ClearExtensions();
-	vector<Engine_Extension*> m_Eng_exts;
+	std::vector<Engine_Extension*> m_Eng_exts;
 
 	friend class NS_Engine_Multithread::thread; // evil hack to access numTS from multithreading context
 };

--- a/FDTD/engine_cylinder.cpp
+++ b/FDTD/engine_cylinder.cpp
@@ -17,6 +17,9 @@
 
 #include "engine_cylinder.h"
 
+using std::cout;
+using std::endl;
+
 Engine_Cylinder::Engine_Cylinder(const Operator_Cylinder* op) : Engine_Multithread(op)
 {
 	m_Op_Cyl = op;

--- a/FDTD/engine_cylindermultigrid.cpp
+++ b/FDTD/engine_cylindermultigrid.cpp
@@ -19,6 +19,9 @@
 #include "operator_cylindermultigrid.h"
 #include "extensions/engine_ext_cylindermultigrid.h"
 
+using std::cout;
+using std::endl;
+
 Engine_CylinderMultiGrid* Engine_CylinderMultiGrid::New(const Operator_CylinderMultiGrid* op, unsigned int numThreads)
 {
 	cout << "Create FDTD engine (cylindrical multi grid mesh using sse compression + multithreading)" << endl;

--- a/FDTD/engine_interface_cylindrical_fdtd.cpp
+++ b/FDTD/engine_interface_cylindrical_fdtd.cpp
@@ -17,6 +17,9 @@
 
 #include "engine_interface_cylindrical_fdtd.h"
 
+using std::cerr;
+using std::endl;
+
 Engine_Interface_Cylindrical_FDTD::Engine_Interface_Cylindrical_FDTD(Operator_sse* op) : Engine_Interface_SSE_FDTD(op)
 {
 	m_Op_Cyl = dynamic_cast<Operator_Cylinder*>(op);

--- a/FDTD/engine_interface_fdtd.cpp
+++ b/FDTD/engine_interface_fdtd.cpp
@@ -17,6 +17,9 @@
 
 #include "engine_interface_fdtd.h"
 
+using std::cerr;
+using std::endl;
+
 Engine_Interface_FDTD::Engine_Interface_FDTD(Operator* op) : Engine_Interface_Base(op)
 {
 	if (op==NULL)

--- a/FDTD/engine_interface_sse_fdtd.cpp
+++ b/FDTD/engine_interface_sse_fdtd.cpp
@@ -17,6 +17,9 @@
 
 #include "engine_interface_sse_fdtd.h"
 
+using std::cerr;
+using std::endl;
+
 Engine_Interface_SSE_FDTD::Engine_Interface_SSE_FDTD(Operator_sse* op) : Engine_Interface_FDTD(op)
 {
 	m_Op_SSE = op;

--- a/FDTD/engine_multithread.cpp
+++ b/FDTD/engine_multithread.cpp
@@ -33,6 +33,9 @@
 #include "boost/date_time/gregorian/gregorian.hpp"
 #include <iomanip>
 
+using std::cout;
+using std::endl;
+
 //! \brief construct an Engine_Multithread instance
 //! it's the responsibility of the caller to free the returned pointer
 Engine_Multithread* Engine_Multithread::New(const Operator_Multithread* op, unsigned int numThreads)
@@ -152,8 +155,8 @@ void Engine_Multithread::changeNumThreads(unsigned int numThreads)
 	if (g_settings.GetVerboseLevel()>0)
 		cout << "Multithreaded engine using " << m_numThreads << " threads. Utilization: (";
 
-	vector<unsigned int> m_Start_Lines;
-	vector<unsigned int> m_Stop_Lines;
+	std::vector<unsigned int> m_Start_Lines;
+	std::vector<unsigned int> m_Stop_Lines;
 	m_Op_MT->CalcStartStopLines( m_numThreads, m_Start_Lines, m_Stop_Lines );
 
 	if (m_IterateBarrier!=0)

--- a/FDTD/engine_sse.cpp
+++ b/FDTD/engine_sse.cpp
@@ -18,6 +18,9 @@
 #include "engine_sse.h"
 #include "tools/denormal.h"
 
+using std::cout;
+using std::endl;
+
 //! \brief construct an Engine_sse instance
 //! it's the responsibility of the caller to free the returned pointer
 Engine_sse* Engine_sse::New(const Operator_sse* op)

--- a/FDTD/engine_sse_compressed.cpp
+++ b/FDTD/engine_sse_compressed.cpp
@@ -28,6 +28,9 @@
 #include <emmintrin.h>
 #endif
 
+using std::cout;
+using std::endl;
+
 Engine_SSE_Compressed* Engine_SSE_Compressed::New(const Operator_SSE_Compressed* op)
 {
 	cout << "Create FDTD engine (compressed SSE)" << endl;

--- a/FDTD/extensions/engine_ext_absorbing_bc.cpp
+++ b/FDTD/extensions/engine_ext_absorbing_bc.cpp
@@ -232,7 +232,10 @@ void Engine_Ext_Absorbing_BC::DoPreCurrentUpdatesImpl(EngType* eng, int threadID
 		return;
 
 	// For magnetic field, -1, due to dual grid
-	unsigned int numLines_1 = min((m_threadStartLine.at(threadID) + m_linesPerThread.at(threadID)),m_numLines[0] - 1);
+	unsigned int numLines_1 = std::min(
+		m_threadStartLine.at(threadID) + m_linesPerThread.at(threadID),
+		m_numLines[0] - 1
+	);
 	unsigned int numLine_0 = m_threadStartLine.at(threadID);
 
 	pos[m_ny] = m_pos_ny0_I;
@@ -287,7 +290,10 @@ void Engine_Ext_Absorbing_BC::DoPostCurrentUpdatesImpl(EngType* eng, int threadI
 		return;
 
 	// For magnetic field, -1, due to dual grid
-	unsigned int numLine_1 = min<unsigned int>((m_threadStartLine.at(threadID) + m_linesPerThread.at(threadID)),m_numLines[0] - 1);
+	unsigned int numLine_1 = std::min<unsigned int>(
+		m_threadStartLine.at(threadID) + m_linesPerThread.at(threadID),
+		m_numLines[0] - 1
+	);
 	unsigned int numLine_0 = m_threadStartLine.at(threadID);
 
 	pos_shift[m_ny] = m_pos_ny0_shift_I;
@@ -329,7 +335,10 @@ void Engine_Ext_Absorbing_BC::Apply2CurrentImpl(EngType* eng, int threadID)
 		return;
 
 	// For magnetic field, -1, due to dual grid
-	unsigned int numLine_1 = min<unsigned int>((m_threadStartLine.at(threadID) + m_linesPerThread.at(threadID)),m_numLines[0] - 1);
+	unsigned int numLine_1 = std::min<unsigned int>(
+		m_threadStartLine.at(threadID) + m_linesPerThread.at(threadID),
+		m_numLines[0] - 1
+	);
 	unsigned int numLine_0 = m_threadStartLine.at(threadID);
 
 	pos[m_ny] = m_pos_ny0_I;

--- a/FDTD/extensions/engine_ext_absorbing_bc.h
+++ b/FDTD/extensions/engine_ext_absorbing_bc.h
@@ -86,8 +86,8 @@ protected:
 
 	int				m_ABCtype;					// Declared as integer here, because of the forward declaration formatting.
 
-	vector<unsigned int>	m_threadStartLine;
-	vector<unsigned int>	m_linesPerThread;
+	std::vector<unsigned int>	m_threadStartLine;
+	std::vector<unsigned int>	m_linesPerThread;
 
 	ArrayLib::ArrayIJ<FDTD_FLOAT>&	m_K1_nyP;	// Copy of first set of coefficients, direction n + 1
 	ArrayLib::ArrayIJ<FDTD_FLOAT>&	m_K1_nyPP;	// Copy of second set of coefficients, direction n + 2

--- a/FDTD/extensions/engine_ext_cylindermultigrid.cpp
+++ b/FDTD/extensions/engine_ext_cylindermultigrid.cpp
@@ -19,6 +19,9 @@
 #include "engine_ext_cylindermultigrid.h"
 #include "FDTD/engine_cylindermultigrid.h"
 
+using std::cerr;
+using std::endl;
+
 Engine_Ext_CylinderMultiGrid::Engine_Ext_CylinderMultiGrid(Operator_Extension* op_ext, bool isBase) : Engine_Extension(op_ext)
 {
 	m_IsBase = isBase;

--- a/FDTD/extensions/engine_ext_mur_abc.cpp
+++ b/FDTD/extensions/engine_ext_mur_abc.cpp
@@ -22,6 +22,9 @@
 #include "tools/useful.h"
 #include "operator_ext_excitation.h"
 
+using std::cerr;
+using std::endl;
+
 Engine_Ext_Mur_ABC::Engine_Ext_Mur_ABC(Operator_Ext_Mur_ABC* op_ext) :
 	Engine_Extension(op_ext),
 	m_Mur_Coeff_nyP (op_ext->m_Mur_Coeff_nyP),

--- a/FDTD/extensions/engine_ext_mur_abc.h
+++ b/FDTD/extensions/engine_ext_mur_abc.h
@@ -62,8 +62,8 @@ protected:
 	int m_LineNr_Shift;
 	unsigned int m_numLines[2];
 
-	vector<unsigned int> m_start;
-	vector<unsigned int> m_numX;
+	std::vector<unsigned int> m_start;
+	std::vector<unsigned int> m_numX;
 
 	ArrayLib::ArrayIJ<FDTD_FLOAT>& m_Mur_Coeff_nyP;
 	ArrayLib::ArrayIJ<FDTD_FLOAT>& m_Mur_Coeff_nyPP;

--- a/FDTD/extensions/engine_ext_steadystate.cpp
+++ b/FDTD/extensions/engine_ext_steadystate.cpp
@@ -87,14 +87,14 @@ void Engine_Ext_SteadyState::Apply2Voltages()
 				curr_pow[n] += buf[nt+new_pos]*buf[nt+new_pos];
 				diff_pow[n] += (buf[nt+old_pos]-buf[nt+new_pos])*(buf[nt+old_pos]-buf[nt+new_pos]);
 			}
-			max_pow = max(max_pow, curr_pow[n]);
+			max_pow = std::max(max_pow, curr_pow[n]);
 		}
 		for (size_t n=0;n<m_E_records.size();++n)
 		{
 			//cerr << "curr_pow: " << curr_pow[n] <<  " diff_pow: " << diff_pow[n] << " diff: " << diff_pow[n]/curr_pow[n] << endl;
 			if (curr_pow[n]>max_pow*1e-2)
 			{
-				m_last_max_diff = max(m_last_max_diff, diff_pow[n]/curr_pow[n]);
+				m_last_max_diff = std::max(m_last_max_diff, diff_pow[n]/curr_pow[n]);
 				//cerr << m_last_max_diff << endl;
 				no_valid = false;
 			}

--- a/FDTD/extensions/engine_ext_steadystate.h
+++ b/FDTD/extensions/engine_ext_steadystate.h
@@ -40,8 +40,8 @@ public:
 protected:
 	Operator_Ext_SteadyState* m_Op_SS;
 	double m_last_max_diff;
-	vector<double*> m_E_records;
-	vector<double*> m_H_records;
+	std::vector<double*> m_E_records;
+	std::vector<double*> m_H_records;
 
 	double last_total_energy;
 	Engine_Interface_FDTD* m_Eng_Interface;

--- a/FDTD/extensions/engine_ext_upml.h
+++ b/FDTD/extensions/engine_ext_upml.h
@@ -58,8 +58,8 @@ protected:
 
 	Operator_Ext_UPML* m_Op_UPML;
 
-	vector<unsigned int> m_start;
-	vector<unsigned int> m_numX;
+	std::vector<unsigned int> m_start;
+	std::vector<unsigned int> m_numX;
 
 	ArrayLib::ArrayNIJK<FDTD_FLOAT> volt_flux;
 	ArrayLib::ArrayNIJK<FDTD_FLOAT> curr_flux;

--- a/FDTD/extensions/engine_extension.cpp
+++ b/FDTD/extensions/engine_extension.cpp
@@ -39,7 +39,7 @@ void Engine_Extension::SetNumberOfThreads(int nrThread)
 	m_NrThreads=nrThread;
 }
 
-string Engine_Extension::GetExtensionName() const
+std::string Engine_Extension::GetExtensionName() const
 {
 	if (m_Op_ext)
 		return m_Op_ext->GetExtensionName();

--- a/FDTD/extensions/operator_ext_absorbing_bc.cpp
+++ b/FDTD/extensions/operator_ext_absorbing_bc.cpp
@@ -22,6 +22,9 @@
 
 #include "CSPrimBox.h"
 
+using std::cerr;
+using std::endl;
+
 Operator_Ext_Absorbing_BC::Operator_Ext_Absorbing_BC(Operator* op) : Operator_Extension(op)
 {
 	Initialize();
@@ -257,7 +260,7 @@ Engine_Extension* Operator_Ext_Absorbing_BC::CreateEngineExtention()
 	return eng_ext;
 }
 
-void Operator_Ext_Absorbing_BC::ShowStat(ostream &ostr) const
+void Operator_Ext_Absorbing_BC::ShowStat(std::ostream &ostr) const
 {
 	Operator_Extension::ShowStat(ostr);
 

--- a/FDTD/extensions/operator_ext_absorbing_bc.h
+++ b/FDTD/extensions/operator_ext_absorbing_bc.h
@@ -64,9 +64,12 @@ public:
 
 	//virtual bool IsMPISave() const {return true;}
 
-	virtual string GetExtensionName() const {return string("Local absorbing boundary condition sheet");}
+	virtual std::string GetExtensionName() const
+	{
+		return std::string("Local absorbing boundary condition sheet");
+	}
 
-	virtual void ShowStat(ostream &ostr) const;
+	virtual void ShowStat(std::ostream &ostr) const;
 
 	//! Initialize all parameters, so the extension can be built later
 	virtual bool SetInitParams(CSPrimitives* prim, CSPropAbsorbingBC* abc_prop);

--- a/FDTD/extensions/operator_ext_conductingsheet.cpp
+++ b/FDTD/extensions/operator_ext_conductingsheet.cpp
@@ -22,6 +22,9 @@
 
 #include "CSPropConductingSheet.h"
 
+using std::cerr;
+using std::endl;
+
 Operator_Ext_ConductingSheet::Operator_Ext_ConductingSheet(Operator* op, double f_max) : Operator_Ext_LorentzMaterial(op)
 {
 	m_f_max = f_max;
@@ -47,7 +50,7 @@ bool Operator_Ext_ConductingSheet::BuildExtension()
 	unsigned int numLines[3] = {m_Op->GetNumberOfLines(0,true),m_Op->GetNumberOfLines(1,true),m_Op->GetNumberOfLines(2,true)};
 
 	m_Order = 0;
-	vector<unsigned int> v_pos[3];
+	std::vector<unsigned int> v_pos[3];
 	int ****tanDir = Create_N_3DArray<int>(numLines);
 	float ****Conductivity = Create_N_3DArray<float>(numLines);
 	float ****Thickness = Create_N_3DArray<float>(numLines);
@@ -61,7 +64,11 @@ bool Operator_Ext_ConductingSheet::BuildExtension()
 	{
 		for (pos[1]=0; pos[1]<numLines[1]; ++pos[1])
 		{
-			vector<CSPrimitives*> vPrims = m_Op->GetPrimitivesBoundBox(pos[0], pos[1], -1, (CSProperties::PropertyType)(CSProperties::MATERIAL | CSProperties::METAL));
+			std::vector<CSPrimitives*> vPrims = m_Op->GetPrimitivesBoundBox(
+				pos[0], pos[1], -1,
+				(CSProperties::PropertyType)(CSProperties::MATERIAL | CSProperties::METAL)
+			);
+
 			for (pos[2]=0; pos[2]<numLines[2]; ++pos[2])
 			{
 				b_pos_on = false;

--- a/FDTD/extensions/operator_ext_conductingsheet.h
+++ b/FDTD/extensions/operator_ext_conductingsheet.h
@@ -40,7 +40,10 @@ public:
 	virtual bool IsCylindricalMultiGridSave(bool child) const {UNUSED(child); return true;}
 	virtual bool IsMPISave() const {return true;}
 
-	virtual string GetExtensionName() const {return string("Conducting Sheet Extension");}
+	virtual std::string GetExtensionName() const
+	{
+		return std::string("Conducting Sheet Extension");
+	}
 
 protected:
 	//! Copy constructor

--- a/FDTD/extensions/operator_ext_cylinder.cpp
+++ b/FDTD/extensions/operator_ext_cylinder.cpp
@@ -19,6 +19,9 @@
 #include "FDTD/operator_cylinder.h"
 #include "engine_ext_cylinder.h"
 
+using std::cerr;
+using std::endl;
+
 Operator_Ext_Cylinder::Operator_Ext_Cylinder(Operator_Cylinder* op) : Operator_Extension(op)
 {
 	m_Op_Cyl = op;
@@ -58,12 +61,20 @@ bool Operator_Ext_Cylinder::BuildExtension()
 	double inEC[4];
 	double dT = m_Op->GetTimestep();
 	pos[0]=0;
-	vector<CSPrimitives*> vPrims_metal = m_Op->GetPrimitivesBoundBox(pos[0], -1, -1, (CSProperties::PropertyType)(CSProperties::MATERIAL | CSProperties::METAL));
+	std::vector<CSPrimitives*> vPrims_metal = m_Op->GetPrimitivesBoundBox(
+		pos[0], -1, -1,
+		(CSProperties::PropertyType)(CSProperties::MATERIAL | CSProperties::METAL)
+	);
+
 	for (pos[2]=0; pos[2]<m_Op->GetNumberOfLines(2,true); ++pos[2])
 	{
 		double C=0;
 		double G=0;
-		vector<CSPrimitives*> vPrims_mat   = m_Op->GetPrimitivesBoundBox(pos[0], -1, pos[2], CSProperties::MATERIAL);
+		std::vector<CSPrimitives*> vPrims_mat = m_Op->GetPrimitivesBoundBox(
+			pos[0], -1, pos[2],
+			CSProperties::MATERIAL
+		);
+
 		for (pos[1]=0; pos[1]<m_Op->GetNumberOfLines(1,true)-2; ++pos[1])
 		{
 			m_Op_Cyl->Calc_ECPos(2,pos,inEC,vPrims_mat);
@@ -105,10 +116,10 @@ Engine_Extension* Operator_Ext_Cylinder::CreateEngineExtention()
 }
 
 
-void Operator_Ext_Cylinder::ShowStat(ostream &ostr)  const
+void Operator_Ext_Cylinder::ShowStat(std::ostream &ostr)  const
 {
 	Operator_Extension::ShowStat(ostr);
-	string On_Off[2] = {"Off", "On"};
+	std::string On_Off[2] = {"Off", "On"};
 	ostr << " Zeroth Radius\t\t: "   << On_Off[CC_R0_included] << endl;
 	ostr << " Closed Rotation\t: " << On_Off[CC_closedAlpha] << endl;
 }

--- a/FDTD/extensions/operator_ext_cylinder.h
+++ b/FDTD/extensions/operator_ext_cylinder.h
@@ -41,9 +41,12 @@ public:
 	// FIXME, this extension is not save or unknown to be save to use with MPI
 	virtual bool IsMPISave() const {return false;}
 
-	virtual std::string GetExtensionName() const {return std::string("Extension for the Cylinder-Coords Operator");}
+	virtual std::string GetExtensionName() const
+	{
+		return std::string("Extension for the Cylinder-Coords Operator");
+	}
 
-	virtual void ShowStat(ostream &ostr) const;
+	virtual void ShowStat(std::ostream &ostr) const;
 
 protected:
 	Operator_Cylinder* m_Op_Cyl;

--- a/FDTD/extensions/operator_ext_dispersive.h
+++ b/FDTD/extensions/operator_ext_dispersive.h
@@ -31,7 +31,10 @@ public:
 
 	virtual int GetDispersionOrder() {return m_Order;}
 
-	virtual std::string GetExtensionName() const {return std::string("Dispersive Material Abstract Base class");}
+	virtual std::string GetExtensionName() const
+	{
+		return std::string("Dispersive Material Abstract Base class");
+	}
 
 	virtual void ShowStat(std::ostream &ostr) const;
 

--- a/FDTD/extensions/operator_ext_excitation.cpp
+++ b/FDTD/extensions/operator_ext_excitation.cpp
@@ -23,6 +23,10 @@
 #include "CSPrimCurve.h"
 #include "CSPropExcitation.h"
 
+using std::cout;
+using std::cerr;
+using std::endl;
+
 Operator_Ext_Excitation::Operator_Ext_Excitation(Operator* op) : Operator_Extension(op)
 {
 	Init();
@@ -113,19 +117,19 @@ bool Operator_Ext_Excitation::BuildExtension()
 	unsigned int pos[3];
 	double amp=0;
 
-	vector<unsigned int> volt_vIndex[3];
-	vector<FDTD_FLOAT> volt_vExcit;
-	vector<unsigned int> volt_vDelay;
-	vector<unsigned int> volt_vDir;
+	std::vector<unsigned int> volt_vIndex[3];
+	std::vector<FDTD_FLOAT> volt_vExcit;
+	std::vector<unsigned int> volt_vDelay;
+	std::vector<unsigned int> volt_vDir;
 	double volt_coord[3];
 
-	vector<unsigned int> curr_vIndex[3];
-	vector<FDTD_FLOAT> curr_vExcit;
-	vector<unsigned int> curr_vDelay;
-	vector<unsigned int> curr_vDir;
+	std::vector<unsigned int> curr_vIndex[3];
+	std::vector<FDTD_FLOAT> curr_vExcit;
+	std::vector<unsigned int> curr_vDelay;
+	std::vector<unsigned int> curr_vDir;
 	double curr_coord[3];
 
-	vector<CSProperties*> vec_prop = CSX->GetPropertyByType(CSProperties::EXCITATION);
+	std::vector<CSProperties*> vec_prop = CSX->GetPropertyByType(CSProperties::EXCITATION);
 
 	if (vec_prop.size()==0)
 	{
@@ -141,7 +145,11 @@ bool Operator_Ext_Excitation::BuildExtension()
 	{
 		for (pos[1]=0; pos[1]<numLines[1]; ++pos[1])
 		{
-			vector<CSPrimitives*> vPrims = m_Op->GetPrimitivesBoundBox(-1, pos[1], pos[2], CSProperties::EXCITATION);
+			std::vector<CSPrimitives*> vPrims = m_Op->GetPrimitivesBoundBox(
+				-1, pos[1], pos[2],
+				CSProperties::EXCITATION
+			);
+
 			for (pos[0]=0; pos[0]<numLines[0]; ++pos[0])
 			{
 				//electric field excite
@@ -288,8 +296,12 @@ bool Operator_Ext_Excitation::BuildExtension()
 	return true;
 }
 
-void Operator_Ext_Excitation::setupVoltageExcitation( vector<unsigned int> const volt_vIndex[3], vector<FDTD_FLOAT> const& volt_vExcit,
-		vector<unsigned int> const& volt_vDelay, vector<unsigned int> const& volt_vDir )
+void Operator_Ext_Excitation::setupVoltageExcitation(
+	std::vector<unsigned int> const volt_vIndex[3],
+	std::vector<FDTD_FLOAT> const& volt_vExcit,
+	std::vector<unsigned int> const& volt_vDelay,
+	std::vector<unsigned int> const& volt_vDir
+)
 {
 	Volt_Count = volt_vIndex[0].size();
 	for (int n=0; n<3; n++)
@@ -320,8 +332,12 @@ void Operator_Ext_Excitation::setupVoltageExcitation( vector<unsigned int> const
 	}
 }
 
-void Operator_Ext_Excitation::setupCurrentExcitation( vector<unsigned int> const curr_vIndex[3], vector<FDTD_FLOAT> const& curr_vExcit,
-		vector<unsigned int> const& curr_vDelay, vector<unsigned int> const& curr_vDir )
+void Operator_Ext_Excitation::setupCurrentExcitation(
+	std::vector<unsigned int> const curr_vIndex[3],
+	std::vector<FDTD_FLOAT> const& curr_vExcit,
+	std::vector<unsigned int> const& curr_vDelay,
+	std::vector<unsigned int> const& curr_vDir
+)
 {
 	Curr_Count = curr_vIndex[0].size();
 	for (int n=0; n<3; n++)
@@ -358,7 +374,7 @@ Engine_Extension* Operator_Ext_Excitation::CreateEngineExtention()
 	return new Engine_Ext_Excitation(this);
 }
 
-void Operator_Ext_Excitation::ShowStat(ostream &ostr)  const
+void Operator_Ext_Excitation::ShowStat(std::ostream &ostr)  const
 {
 	Operator_Extension::ShowStat(ostr);
 	cout << "Voltage excitations\t: " << Volt_Count    << "\t (" << Volt_Count_Dir[0] << ", " << Volt_Count_Dir[1] << ", " << Volt_Count_Dir[2] << ")" << endl;

--- a/FDTD/extensions/operator_ext_excitation.h
+++ b/FDTD/extensions/operator_ext_excitation.h
@@ -42,9 +42,12 @@ public:
 	virtual bool IsCylindricalMultiGridSave(bool child) const {UNUSED(child); return true;}
 	virtual bool IsMPISave() const {return true;}
 
-	virtual string GetExtensionName() const {return string("Excitation Extension");}
+	virtual std::string GetExtensionName() const
+	{
+		return std::string("Excitation Extension");
+	}
 
-	virtual void ShowStat(ostream &ostr) const;
+	virtual void ShowStat(std::ostream &ostr) const;
 
 	virtual void Init();
 	virtual void Reset();
@@ -60,10 +63,20 @@ protected:
 
 	Excitation* m_Exc;
 
-	void setupVoltageExcitation( vector<unsigned int> const volt_vIndex[3], vector<FDTD_FLOAT> const& volt_vExcit,
-								 vector<unsigned int> const& volt_vDelay, vector<unsigned int> const& volt_vDir );
-	void setupCurrentExcitation( vector<unsigned int> const curr_vIndex[3], vector<FDTD_FLOAT> const& curr_vExcit,
-								 vector<unsigned int> const& curr_vDelay, vector<unsigned int> const& curr_vDir );
+	void setupVoltageExcitation(
+		std::vector<unsigned int> const volt_vIndex[3],
+		std::vector<FDTD_FLOAT> const& volt_vExcit,
+		std::vector<unsigned int> const& volt_vDelay,
+		std::vector<unsigned int> const& volt_vDir
+	);
+
+	void setupCurrentExcitation(
+		std::vector<unsigned int> const curr_vIndex[3],
+		std::vector<FDTD_FLOAT> const& curr_vExcit,
+		std::vector<unsigned int> const& curr_vDelay,
+		std::vector<unsigned int> const& curr_vDir
+	);
+
 	//E-Field/voltage Excitation
 	unsigned int Volt_Count;
 	unsigned int Volt_Count_Dir[3];

--- a/FDTD/extensions/operator_ext_lorentzmaterial.cpp
+++ b/FDTD/extensions/operator_ext_lorentzmaterial.cpp
@@ -23,6 +23,9 @@
 #include "CSPropLorentzMaterial.h"
 #include "CSPropDebyeMaterial.h"
 
+using std::cerr;
+using std::endl;
+
 Operator_Ext_LorentzMaterial::Operator_Ext_LorentzMaterial(Operator* op) : Operator_Ext_Dispersive(op)
 {
 	v_int_ADE = NULL;
@@ -128,26 +131,26 @@ bool Operator_Ext_LorentzMaterial::BuildExtension()
 	bool warn_once = true;
 
 	bool b_pos_on;
-	vector<unsigned int> v_pos[3];
+	std::vector<unsigned int> v_pos[3];
 
 	// drude material parameter
 	double w_plasma,t_relax;
 	double L_D[3], C_D[3];
 	double R_D[3], G_D[3];
-	vector<double> v_int[3];
-	vector<double> v_ext[3];
-	vector<double> i_int[3];
-	vector<double> i_ext[3];
+	std::vector<double> v_int[3];
+	std::vector<double> v_ext[3];
+	std::vector<double> i_int[3];
+	std::vector<double> i_ext[3];
 
 	//additional Dorentz material parameter
 	double w_Lor_Pol;
 	double C_L[3];
 	double L_L[3];
-	vector<double> v_Lor[3];
-	vector<double> i_Lor[3];
+	std::vector<double> v_Lor[3];
+	std::vector<double> i_Lor[3];
 
 	m_Order = 0;
-	vector<CSProperties*> LD_props = m_Op->CSX->GetPropertyByType(CSProperties::LORENTZMATERIAL);
+	std::vector<CSProperties*> LD_props = m_Op->CSX->GetPropertyByType(CSProperties::LORENTZMATERIAL);
 	for (size_t n=0;n<LD_props.size();++n)
 	{
 		CSPropLorentzMaterial* LorMat = dynamic_cast<CSPropLorentzMaterial*>(LD_props.at(n));
@@ -206,7 +209,11 @@ bool Operator_Ext_LorentzMaterial::BuildExtension()
 		{
 			for (pos[1]=0; pos[1]<numLines[1]; ++pos[1])
 			{
-				vector<CSPrimitives*> vPrims = m_Op->GetPrimitivesBoundBox(pos[0], pos[1], -1, (CSProperties::PropertyType)(CSProperties::MATERIAL | CSProperties::METAL));
+				std::vector<CSPrimitives*> vPrims = m_Op->GetPrimitivesBoundBox(
+					pos[0], pos[1], -1,
+					(CSProperties::PropertyType)(CSProperties::MATERIAL | CSProperties::METAL)
+				);
+
 				for (pos[2]=0; pos[2]<numLines[2]; ++pos[2])
 				{
 					unsigned int index = m_Op->MainOp->SetPos(pos[0],pos[1],pos[2]);
@@ -445,10 +452,10 @@ Engine_Extension* Operator_Ext_LorentzMaterial::CreateEngineExtention()
 	return eng_ext_lor;
 }
 
-void Operator_Ext_LorentzMaterial::ShowStat(ostream &ostr)  const
+void Operator_Ext_LorentzMaterial::ShowStat(std::ostream &ostr)  const
 {
 	Operator_Extension::ShowStat(ostr);
-	string On_Off[2] = {"Off", "On"};
+	std::string On_Off[2] = {"Off", "On"};
 	ostr << " Max. Dispersion Order N = " << m_Order << endl;
 	for (int i=0;i<m_Order;++i)
 	{

--- a/FDTD/extensions/operator_ext_lorentzmaterial.h
+++ b/FDTD/extensions/operator_ext_lorentzmaterial.h
@@ -38,9 +38,12 @@ public:
 	virtual bool IsCylindricalMultiGridSave(bool child) const {UNUSED(child); return true;}
 	virtual bool IsMPISave() const {return true;}
 
-	virtual string GetExtensionName() const {return string("Drude/Lorentz Dispersive Material Extension");}
+	virtual std::string GetExtensionName() const
+	{
+		return std::string("Drude/Lorentz Dispersive Material Extension");
+	}
 
-	virtual void ShowStat(ostream &ostr) const;
+	virtual void ShowStat(std::ostream &ostr) const;
 
 protected:
 	//! Copy constructor

--- a/FDTD/extensions/operator_ext_lumpedRLC.cpp
+++ b/FDTD/extensions/operator_ext_lumpedRLC.cpp
@@ -29,6 +29,9 @@
 
 #define COPY_V2A(V,A) std::copy(V.begin(),V.end(),A)
 
+using std::cerr;
+using std::endl;
+
 Operator_Ext_LumpedRLC::Operator_Ext_LumpedRLC(Operator* op) : Operator_Extension(op)
 {
 	// Parallel circuit coefficients
@@ -118,25 +121,25 @@ bool Operator_Ext_LumpedRLC::BuildExtension()
 
 	unsigned int 	pos[] = {0,0,0};
 
-	vector<CSProperties*> cs_props;
+	std::vector<CSProperties*> cs_props;
 
 	int 			dir;
 	CSPropLumpedElement::LEtype lumpedType;
 
-	vector<unsigned int> 	v_pos[3];
+	std::vector<unsigned int> 	v_pos[3];
 
-	vector<int>		v_dir;
+	std::vector<int>		v_dir;
 
-	vector<double>  v_ilv;
-	vector<double>	v_i2v;
+	std::vector<double>  v_ilv;
+	std::vector<double>	v_i2v;
 
-	vector<double>	v_vv2;
-	vector<double>	v_vj1;
-	vector<double>	v_vj2;
-	vector<double>	v_vvd;
-	vector<double>	v_ib0;
-	vector<double>	v_b1;
-	vector<double>	v_b2;
+	std::vector<double>	v_vv2;
+	std::vector<double>	v_vj1;
+	std::vector<double>	v_vj2;
+	std::vector<double>	v_vvd;
+	std::vector<double>	v_ib0;
+	std::vector<double>	v_b1;
+	std::vector<double>	v_b2;
 
 	// Lumped RLC parameters
 	double R, L, C;
@@ -242,7 +245,7 @@ bool Operator_Ext_LumpedRLC::BuildExtension()
 
 		// Now iterate through primitive(s). I still think there should be only one per-
 		// material definition, but maybe I'm wrong...
-		vector<CSPrimitives*> cs_RLC_prims = cs_RLC_props->GetAllPrimitives();
+		std::vector<CSPrimitives*> cs_RLC_prims = cs_RLC_props->GetAllPrimitives();
 
 		for (size_t boxIdx = 0 ; boxIdx < cs_RLC_prims.size() ; ++boxIdx)
 		{
@@ -360,7 +363,7 @@ bool Operator_Ext_LumpedRLC::BuildExtension()
 									if (dC == 0)
 									{
 										double Cd = m_Op->EC_C[dir][iPos];
-										Zmin = max(dR,2*PI*fMax*dL);
+										Zmin = std::max(dR,2*PI*fMax*dL);
 										Zcd_min = 1.0/(2.0*PI*fMax*Cd);
 
 										// Check if the "parasitic" capcitance is not small enough
@@ -534,10 +537,10 @@ Engine_Extension* Operator_Ext_LumpedRLC::CreateEngineExtention()
 	return eng_ext_RLC;
 }
 
-void Operator_Ext_LumpedRLC::ShowStat(ostream &ostr)  const
+void Operator_Ext_LumpedRLC::ShowStat(std::ostream &ostr)  const
 {
 	Operator_Extension::ShowStat(ostr);
-	string On_Off[2] = {"Off", "On"};
+	std::string On_Off[2] = {"Off", "On"};
 
 	ostr << "Active cells\t\t: " << RLC_count << endl;
 }

--- a/FDTD/extensions/operator_ext_lumpedRLC.h
+++ b/FDTD/extensions/operator_ext_lumpedRLC.h
@@ -46,9 +46,12 @@ public:
 	virtual bool IsCylindricalMultiGridSave(bool child) const {UNUSED(child); return true;}
 	virtual bool IsMPISave() const {return true;}
 
-	virtual string GetExtensionName() const {return string("Series\\Parallel Lumped RLC load");}
+	virtual std::string GetExtensionName() const
+	{
+		return std::string("Series\\Parallel Lumped RLC load");
+	}
 
-	virtual void ShowStat(ostream &ostr) const;
+	virtual void ShowStat(std::ostream &ostr) const;
 
 	virtual bool IsLElumpedRLC(const CSPropLumpedElement* const p_prop);
 

--- a/FDTD/extensions/operator_ext_mur_abc.cpp
+++ b/FDTD/extensions/operator_ext_mur_abc.cpp
@@ -20,6 +20,9 @@
 
 #include "CSPropMaterial.h"
 
+using std::cerr;
+using std::endl;
+
 Operator_Ext_Mur_ABC::Operator_Ext_Mur_ABC(Operator* op) : Operator_Extension(op)
 {
 	Initialize();
@@ -134,7 +137,11 @@ bool Operator_Ext_Mur_ABC::BuildExtension()
 	for (pos[m_nyP]=0; pos[m_nyP]<m_numLines[0]; ++pos[m_nyP])
 	{
 		posBB[m_nyP]=pos[m_nyP];
-		vector<CSPrimitives*> vPrims = m_Op->GetPrimitivesBoundBox(posBB[0], posBB[1], posBB[2], CSProperties::MATERIAL);
+		std::vector<CSPrimitives*> vPrims = m_Op->GetPrimitivesBoundBox(
+			posBB[0], posBB[1], posBB[2],
+			CSProperties::MATERIAL
+		);
+
 		coord[m_nyP] = m_Op->GetDiscLine(m_nyP,pos[m_nyP]);
 		for (pos[m_nyPP]=0; pos[m_nyPP]<m_numLines[1]; ++pos[m_nyPP])
 		{
@@ -187,10 +194,10 @@ Engine_Extension* Operator_Ext_Mur_ABC::CreateEngineExtention()
 }
 
 
-void Operator_Ext_Mur_ABC::ShowStat(ostream &ostr)  const
+void Operator_Ext_Mur_ABC::ShowStat(std::ostream &ostr)  const
 {
 	Operator_Extension::ShowStat(ostr);
-	string XYZ[3] = {"x","y","z"};
+	std::string XYZ[3] = {"x","y","z"};
 	ostr << " Active direction\t: " << XYZ[m_ny] << " at line: " << m_LineNr << endl;
 	if (m_v_phase>0.0)
 		ostr << " Used phase velocity\t: " << m_v_phase << " (" << m_v_phase/__C0__ << " * c_0)" <<endl;

--- a/FDTD/extensions/operator_ext_mur_abc.h
+++ b/FDTD/extensions/operator_ext_mur_abc.h
@@ -55,9 +55,12 @@ public:
 	virtual bool IsCylindricalMultiGridSave(bool child) const;
 	virtual bool IsMPISave() const {return true;}
 
-	virtual string GetExtensionName() const {return string("Mur ABC Extension");}
+	virtual std::string GetExtensionName() const
+	{
+		return std::string("Mur ABC Extension");
+	}
 
-	virtual void ShowStat(ostream &ostr) const;
+	virtual void ShowStat(std::ostream &ostr) const;
 
 protected:
 	Operator_Ext_Mur_ABC(Operator* op, Operator_Ext_Mur_ABC* op_ext);

--- a/FDTD/extensions/operator_ext_steadystate.cpp
+++ b/FDTD/extensions/operator_ext_steadystate.cpp
@@ -18,6 +18,9 @@
 #include "operator_ext_steadystate.h"
 #include "engine_ext_steadystate.h"
 
+using std::cout;
+using std::endl;
+
 Operator_Ext_SteadyState::Operator_Ext_SteadyState(Operator* op, double period): Operator_Extension(op)
 {
 	this->Reset();
@@ -94,7 +97,7 @@ Engine_Extension* Operator_Ext_SteadyState::CreateEngineExtention()
 	return m_Eng_Ext;
 }
 
-void Operator_Ext_SteadyState::ShowStat(ostream &ostr)  const
+void Operator_Ext_SteadyState::ShowStat(std::ostream &ostr)  const
 {
 	Operator_Extension::ShowStat(ostr);
 	cout << "Period time (s): "  << m_T_period << "\t Period TS: " << m_TS_period << endl;

--- a/FDTD/extensions/operator_ext_steadystate.h
+++ b/FDTD/extensions/operator_ext_steadystate.h
@@ -39,9 +39,12 @@ public:
 	virtual bool IsCylindricalMultiGridSave(bool child) const {UNUSED(child); return true;}
 	virtual bool IsMPISave() const {return true;}
 
-	virtual string GetExtensionName() const {return string("Steady-State Detection Extension");}
+	virtual std::string GetExtensionName() const
+	{
+		return std::string("Steady-State Detection Extension");
+	}
 
-	virtual void ShowStat(ostream &ostr) const;
+	virtual void ShowStat(std::ostream &ostr) const;
 
 	virtual void Reset();
 
@@ -52,10 +55,10 @@ protected:
 	Operator_Ext_SteadyState(Operator* op, Operator_Ext_SteadyState* op_ext);
 	double m_T_period;
 	unsigned int m_TS_period;
-	vector<unsigned int> m_E_probe_pos[3];
-	vector<unsigned int> m_E_probe_dir;
-	vector<unsigned int> m_H_probe_pos[3];
-	vector<unsigned int> m_H_probe_dir;
+	std::vector<unsigned int> m_E_probe_pos[3];
+	std::vector<unsigned int> m_E_probe_dir;
+	std::vector<unsigned int> m_H_probe_pos[3];
+	std::vector<unsigned int> m_H_probe_dir;
 };
 
 #endif // OPERATOR_EXT_STEADYSTATE_H

--- a/FDTD/extensions/operator_ext_tfsf.cpp
+++ b/FDTD/extensions/operator_ext_tfsf.cpp
@@ -22,6 +22,10 @@
 #include "CSPrimBox.h"
 #include "CSPropExcitation.h"
 
+using std::cout;
+using std::cerr;
+using std::endl;
+
 Operator_Ext_TFSF::Operator_Ext_TFSF(Operator* op) : Operator_Extension(op)
 {
 	Init();
@@ -91,7 +95,7 @@ bool Operator_Ext_TFSF::BuildExtension()
 	Reset();
 	ContinuousStructure* CSX = m_Op->GetGeometryCSX();
 
-	vector<CSProperties*> vec_prop = CSX->GetPropertyByType(CSProperties::EXCITATION);
+	std::vector<CSProperties*> vec_prop = CSX->GetPropertyByType(CSProperties::EXCITATION);
 
 	if (vec_prop.size()==0)
 	{
@@ -267,7 +271,7 @@ bool Operator_Ext_TFSF::BuildExtension()
 						m_Op->GetYeeCoords(nP,pos,coord,false);
 						dist = fabs((coord[0]-origin[0])*m_PropDir[0])+fabs((coord[1]-origin[1])*m_PropDir[1])+fabs((coord[2]-origin[2])*m_PropDir[2]);
 						delay = dist*unit/m_PhVel/dT;
-						m_maxDelay = max((unsigned int)delay,m_maxDelay);
+						m_maxDelay = std::max((unsigned int)delay,m_maxDelay);
 						m_CurrDelay[n][0][1][ui_pos] = floor(delay);
 						m_CurrDelayDelta[n][0][1][ui_pos] = delay - floor(delay);
 						m_CurrAmp[n][0][1][ui_pos] = m_E_Amp[nP]*m_Op->GetEdgeLength(nP,pos);
@@ -275,7 +279,7 @@ bool Operator_Ext_TFSF::BuildExtension()
 						m_Op->GetYeeCoords(nPP,pos,coord,false);
 						dist = fabs((coord[0]-origin[0])*m_PropDir[0])+fabs((coord[1]-origin[1])*m_PropDir[1])+fabs((coord[2]-origin[2])*m_PropDir[2]);
 						delay = dist*unit/m_PhVel/dT;
-						m_maxDelay = max((unsigned int)delay,m_maxDelay);
+						m_maxDelay = std::max((unsigned int)delay,m_maxDelay);
 						m_CurrDelay[n][0][0][ui_pos] = floor(delay);
 						m_CurrDelayDelta[n][0][0][ui_pos] = delay - floor(delay);
 						m_CurrAmp[n][0][0][ui_pos] = m_E_Amp[nPP]*m_Op->GetEdgeLength(nPP,pos);
@@ -291,7 +295,7 @@ bool Operator_Ext_TFSF::BuildExtension()
 						m_Op->GetYeeCoords(nP,pos,coord,false);
 						dist = fabs((coord[0]-origin[0])*m_PropDir[0])+fabs((coord[1]-origin[1])*m_PropDir[1])+fabs((coord[2]-origin[2])*m_PropDir[2]);
 						delay = dist*unit/m_PhVel/dT;
-						m_maxDelay = max((unsigned int)delay,m_maxDelay);
+						m_maxDelay = std::max((unsigned int)delay,m_maxDelay);
 						m_CurrDelay[n][1][1][ui_pos] = floor(delay);
 						m_CurrDelayDelta[n][1][1][ui_pos] = delay - floor(delay);
 						m_CurrAmp[n][1][1][ui_pos] = m_E_Amp[nP]*m_Op->GetEdgeLength(nP,pos);
@@ -299,7 +303,7 @@ bool Operator_Ext_TFSF::BuildExtension()
 						m_Op->GetYeeCoords(nPP,pos,coord,false);
 						dist = fabs((coord[0]-origin[0])*m_PropDir[0])+fabs((coord[1]-origin[1])*m_PropDir[1])+fabs((coord[2]-origin[2])*m_PropDir[2]);
 						delay = dist*unit/m_PhVel/dT;
-						m_maxDelay = max((unsigned int)delay,m_maxDelay);
+						m_maxDelay = std::max((unsigned int)delay,m_maxDelay);
 						m_CurrDelay[n][1][0][ui_pos] = floor(delay);
 						m_CurrDelayDelta[n][1][0][ui_pos] = delay - floor(delay);
 						m_CurrAmp[n][1][0][ui_pos] = m_E_Amp[nPP]*m_Op->GetEdgeLength(nPP,pos);
@@ -335,7 +339,7 @@ bool Operator_Ext_TFSF::BuildExtension()
 						m_Op->GetYeeCoords(nP,pos,coord,true);
 						dist = fabs((coord[0]-origin[0])*m_PropDir[0])+fabs((coord[1]-origin[1])*m_PropDir[1])+fabs((coord[2]-origin[2])*m_PropDir[2]);
 						delay = dist*unit/m_PhVel/dT + 1.0;
-						m_maxDelay = max((unsigned int)delay,m_maxDelay);
+						m_maxDelay = std::max((unsigned int)delay,m_maxDelay);
 						m_VoltDelay[n][0][1][ui_pos] = floor(delay);
 						m_VoltDelayDelta[n][0][1][ui_pos] = delay - floor(delay);
 						m_VoltAmp[n][0][1][ui_pos] = m_H_Amp[nP]*m_Op->GetEdgeLength(nP,pos,true);
@@ -343,7 +347,7 @@ bool Operator_Ext_TFSF::BuildExtension()
 						m_Op->GetYeeCoords(nPP,pos,coord,true);
 						dist = fabs((coord[0]-origin[0])*m_PropDir[0])+fabs((coord[1]-origin[1])*m_PropDir[1])+fabs((coord[2]-origin[2])*m_PropDir[2]);
 						delay = dist*unit/m_PhVel/dT + 1.0;
-						m_maxDelay = max((unsigned int)delay,m_maxDelay);
+						m_maxDelay = std::max((unsigned int)delay,m_maxDelay);
 						m_VoltDelay[n][0][0][ui_pos] = floor(delay);
 						m_VoltDelayDelta[n][0][0][ui_pos] = delay - floor(delay);
 						m_VoltAmp[n][0][0][ui_pos] = m_H_Amp[nPP]*m_Op->GetEdgeLength(nPP,pos,true);
@@ -359,7 +363,7 @@ bool Operator_Ext_TFSF::BuildExtension()
 						m_Op->GetYeeCoords(nP,pos,coord,true);
 						dist = fabs((coord[0]-origin[0])*m_PropDir[0])+fabs((coord[1]-origin[1])*m_PropDir[1])+fabs((coord[2]-origin[2])*m_PropDir[2]);
 						delay = dist*unit/m_PhVel/dT + 1.0;
-						m_maxDelay = max((unsigned int)delay,m_maxDelay);
+						m_maxDelay = std::max((unsigned int)delay,m_maxDelay);
 						m_VoltDelay[n][1][1][ui_pos] = floor(delay);
 						m_VoltDelayDelta[n][1][1][ui_pos] = delay - floor(delay);
 						m_VoltAmp[n][1][1][ui_pos] = m_H_Amp[nP]*m_Op->GetEdgeLength(nP,pos,true);
@@ -367,7 +371,7 @@ bool Operator_Ext_TFSF::BuildExtension()
 						m_Op->GetYeeCoords(nPP,pos,coord,true);
 						dist = fabs((coord[0]-origin[0])*m_PropDir[0])+fabs((coord[1]-origin[1])*m_PropDir[1])+fabs((coord[2]-origin[2])*m_PropDir[2]);
 						delay = dist*unit/m_PhVel/dT + 1.0;
-						m_maxDelay = max((unsigned int)delay,m_maxDelay);
+						m_maxDelay = std::max((unsigned int)delay,m_maxDelay);
 						m_VoltDelay[n][1][0][ui_pos] = floor(delay);
 						m_VoltDelayDelta[n][1][0][ui_pos] = delay - floor(delay);
 						m_VoltAmp[n][1][0][ui_pos] = m_H_Amp[nPP]*m_Op->GetEdgeLength(nPP,pos,true);
@@ -414,7 +418,7 @@ Engine_Extension* Operator_Ext_TFSF::CreateEngineExtention()
 	return new Engine_Ext_TFSF(this);
 }
 
-void Operator_Ext_TFSF::ShowStat(ostream &ostr) const
+void Operator_Ext_TFSF::ShowStat(std::ostream &ostr) const
 {
 	Operator_Extension::ShowStat(ostr);
 	cout << "Active directions\t: " << "(" << m_ActiveDir[0][0] << "/" << m_ActiveDir[0][1] << ", " << m_ActiveDir[1][0] << "/" << m_ActiveDir[1][1]  << ", " << m_ActiveDir[2][0] << "/" << m_ActiveDir[2][1]  << ")" << endl;

--- a/FDTD/extensions/operator_ext_tfsf.h
+++ b/FDTD/extensions/operator_ext_tfsf.h
@@ -43,9 +43,12 @@ public:
 	// FIXME, this extension is not save to use with MPI
 	virtual bool IsMPISave() const {return false;}
 
-	virtual string GetExtensionName() const {return string("Total-Field/Scattered-Field Extension");}
+	virtual std::string GetExtensionName() const
+	{
+		return std::string("Total-Field/Scattered-Field Extension");
+	}
 
-	virtual void ShowStat(ostream &ostr) const;
+	virtual void ShowStat(std::ostream &ostr) const;
 
 	virtual void Init();
 	virtual void Reset();

--- a/FDTD/extensions/operator_ext_upml.h
+++ b/FDTD/extensions/operator_ext_upml.h
@@ -62,18 +62,26 @@ public:
 
 		An empty function string will be ignored.
 	*/
-	virtual bool SetGradingFunction(string func);
+	virtual bool SetGradingFunction(std::string func);
 
 	virtual bool BuildExtension();
 
 	virtual Engine_Extension* CreateEngineExtention();
 
-	virtual string GetExtensionName() const {return string("Uniaxial PML Extension");}
+	virtual std::string GetExtensionName() const
+	{
+		return std::string("Uniaxial PML Extension");
+	}
 
-	virtual void ShowStat(ostream &ostr) const;
+	virtual void ShowStat(std::ostream &ostr) const;
 
 	//! Create the UPML
-	static bool Create_UPML(Operator* op, const int ui_BC[6], const unsigned int ui_size[6], const string gradFunc);
+	static bool Create_UPML(
+		Operator* op,
+		const int ui_BC[6],
+		const unsigned int ui_size[6],
+		const std::string gradFunc
+	);
 
 protected:
 	Operator_Ext_UPML(Operator* op);
@@ -83,7 +91,7 @@ protected:
 	unsigned int m_StartPos[3];
 	unsigned int m_numLines[3];
 
-	string m_GradFunc;
+	std::string m_GradFunc;
 	FunctionParser* m_GradingFunction;
 
 	void CalcGradingKappa(int ny, unsigned int pos[3], double Zm, double kappa_v[3], double kappa_i[3]);

--- a/FDTD/extensions/operator_extension.h
+++ b/FDTD/extensions/operator_extension.h
@@ -58,7 +58,10 @@ public:
 	//! The MPI operator (if enabled) will check whether the extension is compatible with MPI. Default is false. Derive this method to override.
 	virtual bool IsMPISave() const {return false;}
 
-	virtual std::string GetExtensionName() const {return std::string("Abstract Operator Extension Base Class");}
+	virtual std::string GetExtensionName() const
+	{
+		return std::string("Abstract Operator Extension Base Class");
+	}
 
 	virtual void ShowStat(std::ostream &ostr) const;
 

--- a/FDTD/operator.cpp
+++ b/FDTD/operator.cpp
@@ -36,6 +36,11 @@
 #include "CSPropMaterial.h"
 #include "CSPropLumpedElement.h"
 
+using std::cout;
+using std::cerr;
+using std::endl;
+using std::flush;
+
 Operator* Operator::New()
 {
 	cout << "Create FDTD operator" << endl;
@@ -546,7 +551,7 @@ void Operator::ShowExtStat() const
 	cout << "-----------------------------------" << endl;
 }
 
-void Operator::DumpOperator2File(string filename)
+void Operator::DumpOperator2File(std::string filename)
 {
 #ifdef OUTPUT_IN_DRAWINGUNITS
 	double discLines_scaling = 1;
@@ -618,7 +623,7 @@ void Operator::DumpOperator2File(string filename)
 //! \brief dump PEC (perfect electric conductor) information (into VTK-file)
 //! visualization via paraview
 //! visualize only one component (x, y or z)
-void Operator::DumpPEC2File(string filename , unsigned int *range)
+void Operator::DumpPEC2File(std::string filename , unsigned int *range)
 {
 	cout << "Operator: Dumping PEC information to vtk file: " << filename << " ..." << flush;
 
@@ -730,7 +735,7 @@ void Operator::DumpPEC2File(string filename , unsigned int *range)
 	cout << " done." << endl;
 }
 
-void Operator::DumpMaterial2File(string filename)
+void Operator::DumpMaterial2File(std::string filename)
 {
 #ifdef OUTPUT_IN_DRAWINGUNITS
 	double discLines_scaling = 1;
@@ -750,7 +755,11 @@ void Operator::DumpMaterial2File(string filename)
 	{
 		for (pos[1]=0; pos[1]<numLines[1]; ++pos[1])
 		{
-			vector<CSPrimitives*> vPrims = this->GetPrimitivesBoundBox(pos[0], pos[1], -1, CSProperties::MATERIAL);
+			std::vector<CSPrimitives*> vPrims = this->GetPrimitivesBoundBox(
+				pos[0], pos[1], -1,
+				CSProperties::MATERIAL
+			);
+
 			for (pos[2]=0; pos[2]<numLines[2]; ++pos[2])
 			{
 				for (int n=0; n<3; ++n)
@@ -1054,7 +1063,7 @@ int Operator::CalcECOperator( DebugFlags debugFlags )
 		m_Op_exts.at(n)->BuildExtension();
 
 	//remove inactive extensions
-	vector<Operator_Extension*>::iterator it = m_Op_exts.begin();
+	std::vector<Operator_Extension*>::iterator it = m_Op_exts.begin();
 	while (it!=m_Op_exts.end())
 	{
 		if ( (*it)->IsActive() == false)
@@ -1179,7 +1188,12 @@ void Operator::ApplyMagneticBC(bool* dirs)
 	}
 }
 
-bool Operator::Calc_ECPos(int ny, const unsigned int* pos, double* EC, vector<CSPrimitives*> vPrims) const
+bool Operator::Calc_ECPos(
+	int ny,
+	const unsigned int* pos,
+	double* EC,
+	std::vector<CSPrimitives*> vPrims
+) const
 {
 	double EffMat[4];
 	Calc_EffMatPos(ny,pos,EffMat, vPrims);
@@ -1266,7 +1280,13 @@ bool Operator::GetCellCenterMaterialAvgCoord(const int pos[], double coord[3]) c
 	return true;
 }
 
-double Operator::GetMaterial(int ny, const double* coords, int MatType, vector<CSPrimitives*> vPrims, bool markAsUsed) const
+double Operator::GetMaterial(
+	int ny,
+	const double* coords,
+	int MatType,
+	std::vector<CSPrimitives*> vPrims,
+	bool markAsUsed
+) const
 {
 	CSProperties* prop = CSX->GetPropertyByCoordPriority(coords,vPrims,markAsUsed);
 //	CSProperties* old_prop = CSX->GetPropertyByCoordPriority(coords,CSProperties::MATERIAL,markAsUsed);
@@ -1315,7 +1335,12 @@ double Operator::GetMaterial(int ny, const double* coords, int MatType, vector<C
 	}
 }
 
-bool Operator::AverageMatCellCenter(int ny, const unsigned int* pos, double* EffMat, vector<CSPrimitives *> vPrims) const
+bool Operator::AverageMatCellCenter(
+	int ny,
+	const unsigned int* pos,
+	double* EffMat,
+	std::vector<CSPrimitives *> vPrims
+) const
 {
 	int n=ny;
 	double coord[3];
@@ -1421,7 +1446,12 @@ bool Operator::AverageMatCellCenter(int ny, const unsigned int* pos, double* Eff
 	return true;
 }
 
-bool Operator::AverageMatQuarterCell(int ny, const unsigned int* pos, double* EffMat, vector<CSPrimitives*> vPrims) const
+bool Operator::AverageMatQuarterCell(
+	int ny,
+	const unsigned int* pos,
+	double* EffMat,
+	std::vector<CSPrimitives*> vPrims
+) const
 {
 	int n=ny;
 	double coord[3];
@@ -1535,7 +1565,12 @@ bool Operator::AverageMatQuarterCell(int ny, const unsigned int* pos, double* Ef
 	return true;
 }
 
-bool Operator::Calc_EffMatPos(int ny, const unsigned int* pos, double* EffMat, vector<CSPrimitives *> vPrims) const
+bool Operator::Calc_EffMatPos(
+	int ny,
+	const unsigned int* pos,
+	double* EffMat,
+	std::vector<CSPrimitives *> vPrims
+) const
 {
 	switch (m_MatAverageMethod)
 	{
@@ -1552,7 +1587,7 @@ bool Operator::Calc_EffMatPos(int ny, const unsigned int* pos, double* EffMat, v
 
 bool Operator::Calc_LumpedElements()
 {
-	vector<CSProperties*> props = CSX->GetPropertyByType(CSProperties::LUMPED_ELEMENT);
+	std::vector<CSProperties*> props = CSX->GetPropertyByType(CSProperties::LUMPED_ELEMENT);
 
 	for (size_t i=0;i<props.size();++i)
 	{
@@ -1562,7 +1597,7 @@ bool Operator::Calc_LumpedElements()
 		if (PLE==NULL)
 			return false; //sanity check: this should never happen!
 
-		vector<CSPrimitives*> prims = PLE->GetAllPrimitives();
+		std::vector<CSPrimitives*> prims = PLE->GetAllPrimitives();
 		for (size_t bn=0;bn<prims.size();++bn)
 		{
 			CSPrimBox* box = dynamic_cast<CSPrimBox*>(prims.at(bn));
@@ -1777,7 +1812,11 @@ bool Operator::Calc_EC()
 	return true;
 }
 
-vector<CSPrimitives*> Operator::GetPrimitivesBoundBox(int posX, int posY, int posZ, CSProperties::PropertyType type) const
+std::vector<CSPrimitives*>
+Operator::GetPrimitivesBoundBox(
+	int posX, int posY, int posZ,
+	CSProperties::PropertyType type
+) const
 {
 	double boundBox[6];
 	int BBpos[3] = {posX, posY, posZ};
@@ -1790,18 +1829,18 @@ vector<CSPrimitives*> Operator::GetPrimitivesBoundBox(int posX, int posY, int po
 		}
 		else
 		{
-			boundBox[2*n]   = this->GetDiscLine(n, max(0, BBpos[n]-1));
-			boundBox[2*n+1] = this->GetDiscLine(n, min(int(numLines[n])-1, BBpos[n]+1));
+			boundBox[2*n]   = this->GetDiscLine(n, std::max(0, BBpos[n]-1));
+			boundBox[2*n+1] = this->GetDiscLine(n, std::min(int(numLines[n])-1, BBpos[n]+1));
 		}
 	}
 
-	vector<CSPrimitives*> vPrim = this->CSX->GetPrimitivesByBoundBox(boundBox, true, type);
+	std::vector<CSPrimitives*> vPrim = this->CSX->GetPrimitivesByBoundBox(boundBox, true, type);
 	return vPrim;
 }
 
 void Operator::Calc_EC_Range(unsigned int xStart, unsigned int xStop)
 {
-//	vector<CSPrimitives*> vPrims = this->CSX->GetAllPrimitives(true, CSProperties::MATERIAL);
+//	std::vector<CSPrimitives*> vPrims = this->CSX->GetAllPrimitives(true, CSProperties::MATERIAL);
 	unsigned int ipos;
 	unsigned int pos[3];
 	double inEC[4];
@@ -1809,7 +1848,11 @@ void Operator::Calc_EC_Range(unsigned int xStart, unsigned int xStop)
 	{
 		for (pos[1]=0; pos[1]<numLines[1]; ++pos[1])
 		{
-			vector<CSPrimitives*> vPrims = this->GetPrimitivesBoundBox(pos[0], pos[1], -1, CSProperties::MATERIAL);
+			std::vector<CSPrimitives*> vPrims = this->GetPrimitivesBoundBox(
+				pos[0], pos[1], -1,
+				CSProperties::MATERIAL
+			);
+
 			for (pos[2]=0; pos[2]<numLines[2]; ++pos[2])
 			{
 				ipos = MainOp->GetPos(pos[0],pos[1],pos[2]);
@@ -1850,7 +1893,7 @@ double Operator::CalcTimestep()
 ////Berechnung nach Andreas Rennings Dissertation 2008, Seite 66, Formel 4.52
 double Operator::CalcTimestep_Var1()
 {
-	m_Used_TS_Name = string("Rennings_1");
+	m_Used_TS_Name = std::string("Rennings_1");
 //	cout << "Operator::CalcTimestep(): Using timestep algorithm by Andreas Rennings, Dissertation @ University Duisburg-Essen, 2008, pp. 66, eq. 4.52" << endl;
 	dT=1e200;
 	double newT;
@@ -1915,7 +1958,7 @@ double min(double* val, unsigned int count)
 double Operator::CalcTimestep_Var3()
 {
 	dT=1e200;
-	m_Used_TS_Name = string("Rennings_2");
+	m_Used_TS_Name = std::string("Rennings_2");
 //	cout << "Operator::CalcTimestep(): Using timestep algorithm by Andreas Rennings, Dissertation @ University Duisburg-Essen, 2008, pp. 76, eq. 4.77 ff." << endl;
 	double newT;
 	unsigned int pos[3];
@@ -2009,7 +2052,11 @@ void Operator::CalcPEC_Range(unsigned int startX, unsigned int stopX, unsigned i
 	{
 		for (pos[1]=0; pos[1]<numLines[1]; ++pos[1])
 		{
-			vector<CSPrimitives*> vPrims = this->GetPrimitivesBoundBox(pos[0], pos[1], -1, (CSProperties::PropertyType)(CSProperties::MATERIAL | CSProperties::METAL));
+			std::vector<CSPrimitives*> vPrims = this->GetPrimitivesBoundBox(
+				pos[0], pos[1], -1,
+				(CSProperties::PropertyType)(CSProperties::MATERIAL | CSProperties::METAL)
+			);
+
 			for (pos[2]=0; pos[2]<numLines[2]; ++pos[2])
 			{
 				for (int n=0; n<3; ++n)
@@ -2043,7 +2090,7 @@ void Operator::CalcPEC_Curves()
 	double p1[3];
 	double p2[3];
 	Grid_Path path;
-	vector<CSProperties*> vec_prop = CSX->GetPropertyByType(CSProperties::METAL);
+	std::vector<CSProperties*> vec_prop = CSX->GetPropertyByType(CSProperties::METAL);
 	for (size_t p=0; p<vec_prop.size(); ++p)
 	{
 		CSProperties* prop = vec_prop.at(p);

--- a/FDTD/operator.h
+++ b/FDTD/operator.h
@@ -231,7 +231,12 @@ public:
 
 	virtual double CalcNumericPhaseVelocity(unsigned int start[3], unsigned int stop[3], double propDir[3], float freq) const;
 
-	virtual vector<CSPrimitives*> GetPrimitivesBoundBox(int posX, int posY, int posZ, CSProperties::PropertyType type=CSProperties::ANY) const;
+	virtual std::vector<CSPrimitives*> GetPrimitivesBoundBox(
+		int posX,
+		int posY,
+		int posZ,
+		CSProperties::PropertyType type=CSProperties::ANY
+	) const;
 
 protected:
 	//! use New() for creating a new Operator
@@ -248,9 +253,9 @@ protected:
 	virtual Grid_Path FindPath(double start[], double stop[]);
 
 	// debug
-	virtual void DumpOperator2File(string filename);
-	virtual void DumpMaterial2File(string filename);
-	virtual void DumpPEC2File( string filename, unsigned int *range = NULL );
+	virtual void DumpOperator2File(std::string filename);
+	virtual void DumpMaterial2File(std::string filename);
+	virtual void DumpPEC2File( std::string filename, unsigned int *range = NULL );
 
 	unsigned int m_Nr_PEC[3]; //count PEC edges
 	virtual bool CalcPEC();
@@ -263,13 +268,17 @@ protected:
 	virtual double CalcTimestep();
 	double opt_dT;
 	bool m_InvaildTimestep;
-	string m_Used_TS_Name;
+	std::string m_Used_TS_Name;
 
 	double CalcTimestep_Var1();
 	double CalcTimestep_Var3();
 
 	//! Calculate the FDTD equivalent circuit parameter for the given position and direction ny. \sa Calc_EffMat_Pos
-	virtual bool Calc_ECPos(int ny, const unsigned int* pos, double* EC, vector<CSPrimitives *> vPrims) const;
+	virtual bool Calc_ECPos(
+		int ny,
+		const unsigned int* pos,
+		double* EC, std::vector<CSPrimitives *> vPrims
+	) const;
 
 	//! Get the FDTD raw disc delta, needed by Calc_EffMatPos() \sa Calc_EffMatPos
 	/*!
@@ -280,15 +289,37 @@ protected:
 	virtual double GetRawDiscDelta(int ny, const int pos) const;
 
 	//! Get the material at a given coordinate, direction and type from CSX (internal use only)
-	virtual double GetMaterial(int ny, const double coords[3], int MatType, vector<CSPrimitives*> vPrims, bool markAsUsed=true) const;
+	virtual double GetMaterial(
+		int ny,
+		const double coords[3],
+		int MatType,
+		std::vector<CSPrimitives*> vPrims,
+		bool markAsUsed=true
+	) const;
 
 	MatAverageMethods m_MatAverageMethod;
 
 	//! Calculate the effective/averaged material properties at the given position and direction ny.
-	virtual bool Calc_EffMatPos(int ny, const unsigned int* pos, double* EffMat, vector<CSPrimitives*> vPrims) const;
+	virtual bool Calc_EffMatPos(
+		int ny,
+		const unsigned int* pos,
+		double* EffMat,
+		std::vector<CSPrimitives*> vPrims
+	) const;
 
-	virtual bool AverageMatCellCenter(int ny, const unsigned int* pos, double* EffMat, vector<CSPrimitives*> vPrims) const;
-	virtual bool AverageMatQuarterCell(int ny, const unsigned int* pos, double* EffMat, vector<CSPrimitives*> vPrims) const;
+	virtual bool AverageMatCellCenter(
+		int ny,
+		const unsigned int* pos,
+		double* EffMat,
+		std::vector<CSPrimitives*> vPrims
+	) const;
+
+	virtual bool AverageMatQuarterCell(
+		int ny,
+		const unsigned int* pos,
+		double* EffMat,
+		std::vector<CSPrimitives*> vPrims
+	) const;
 
 	//! Calc operator at certain \a pos
 	virtual void Calc_ECOperatorPos(int n, unsigned int* pos);
@@ -319,7 +350,7 @@ protected:
 
 	AdrOp* MainOp;
 
-	vector<Operator_Extension*> m_Op_exts;
+	std::vector<Operator_Extension*> m_Op_exts;
 
 	Engine* m_Engine;
 

--- a/FDTD/operator_cylinder.cpp
+++ b/FDTD/operator_cylinder.cpp
@@ -23,6 +23,10 @@
 #include "extensions/operator_ext_cylinder.h"
 #include "tools/useful.h"
 
+using std::cout;
+using std::cerr;
+using std::endl;
+
 Operator_Cylinder* Operator_Cylinder::New(unsigned int numThreads)
 {
 	cout << "Create cylindrical FDTD operator" << endl;
@@ -67,7 +71,13 @@ double Operator_Cylinder::GetRawDiscDelta(int ny, const int pos) const
 	return Operator_Multithread::GetRawDiscDelta(ny,pos);
 }
 
-double Operator_Cylinder::GetMaterial(int ny, const double* coords, int MatType, vector<CSPrimitives*> vPrims, bool markAsUsed) const
+double Operator_Cylinder::GetMaterial(
+	int ny,
+	const double* coords,
+	int MatType,
+	std::vector<CSPrimitives*> vPrims,
+	bool markAsUsed
+) const
 {
 	double l_coords[] = {coords[0],coords[1],coords[2]};
 	if (CC_closedAlpha && (coords[1]>GetDiscLine(1,0,false)+2*PI))
@@ -109,7 +119,7 @@ inline unsigned int Operator_Cylinder::GetNumberOfLines(int ny, bool full) const
 	return Operator_Multithread::GetNumberOfLines(ny, full);
 }
 
-string Operator_Cylinder::GetDirName(int ny) const
+std::string Operator_Cylinder::GetDirName(int ny) const
 {
 	if (ny==0) return "rho";
 	if (ny==1) return "alpha";

--- a/FDTD/operator_cylinder.h
+++ b/FDTD/operator_cylinder.h
@@ -43,7 +43,7 @@ public:
 	virtual unsigned int GetNumberOfLines(int ny, bool full=false) const;
 
 	//! Get the name for the given direction: 0 -> rho, 1 -> alpha, 2 -> z
-	virtual string GetDirName(int ny) const;
+	virtual std::string GetDirName(int ny) const;
 
 	//! Get the coordinates for a given node index and component, according to the cylindrical yee-algorithm. Returns true if inside the FDTD domain.
 	virtual bool GetYeeCoords(int ny, unsigned int pos[3], double* coords, bool dualMesh) const;
@@ -102,7 +102,13 @@ protected:
 
 	virtual double GetRawDiscDelta(int ny, const int pos) const;
 
-	virtual double GetMaterial(int ny, const double coords[3], int MatType, vector<CSPrimitives*> vPrims, bool markAsUsed=true) const;
+	virtual double GetMaterial(
+		int ny,
+		const double coords[3],
+		int MatType,
+		std::vector<CSPrimitives*> vPrims,
+		bool markAsUsed=true
+	) const;
 
 	virtual int CalcECOperator( DebugFlags debugFlags = None );
 	virtual double CalcTimestep();

--- a/FDTD/operator_cylindermultigrid.cpp
+++ b/FDTD/operator_cylindermultigrid.cpp
@@ -21,7 +21,14 @@
 #include "tools/useful.h"
 #include "CSUseful.h"
 
-Operator_CylinderMultiGrid::Operator_CylinderMultiGrid(vector<double> Split_Radii, unsigned int level) : Operator_Cylinder()
+using std::cout;
+using std::cerr;
+using std::endl;
+
+Operator_CylinderMultiGrid::Operator_CylinderMultiGrid(
+	std::vector<double> Split_Radii,
+	unsigned int level
+) : Operator_Cylinder()
 {
 	m_Split_Radii = Split_Radii;
 	m_Split_Rad = m_Split_Radii.back();
@@ -34,7 +41,11 @@ Operator_CylinderMultiGrid::~Operator_CylinderMultiGrid()
 	Delete();
 }
 
-Operator_CylinderMultiGrid* Operator_CylinderMultiGrid::New(vector<double> Split_Radii, unsigned int numThreads, unsigned int level)
+Operator_CylinderMultiGrid* Operator_CylinderMultiGrid::New(
+	std::vector<double> Split_Radii,
+	unsigned int numThreads,
+	unsigned int level
+)
 {
 	if ((Split_Radii.size()==0) || (Split_Radii.size()>CYLIDINDERMULTIGRID_LIMIT))
 	{
@@ -189,9 +200,15 @@ void Operator_CylinderMultiGrid::SetNeighborDown(int ny, int id)
 }
 #endif
 
-void Operator_CylinderMultiGrid::CalcStartStopLines(unsigned int &numThreads, vector<unsigned int> &start, vector<unsigned int> &stop) const
+void Operator_CylinderMultiGrid::CalcStartStopLines(
+	unsigned int &numThreads,
+	std::vector<unsigned int> &start,
+	std::vector<unsigned int> &stop
+) const
 {
-	vector<unsigned int> jpt = AssignJobs2Threads(numLines[0]- m_Split_Pos + 1, numThreads, true);
+	std::vector<unsigned int> jpt = AssignJobs2Threads(
+		numLines[0]- m_Split_Pos + 1, numThreads, true
+	);
 
 	numThreads = jpt.size();
 
@@ -219,7 +236,10 @@ void Operator_CylinderMultiGrid::FillMissingDataStorage()
 		{
 			for (pos[1]=0; pos[1]<numLines[1]; ++pos[1])
 			{
-				vector<CSPrimitives*> vPrims = this->GetPrimitivesBoundBox(pos[0], pos[1], -1, CSProperties::MATERIAL);
+				std::vector<CSPrimitives*> vPrims = this->GetPrimitivesBoundBox(
+					pos[0], pos[1], -1, CSProperties::MATERIAL
+				);
+
 				for (pos[2]=0; pos[2]<numLines[2]; ++pos[2])
 				{
 					Calc_EffMatPos(ny,pos,EffMat,vPrims);
@@ -293,7 +313,7 @@ int Operator_CylinderMultiGrid::CalcECOperator( DebugFlags debugFlags )
 	return retCode;
 }
 
-void Operator_CylinderMultiGrid::DumpPEC2File( string filename, unsigned int *range)
+void Operator_CylinderMultiGrid::DumpPEC2File( std::string filename, unsigned int *range)
 {
 	if (range!=NULL)
 		return Operator_Cylinder::DumpPEC2File(filename, range);

--- a/FDTD/operator_cylindermultigrid.h
+++ b/FDTD/operator_cylindermultigrid.h
@@ -32,7 +32,12 @@ class Operator_CylinderMultiGrid : public Operator_Cylinder
 {
 	friend class Engine_CylinderMultiGrid;
 public:
-	static Operator_CylinderMultiGrid* New(vector<double> Split_Radii, unsigned int numThreads = 0, unsigned int level = 0);
+	static Operator_CylinderMultiGrid* New(
+		std::vector<double> Split_Radii,
+		unsigned int numThreads = 0,
+		unsigned int level = 0
+	);
+
 	virtual ~Operator_CylinderMultiGrid();
 
 	virtual double GetNumberCells() const;
@@ -69,7 +74,7 @@ public:
 #endif
 
 protected:
-	Operator_CylinderMultiGrid(vector<double> Split_Radii, unsigned int level);
+	Operator_CylinderMultiGrid(std::vector<double> Split_Radii, unsigned int level);
 	virtual void Init();
 	void Delete();
 	virtual void Reset();
@@ -78,14 +83,14 @@ protected:
 
 	virtual int CalcECOperator( DebugFlags debugFlags = None );
 
-	virtual void DumpPEC2File( string filename, unsigned int *range = NULL );
+	virtual void DumpPEC2File( std::string filename, unsigned int *range = NULL );
 
 	//! The material data storage in the sub-grid area's will not be filled by the base-operator. Check and do this here!
 	void FillMissingDataStorage();
 
 	unsigned int m_MultiGridLevel;
 	double m_Split_Rad;
-	vector<double> m_Split_Radii;
+	std::vector<double> m_Split_Radii;
 	unsigned int m_Split_Pos;
 
 	Operator_Cylinder* m_InnerOp;
@@ -103,7 +108,11 @@ protected:
 
 	void SetupInterpolation();
 
-	virtual void CalcStartStopLines(unsigned int &numThreads, vector<unsigned int> &start, vector<unsigned int> &stop) const;
+	virtual void CalcStartStopLines(
+		unsigned int &numThreads,
+		std::vector<unsigned int> &start,
+		std::vector<unsigned int> &stop
+	) const;
 };
 
 #endif // OPERATOR_CYLINDERMULTIGRID_H

--- a/FDTD/operator_multithread.cpp
+++ b/FDTD/operator_multithread.cpp
@@ -19,6 +19,10 @@
 #include "engine_multithread.h"
 #include "tools/useful.h"
 
+using std::cout;
+using std::cerr;
+using std::endl;
+
 Operator_Multithread* Operator_Multithread::New(unsigned int numThreads)
 {
 	cout << "Create FDTD operator (compressed SSE + multi-threading)" << endl;
@@ -86,9 +90,13 @@ void Operator_Multithread::Reset()
 	OPERATOR_MULTITHREAD_BASE::Reset();
 }
 
-void Operator_Multithread::CalcStartStopLines(unsigned int &numThreads, vector<unsigned int> &start, vector<unsigned int> &stop) const
+void Operator_Multithread::CalcStartStopLines(
+	unsigned int &numThreads,
+	std::vector<unsigned int> &start,
+	std::vector<unsigned int> &stop
+) const
 {
-	vector<unsigned int> jpt = AssignJobs2Threads(numLines[0], numThreads, true);
+	std::vector<unsigned int> jpt = AssignJobs2Threads(numLines[0], numThreads, true);
 
 	numThreads = jpt.size();
 
@@ -110,8 +118,8 @@ int Operator_Multithread::CalcECOperator( DebugFlags debugFlags )
 	if ((m_numThreads == 0) || (m_numThreads > boost::thread::hardware_concurrency()))
 		m_numThreads = boost::thread::hardware_concurrency();
 
-	vector<unsigned int> m_Start_Lines;
-	vector<unsigned int> m_Stop_Lines;
+	std::vector<unsigned int> m_Start_Lines;
+	std::vector<unsigned int> m_Stop_Lines;
 	CalcStartStopLines( m_numThreads, m_Start_Lines, m_Stop_Lines );
 
 	if (g_settings.GetVerboseLevel()>0)

--- a/FDTD/operator_multithread.h
+++ b/FDTD/operator_multithread.h
@@ -72,7 +72,11 @@ protected:
 		This method is also used by the multithreading engine!
 		This method may also reduce the usable number of thread in case of too few lines or otherwise bad utilization.
 	*/
-	virtual void CalcStartStopLines(unsigned int &numThreads, vector<unsigned int> &start, vector<unsigned int> &stop) const;
+	virtual void CalcStartStopLines(
+		unsigned int &numThreads,
+		std::vector<unsigned int> &start,
+		std::vector<unsigned int> &stop
+	) const;
 };
 
 class Operator_Thread

--- a/FDTD/operator_sse.cpp
+++ b/FDTD/operator_sse.cpp
@@ -19,6 +19,9 @@
 #include "operator_sse.h"
 //#include "processfields.h"
 
+using std::cout;
+using std::endl;
+
 Operator_sse* Operator_sse::New()
 {
 	cout << "Create FDTD operator (SSE)" << endl;

--- a/FDTD/operator_sse_compressed.cpp
+++ b/FDTD/operator_sse_compressed.cpp
@@ -22,6 +22,9 @@
 #include <map>
 #include <cstring>
 
+using std::cout;
+using std::endl;
+
 Operator_SSE_Compressed* Operator_SSE_Compressed::New()
 {
 	cout << "Create FDTD operator (compressed SSE)" << endl;
@@ -118,7 +121,7 @@ bool Operator_SSE_Compressed::CompressOperator()
 	ArrayLib::ArrayNIJK<f4vector>& f4_iv = *f4_iv_ptr;
 	ArrayLib::ArrayNIJK<f4vector>& f4_ii = *f4_ii_ptr;
 
-	map<SSE_coeff,unsigned int> lookUpMap;
+	std::map<SSE_coeff,unsigned int> lookUpMap;
 
 	unsigned int pos[3];
 	for (pos[0]=0; pos[0]<numLines[0]; ++pos[0])
@@ -133,7 +136,7 @@ bool Operator_SSE_Compressed::CompressOperator()
 				f4vector ii[3] = { f4_ii(0, pos[0], pos[1], pos[2]), f4_ii(1, pos[0], pos[1], pos[2]), f4_ii(2, pos[0], pos[1], pos[2]) };
 				SSE_coeff c( vv, vi, iv, ii );
 
-				map<SSE_coeff,unsigned int>::iterator it;
+				std::map<SSE_coeff,unsigned int>::iterator it;
 				it = lookUpMap.find(c);
 				if (it == lookUpMap.end())
 				{
@@ -221,7 +224,7 @@ bool SSE_coeff::operator<( const SSE_coeff& other ) const
 	return false;
 }
 
-void SSE_coeff::print( ostream& stream ) const
+void SSE_coeff::print( std::ostream& stream ) const
 {
 	stream << "SSE_coeff: (" << endl;
 	for (int n=0; n<3; n++)

--- a/FDTD/operator_sse_compressed.h
+++ b/FDTD/operator_sse_compressed.h
@@ -29,7 +29,7 @@ public:
 	bool operator==( const SSE_coeff& ) const;
 	bool operator!=( const SSE_coeff& ) const;
 	bool operator<( const SSE_coeff& ) const;
-	void print( ostream& stream ) const;
+	void print( std::ostream& stream ) const;
 protected:
 	f4vector m_vv[3];
 	f4vector m_vi[3];
@@ -75,11 +75,14 @@ protected:
 	// engine needs access
 public:
 	ArrayLib::ArrayIJK<unsigned int> m_Op_index;
-	vector<f4vector,aligned_allocator<f4vector> > f4_vv_Compressed[3]; //!< coefficient: calc new voltage from old voltage
-	vector<f4vector,aligned_allocator<f4vector> > f4_vi_Compressed[3]; //!< coefficient: calc new voltage from old current
-	vector<f4vector,aligned_allocator<f4vector> > f4_iv_Compressed[3]; //!< coefficient: calc new current from old voltage
-	vector<f4vector,aligned_allocator<f4vector> > f4_ii_Compressed[3]; //!< coefficient: calc new current from old current
-
+	//!< coefficient: calc new voltage from old voltage
+	std::vector<f4vector,aligned_allocator<f4vector> > f4_vv_Compressed[3];
+	//!< coefficient: calc new voltage from old current
+	std::vector<f4vector,aligned_allocator<f4vector> > f4_vi_Compressed[3];
+	//!< coefficient: calc new current from old voltage
+	std::vector<f4vector,aligned_allocator<f4vector> > f4_iv_Compressed[3];
+	//!< coefficient: calc new current from old current
+	std::vector<f4vector,aligned_allocator<f4vector> > f4_ii_Compressed[3];
 };
 
 #endif // OPERATOR_SSE_Compressed_H

--- a/tools/ExpenseLog.h
+++ b/tools/ExpenseLog.h
@@ -3,8 +3,6 @@
 #include <stdlib.h>
 #include <vector>
 
-using namespace std;
-
 #define EXPENSE_LOG 0
 #define MRD 1000000000
 
@@ -86,7 +84,7 @@ public:
 	void PrintAll(FILE *file=stdout);
 	void ClearAll();
 protected:
-	vector<ExpenseModule*> vModules;
+	std::vector<ExpenseModule*> vModules;
 };
 
 


### PR DESCRIPTION
In general, it's not recommended to write `using namespace std` in a header file, because it causes accidental namespace pollution to all files that use this header indirectly. In openEMS, the statement `using namespace std` was written into `tools/ExpenseLog.h`, which was then indirectly included to nearly all engines and all extensions, which violates the principle of least surprises.

When building openEMS with MSVC, this unintentional namespace pollution also causes a name conflict between `std::byte` in C++17 and `C:\Program Files (x86)\Windows Kits\10\include\10.0.26100.0\shared\rpcndr.h`, creating hundreds of build errors.

    C:\Program Files (x86)\Windows Kits\10\include\10.0.26100.0\shared\rpcndr.h(203): error C2872: 'byte': ambiguous symbol
    C:\Program Files (x86)\Windows Kits\10\include\10.0.26100.0\shared\rpcndr.h(202): note: could be 'unsigned char byte'
    C:\Program Files\Microsoft Visual Studio\18\Community\VC\Tools\MSVC\14.50.35717\include\cstddef(34): note: or       'std::byte'

Since unintentional namespace pollution is both a theoretical and practical problem, this commit removes `using namespace std` from `tools/ExpenseLog.h`, usage of most STL classes in openEMS are now made explicit using the `std::` prefix.

If a line is exceedingly long (most modified lines were already extremely long even before adding the `std::` prefix), this commit also uses this opportunity to break them into multiple lines for readability.

As a special case, `using std::out; using std::cerr; using std::endl` are imported into the global namespace in some `.cpp` files to reduce the length of repetitive string formatting code.