### PR TITLE
Fix:GetCSX

### DIFF
--- a/openems.cpp
+++ b/openems.cpp
@@ -1125,6 +1125,11 @@ void openEMS::SetCSX(ContinuousStructure* csx)
 	m_CSX = csx;
 }
 
+ContinuousStructure* openEMS::GetCSX() const
+{
+	return m_CSX;
+}
+
 int openEMS::SetupFDTD()
 {
 	timeval startTime;

--- a/openems.h
+++ b/openems.h
@@ -115,6 +115,7 @@ public:
 	Excitation* InitExcitation();
 
 	void SetCSX(ContinuousStructure* csx);
+	ContinuousStructure* GetCSX() const;
 
 	Engine_Interface_FDTD* NewEngineInterface(int multigridlevel = 0);
 

--- a/python/openEMS/openEMS.pxd
+++ b/python/openEMS/openEMS.pxd
@@ -29,6 +29,7 @@ cdef extern from "openEMS/openems.h":
 
         void SetNumberOfTimeSteps(unsigned int val)
         void SetCSX(_ContinuousStructure* csx)
+        _ContinuousStructure* GetCSX()
 
         void SetEndCriteria(double val)
         void SetOverSampling(int val)

--- a/python/openEMS/openEMS.pyx
+++ b/python/openEMS/openEMS.pyx
@@ -428,6 +428,17 @@ cdef class openEMS:
         self.thisptr.SetCSX(CSX.thisptr)
 
     def GetCSX(self):
+        cdef _ContinuousStructure* ptr = self.thisptr.GetCSX()
+        cdef ContinuousStructure csx  # declare here
+
+        if ptr == NULL:
+            self.__CSX = None
+            return None
+
+        if self.__CSX is None or self.__CSX.thisptr != ptr:
+            csx = ContinuousStructure.__new__(ContinuousStructure)
+            csx.thisptr = ptr
+            self.__CSX = csx
         return self.__CSX
 
     def AddEdges2Grid(self, dirs, primitives=None, properties=None, **kw):


### PR DESCRIPTION
Fix: GetCSX returns an empty list when structure is read from xml usi)ng openEMS ReadFromXML API.
This patch fixes GetCSX API to return the created object.