### PR TITLE
all: use _WIN32 macro instead of WIN32 or __GNUC__ if possible.

### DIFF
--- a/FDTD/engine_multithread.h
+++ b/FDTD/engine_multithread.h
@@ -27,7 +27,7 @@
 #include <boost/fusion/include/list_fwd.hpp>
 
 #include "tools/useful.h"
-#ifndef __GNUC__
+#if defined(_WIN32) && !defined(__GNUC__)
 #include <Winsock2.h> // for struct timeval
 #else
 #include <sys/time.h>

--- a/nf2ff/nf2ff.h
+++ b/nf2ff/nf2ff.h
@@ -26,7 +26,7 @@
 
 using namespace std;
 
-#if defined(WIN32)
+#if defined(_WIN32)
 	#ifdef BUILD_NF2FF_LIB
 	#define NF2FF_EXPORT __declspec(dllexport)
 	#else

--- a/openems.h
+++ b/openems.h
@@ -19,7 +19,7 @@
 #define OPENEMS_H
 
 #include <sstream>
-#ifndef __GNUC__
+#if defined(_WIN32) && !defined(__GNUC__)
 #include <Winsock2.h> // for struct timeval
 #else
 #include <sys/time.h>

--- a/openems_global.h
+++ b/openems_global.h
@@ -18,7 +18,7 @@
 #ifndef OPENEMS_GLOBAL_H
 #define OPENEMS_GLOBAL_H
 
-#if defined(WIN32)
+#if defined(_WIN32)
 	#ifdef BUILD_OPENEMS_LIB
 	#define OPENEMS_EXPORT __declspec(dllexport)
 	#else

--- a/tools/aligned_allocator.h
+++ b/tools/aligned_allocator.h
@@ -25,7 +25,7 @@
 #include <stdexcept> // Required for std::length_error
 
 
-#ifdef WIN32
+#ifdef _WIN32
 #define __MSVCRT_VERSION__ 0x0700
 #include <malloc.h>
 #define MEMALIGN( array, alignment, size ) !(*array = _aligned_malloc( size, alignment ))

--- a/tools/array_ops.cpp
+++ b/tools/array_ops.cpp
@@ -20,7 +20,7 @@
 
 using namespace std;
 
-#ifdef WIN32
+#ifdef _WIN32
 #include <malloc.h>
 #define MEMALIGN( array, alignment, size ) !(*array = _mm_malloc( size, alignment ))
 #define FREE( array ) _mm_free( array )

--- a/tools/arraylib/impl/allocator.h
+++ b/tools/arraylib/impl/allocator.h
@@ -47,7 +47,7 @@ public:
 	}
 };
 
-#ifdef WIN32
+#ifdef _WIN32
 #include <malloc.h>
 #endif
 
@@ -68,7 +68,7 @@ public:
 			alignment = 1 << (size_t) ceil(log2(sizeof(T)));
 
 		T* buf;
-#ifdef WIN32
+#ifdef _WIN32
 		buf = (T*) _mm_malloc(numelem * sizeof(T), alignment);
 		if (buf == NULL)
 		{
@@ -96,7 +96,7 @@ public:
 		{
 			for (size_t i = 0; i < numelem; i++)
 				(&ptr[i])->~T();
-#ifdef WIN32
+#ifdef _WIN32
 			_mm_free(ptr);
 #else
 			std::free(ptr);

--- a/tools/signal.cpp
+++ b/tools/signal.cpp
@@ -22,7 +22,7 @@
 
 static volatile std::sig_atomic_t m_sigintAbort = 0;
 
-#ifndef WIN32
+#ifndef _WIN32
 static void (*m_sigHandlerOriginal)(int) = NULL;
 #else
 static PHANDLER_ROUTINE m_sigHandlerRegistered = NULL;
@@ -32,14 +32,14 @@ void Signal::SetupHandlerForSIGINT(int type)
 {
 	m_sigintAbort = 0;
 
-#ifndef WIN32
+#ifndef _WIN32
 	UnixSetupHandlerForSIGINT(type);
 #else
 	Win32SetupHandlerForConsoleCtrl(type);
 #endif
 }
 
-#ifndef WIN32
+#ifndef _WIN32
 void Signal::UnixSetupHandlerForSIGINT(int type)
 {
 	if (type == SIGNAL_ORIGINAL && m_sigHandlerOriginal)
@@ -229,7 +229,7 @@ bool Signal::ReceivedSIGINT(void)
 
 void Signal::SafeStderrWrite(const char *buf)
 {
-#ifdef WIN32
+#ifdef _WIN32
 	// On Windows, using any kind of system calls in a ANSI C signal
 	// handler is prohibited, in this case, this function should return
 	// immediately without doing anything. But, when the official way

--- a/tools/signal.h
+++ b/tools/signal.h
@@ -20,7 +20,7 @@
 
 #include <csignal>
 
-#ifndef WIN32
+#ifndef _WIN32
 #include <unistd.h>
 #else
 #include <windows.h>
@@ -42,7 +42,7 @@ public:
 private:
 	static void SafeStderrWrite(const char *buf);
 
-#ifndef WIN32
+#ifndef _WIN32
 	static void UnixSetupHandlerForSIGINT(int type);
 	static void UnixGracefulExitHandler(int signal);
 	static void UnixForceExitHandler(int signal);

--- a/tools/useful.cpp
+++ b/tools/useful.cpp
@@ -184,7 +184,7 @@ int LinePlaneIntersection(const double *p0, const double *p1, const double *p2, 
 	return 0;
 }
 
-#ifndef __GNUC__
+#if defined(_WIN32) && !defined(__GNUC__)
 #include <chrono>
 #include <Winsock2.h> // for struct timeval
 
@@ -198,4 +198,4 @@ int gettimeofday(struct timeval* tp, struct timezone* tzp) {
   return 0;
 }
 
-#endif // _WIN32
+#endif // defined(_WIN32) && !defined(__GNUC__)

--- a/tools/useful.h
+++ b/tools/useful.h
@@ -41,8 +41,8 @@ double* Invert(const double* in, double* out);
 
 int LinePlaneIntersection(const double *p0, const double* p1, const double* p2, const double* l_start, const double* l_stop, double* is_point, double &dist);
 
-#ifndef __GNUC__
+#if defined(_WIN32) && !defined(__GNUC__)
 int gettimeofday(struct timeval* tp, struct timezone* tzp);
-#endif // _WIN32
+#endif // defined(_WIN32) && !defined(__GNUC__)
 
 #endif // USEFUL_H


### PR DESCRIPTION
Currently, the project uses the macros `WIN32`, `_WIN32` and `__GNUC__` interchangeably. However these macros have different meanings. The `WIN32` macro is defined by the Windows SDK, the `_WIN32` macro is defined by compilers on Windows, and the `__GNUC__` macro is defined by GCC on all platforms.

The `WIN32` macro is undefined unless Windows SDK headers are included, so Windows detection macros may not work correctly (reproduced on the latest version of Visual Studio 2022 with built-in CMake). This commit replaces all `WIN32` macros with `_WIN32`.

The `__GNUC__` macro should only be used if the code contains a GCC extension. If the code only uses a Windows-specific header, one should also guard that macro with _WIN32.